### PR TITLE
ミッション画面のデザイン改善

### DIFF
--- a/app/missions/[id]/_components/CancelSubmissionDialog.tsx
+++ b/app/missions/[id]/_components/CancelSubmissionDialog.tsx
@@ -28,9 +28,9 @@ const CancelSubmissionDialog: React.FC<CancelSubmissionDialogProps> = ({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>提出をキャンセルしますか？</DialogTitle>
+          <DialogTitle>達成を取り消しますか？</DialogTitle>
           <DialogDescription>
-            この操作は取り消すことができません。提出した成果物と関連データがすべて削除されます。
+            この操作は取り消すことができません。報告した履歴と関連データは削除されます。
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/app/missions/[id]/_components/MissionFormWrapper.tsx
+++ b/app/missions/[id]/_components/MissionFormWrapper.tsx
@@ -61,11 +61,14 @@ export function MissionFormWrapper({
 
   const handleDialogClose = () => {
     setIsDialogOpen(false);
-    // 提出履歴を更新
+    // 達成履歴を更新
     if (onSubmissionSuccess) {
       onSubmissionSuccess();
     }
   };
+
+  const completed =
+    hasReachedUserMaxAchievements && mission?.max_achievement_count !== null;
 
   return (
     <>
@@ -84,23 +87,13 @@ export function MissionFormWrapper({
           </div>
         )}
 
-        <ArtifactForm
-          key={formKey}
-          mission={mission}
-          authUser={authUser}
-          disabled={isButtonDisabled || isSubmitting}
-          submittedArtifactImagePath={null}
-        />
-
-        {hasReachedUserMaxAchievements &&
-          mission?.max_achievement_count !== null && (
-            <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 text-center">
-              <p className="text-sm font-medium text-orange-800">
-                あなたはこのミッションの達成回数の上限 (
-                {mission.max_achievement_count}回) に達しました。
-              </p>
-            </div>
-          )}
+        {completed && (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center">
+            <p className="text-sm font-medium text-gray-800">
+              このミッションの達成済みです。
+            </p>
+          </div>
+        )}
 
         {!hasReachedUserMaxAchievements &&
           userAchievementCount > 0 &&
@@ -113,12 +106,23 @@ export function MissionFormWrapper({
             </div>
           )}
 
-        <SubmitButton
-          pendingText="登録中..."
+        <ArtifactForm
+          key={formKey}
+          mission={mission}
+          authUser={authUser}
           disabled={isButtonDisabled || isSubmitting}
-        >
-          {buttonLabel}
-        </SubmitButton>
+          submittedArtifactImagePath={null}
+        />
+
+        {!completed && (
+          <SubmitButton
+            pendingText="登録中..."
+            className="w-full md:max-w-48 mx-auto"
+            disabled={isButtonDisabled || isSubmitting}
+          >
+            {buttonLabel}
+          </SubmitButton>
+        )}
       </form>
 
       <MissionCompleteDialog

--- a/app/missions/[id]/_components/MissionWithSubmissionHistory.tsx
+++ b/app/missions/[id]/_components/MissionWithSubmissionHistory.tsx
@@ -33,7 +33,7 @@ export function MissionWithSubmissionHistory({
     try {
       const supabase = createClient();
 
-      // ユーザーの提出履歴を取得
+      // ユーザーの達成履歴を取得
       const { data: achievementsData, error: achievementsError } =
         await supabase
           .from("achievements")

--- a/app/missions/[id]/_components/SubmissionHistory.tsx
+++ b/app/missions/[id]/_components/SubmissionHistory.tsx
@@ -40,7 +40,7 @@ const SubmissionHistory: React.FC<SubmissionHistoryProps> = ({
 
   return (
     <div className="mt-8">
-      <h2 className="text-xl font-semibold mb-4">あなたの提出履歴</h2>
+      <h2 className="text-xl font-semibold mb-4">あなたの達成履歴</h2>
       <ul className="space-y-4">
         {sortedSubmissions.map((submission, index) => (
           <SubmissionItem

--- a/app/missions/[id]/_components/SubmissionItem.tsx
+++ b/app/missions/[id]/_components/SubmissionItem.tsx
@@ -39,7 +39,7 @@ const SubmissionItem: React.FC<SubmissionItemProps> = ({
             size="xs"
             onClick={() => onCancelClick(submission.id)}
           >
-            提出をキャンセル
+            取り消す
           </Button>
         )}
       </div>

--- a/app/missions/[id]/_hooks/useMissionSubmission.ts
+++ b/app/missions/[id]/_hooks/useMissionSubmission.ts
@@ -14,7 +14,7 @@ export function useMissionSubmission(
     ) {
       return "このミッションは完了済みです";
     }
-    return "完了する";
+    return "達成を報告する";
   }, [mission.max_achievement_count, userAchievementCount]);
 
   const isButtonDisabled = useMemo(() => {

--- a/app/missions/[id]/_lib/data.ts
+++ b/app/missions/[id]/_lib/data.ts
@@ -75,7 +75,7 @@ export async function getSubmissionHistory(
 ): Promise<SubmissionData[]> {
   const supabase = await createServerClient();
 
-  // ユーザーの提出履歴を取得
+  // ユーザーの達成履歴を取得
   const { data: achievementsData, error: achievementsError } = await supabase
     .from("achievements")
     .select("id, created_at, mission_id, user_id")

--- a/app/missions/[id]/actions.ts
+++ b/app/missions/[id]/actions.ts
@@ -446,9 +446,9 @@ export const cancelSubmissionAction = async (formData: FormData) => {
     console.error(`Delete Error: ${deleteError.code} ${deleteError.message}`);
     return {
       success: false,
-      error: `提出のキャンセルに失敗しました: ${deleteError.message}`,
+      error: `達成の取り消しに失敗しました: ${deleteError.message}`,
     };
   }
 
-  return { success: true, message: "提出をキャンセルしました。" };
+  return { success: true, message: "達成を取り消しました。" };
 };

--- a/app/missions/[id]/page.tsx
+++ b/app/missions/[id]/page.tsx
@@ -35,7 +35,7 @@ export default async function MissionPage({ params }: Props) {
 
   return (
     <div className="container mx-auto max-w-4xl p-4">
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-6 max-w-lg mx-auto">
         <MissionDetails mission={mission} />
 
         {user ? (

--- a/components/mission/ArtifactForm.tsx
+++ b/components/mission/ArtifactForm.tsx
@@ -48,7 +48,7 @@ export function ArtifactForm({
     <Card>
       <CardHeader>
         <CardTitle className="text-lg">
-          提出フォーム - {artifactConfig.displayName}
+          達成報告フォーム - {artifactConfig.displayName}
         </CardTitle>
         <p className="text-sm text-muted-foreground">{artifactConfig.prompt}</p>
       </CardHeader>
@@ -56,7 +56,7 @@ export function ArtifactForm({
         {/* リンク入力フォーム */}
         {artifactConfig.key === ARTIFACT_TYPES.LINK.key && (
           <div className="space-y-2">
-            <Label htmlFor="artifactLink">提出リンク</Label>
+            <Label htmlFor="artifactLink">成果物のリンク</Label>
             <Input
               type="url"
               name="artifactLink"
@@ -154,7 +154,7 @@ export function ArtifactForm({
           <Textarea
             name="artifactDescription"
             id="artifactDescription"
-            placeholder="提出内容に関する補足説明 (任意)"
+            placeholder="達成内容に関する補足説明 (任意)"
             rows={3}
             disabled={disabled}
           />

--- a/components/mission/GeolocationInput.tsx
+++ b/components/mission/GeolocationInput.tsx
@@ -57,7 +57,7 @@ export function GeolocationInput({
     <div className="space-y-2">
       <Button
         type="button"
-        variant="secondary"
+        variant="outline"
         size="sm"
         onClick={handleGetGeolocation}
         disabled={disabled || isFetchingGeo}

--- a/components/mission/MissionDetails.tsx
+++ b/components/mission/MissionDetails.tsx
@@ -3,6 +3,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DifficultyBadge } from "@/components/ui/difficulty-badge";
+import { MissionIcon } from "@/components/ui/mission-icon";
 import { dateFormatter } from "@/lib/formatter";
 import type { Tables } from "@/lib/types/supabase";
 
@@ -16,11 +17,7 @@ export function MissionDetails({ mission }: MissionDetailsProps) {
       <CardHeader>
         <div className="flex items-start gap-4">
           {mission.icon_url && (
-            <img
-              src={mission.icon_url}
-              alt={mission.title}
-              className="w-16 h-16 object-cover rounded-lg border"
-            />
+            <MissionIcon src={mission.icon_url} alt={mission.title} size="lg" />
           )}
           <div className="flex-1 space-y-2">
             <CardTitle className="text-xl">{mission.title}</CardTitle>

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -5,6 +5,7 @@ import type { Tables } from "@/lib/types/supabase";
 import clsx from "clsx";
 import Link from "next/link";
 import { Button } from "../ui/button";
+import { MissionIcon } from "../ui/mission-icon";
 import MissionAchievementStatus from "./mission-achievement-status";
 
 interface MissionProps {
@@ -44,24 +45,7 @@ export default function Mission({
     >
       <div className="flex items-start gap-4">
         <div className="flex-col items-center justify-center">
-          <Avatar
-            className={clsx(
-              "h-16 w-16 shadow-md",
-              hasReachedMaxAchievements && "grayscale",
-            )}
-          >
-            <AvatarImage src={iconUrl} alt={mission.title} />
-            <AvatarFallback
-              className={clsx(
-                "font-bold text-white",
-                hasReachedMaxAchievements
-                  ? "bg-gradient-to-br from-gray-400 to-gray-500"
-                  : "bg-gradient-to-br from-emerald-400 to-teal-400",
-              )}
-            >
-              M
-            </AvatarFallback>
-          </Avatar>
+          <MissionIcon src={iconUrl} alt={mission.title} size="md" />
           <MissionAchievementStatus
             hasReachedMaxAchievements={hasReachedMaxAchievements}
             userAchievementCount={userAchievementCount}

--- a/components/ui/mission-icon.tsx
+++ b/components/ui/mission-icon.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils/utils";
+
+interface MissionIconProps {
+  src: string;
+  alt: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: "w-8 h-8",
+  md: "w-20 h-20",
+  lg: "w-24 h-24",
+};
+
+export function MissionIcon({
+  src,
+  alt,
+  size = "md",
+  className,
+}: MissionIconProps) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={cn(
+        "object-cover rounded-full border shadow-sm",
+        sizeClasses[size],
+        className,
+      )}
+    />
+  );
+}

--- a/lib/artifactTypes.ts
+++ b/lib/artifactTypes.ts
@@ -2,27 +2,27 @@ export const ARTIFACT_TYPES = {
   LINK: {
     key: "LINK",
     displayName: "リンク",
-    prompt: "提出する成果物のURLを入力してください。",
+    prompt: "成果物のURLを入力してください。",
     validationRegex: /^https?:\/\/.+/,
   },
   IMAGE: {
     key: "IMAGE",
     displayName: "画像",
-    prompt: "画像を提出してください。",
+    prompt: "画像の添付が必要です。",
     allowedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
     maxFileSizeMB: 10,
   },
   IMAGE_WITH_GEOLOCATION: {
     key: "IMAGE_WITH_GEOLOCATION",
     displayName: "画像および位置情報",
-    prompt: "画像と位置情報を提出してください。",
+    prompt: "画像の添付と位置情報の設定が必要です。",
     allowedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
     maxFileSizeMB: 10,
   },
   NONE: {
     key: "NONE",
-    displayName: "提出物なし",
-    prompt: "このミッションでは提出物の投稿は不要です。",
+    displayName: "添付データ不要",
+    prompt: "このミッションでは添付データの投稿は不要です。",
   },
 } as const;
 


### PR DESCRIPTION
# 変更の概要

- 横幅を制限
- 「提出する」=>「達成を報告する」という言い回しに変更

<img width="642" alt="image" src="https://github.com/user-attachments/assets/463cbdb2-b317-41ef-94a8-5e2e02086867" />


# 変更の背景

- 言い回しがバラバラだったり堅苦しいところの修正
- 横長すぎるフォームやボタンを小さくまとめた

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました