### PR TITLE
feat: SignUpFormをInputからSelectBoxへ変更

### DIFF
--- a/app/(auth-pages)/sign-up/SignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/SignUpForm.tsx
@@ -116,7 +116,7 @@ function SignUpFormContent({
               required
               disabled={pending}
             >
-              <SelectTrigger>
+              <SelectTrigger data-testid="year_select">
                 <SelectValue placeholder="年" />
               </SelectTrigger>
               <SelectContent>
@@ -139,7 +139,7 @@ function SignUpFormContent({
               disabled={pending}
               required
             >
-              <SelectTrigger>
+              <SelectTrigger data-testid="month_select">
                 <SelectValue placeholder="月" />
               </SelectTrigger>
               <SelectContent>
@@ -162,7 +162,7 @@ function SignUpFormContent({
               disabled={pending}
               required
             >
-              <SelectTrigger>
+              <SelectTrigger data-testid="day_select">
                 <SelectValue placeholder="日" />
               </SelectTrigger>
               <SelectContent>

--- a/app/(protected)/settings/profile/ProfileForm.tsx
+++ b/app/(protected)/settings/profile/ProfileForm.tsx
@@ -14,13 +14,6 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { getAvatarUrl } from "@/lib/avatar";
 import { AVATAR_MAX_FILE_SIZE } from "@/lib/avatar";
 import { createClient } from "@/lib/supabase/client";
@@ -71,67 +64,6 @@ export default function ProfileForm({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
 
-  // 生年月日関連のステート
-  const initialDate = initialProfile?.date_of_birth
-    ? new Date(initialProfile.date_of_birth)
-    : null;
-  const [selectedYear, setSelectedYear] = useState<number | null>(
-    initialDate ? initialDate.getFullYear() : null,
-  );
-  const [selectedMonth, setSelectedMonth] = useState<number | null>(
-    initialDate ? initialDate.getMonth() + 1 : null,
-  );
-  const [selectedDay, setSelectedDay] = useState<number | null>(
-    initialDate ? initialDate.getDate() : null,
-  );
-
-  // 年の選択肢 (2007年から100年前まで)
-  // なぜ2007年かというと、18歳未満の選挙活動が禁止されており、それを満たす要件は2007年生まれ以前の必要があるため
-  const birthYearThreshold = 2007;
-  const years = Array.from({ length: 100 }, (_, i) => birthYearThreshold - i);
-
-  // 月の選択肢
-  const months = Array.from({ length: 12 }, (_, i) => i + 1);
-
-  // 年月が変更されたら日をリセット
-  // 現在選択されている日がその月の日数を超えている場合は、日をリセットする
-  useEffect(() => {
-    const getDaysInMonth = (year: number, month: number) => {
-      return new Date(year, month, 0).getDate();
-    };
-
-    if (selectedYear && selectedMonth) {
-      const daysInMonth = getDaysInMonth(selectedYear, selectedMonth);
-      if (selectedDay && selectedDay > daysInMonth) {
-        setSelectedDay(null);
-      }
-    } else {
-      setSelectedDay(null);
-    }
-  }, [selectedYear, selectedMonth, selectedDay]);
-
-  // 日の選択肢 (選択された年月に基づいて動的に計算)
-  const days =
-    selectedYear && selectedMonth
-      ? Array.from(
-          { length: new Date(selectedYear, selectedMonth, 0).getDate() },
-          (_, i) => i + 1,
-        )
-      : [];
-
-  // フォーム送信用に日付をフォーマット
-  const formatDate = (
-    year: number | null,
-    month: number | null,
-    day: number | null,
-  ) => {
-    if (!year || !month || !day) return "";
-    // 数値を2桁にフォーマットするヘルパー関数
-    const pad = (n: number) => n.toString().padStart(2, "0");
-    return `${year}-${pad(month)}-${pad(day)}`;
-  };
-
-  const formattedDate = formatDate(selectedYear, selectedMonth, selectedDay);
   useEffect(() => {
     // フォーム送信成功時の処理
     if (state?.success && isNew) {
@@ -253,73 +185,14 @@ export default function ProfileForm({
           </div>
 
           <div className="space-y-2">
-            <Label>生年月日</Label>
-            <div className="grid grid-cols-3 gap-2" aria-required="true">
-              <legend className="sr-only">生年月日</legend>
-              <div>
-                <Select
-                  name="year"
-                  value={selectedYear?.toString() || ""}
-                  onValueChange={(value) => setSelectedYear(Number(value))}
-                  required
-                  aria-required="true"
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="年" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {years.map((year) => (
-                      <SelectItem key={year} value={year.toString()}>
-                        {year}年
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Select
-                  name="month"
-                  value={selectedMonth?.toString() || ""}
-                  onValueChange={(value) => setSelectedMonth(Number(value))}
-                  disabled={!selectedYear}
-                  required
-                  aria-required="true"
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="月" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {months.map((month) => (
-                      <SelectItem key={month} value={month.toString()}>
-                        {month}月
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Select
-                  name="day"
-                  value={selectedDay?.toString() || ""}
-                  onValueChange={(value) => setSelectedDay(Number(value))}
-                  disabled={!selectedMonth || !selectedYear}
-                  required
-                  aria-required="true"
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="日" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {days.map((day) => (
-                      <SelectItem key={day} value={day.toString()}>
-                        {day}日
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <input type="hidden" name="date_of_birth" value={formattedDate} />
+            <Label htmlFor="date_of_birth">生年月日</Label>
+            <Input
+              type="date"
+              name="date_of_birth"
+              required
+              readOnly
+              value={initialProfile?.date_of_birth || ""}
+            />
           </div>
 
           <div className="space-y-2">

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -36,11 +36,23 @@ test.describe("認証フロー", () => {
     await page.fill('input[name="email"]', testEmail);
     await page.fill('input[name="password"]', testPassword);
 
-    await page.fill(
-      'input[name="date_of_birth"]',
-      "2000-01-01", // 18歳以上の日付を入力
-      { force: true },
-    );
+    // 年を選択
+    const year = page.getByTestId("year_select");
+    await year.press("Enter");
+    const selectedYear = page.getByRole("option", { name: "2001年" });
+    await selectedYear.click();
+
+    // 月を選択
+    const month = page.getByTestId("month_select");
+    await month.press("Enter");
+    const selectedMonth = page.getByRole("option", { name: "3月" });
+    await selectedMonth.click();
+
+    // 日を選択
+    const day = page.getByTestId("day_select");
+    await day.press("Enter");
+    const selectedDay = page.getByRole("option", { name: "14日" });
+    await selectedDay.click();
 
     // 利用規約に同意する
     await page.locator("#terms").click();
@@ -105,11 +117,23 @@ test.describe("認証フロー", () => {
     ).toBeVisible();
     await expect(page.getByRole("link", { name: "こちら" })).toBeVisible();
 
-    await page.fill(
-      'input[name="date_of_birth"]',
-      "2000-01-01", // 18歳以上の日付を入力
-      { force: true },
-    );
+    // 年を選択
+    const year = page.getByTestId("year_select");
+    await year.press("Enter");
+    const selectedYear = page.getByRole("option", { name: "2001年" });
+    await selectedYear.click();
+
+    // 月を選択
+    const month = page.getByTestId("month_select");
+    await month.press("Enter");
+    const selectedMonth = page.getByRole("option", { name: "3月" });
+    await selectedMonth.click();
+
+    // 日を選択
+    const day = page.getByTestId("day_select");
+    await day.press("Enter");
+    const selectedDay = page.getByRole("option", { name: "14日" });
+    await selectedDay.click();
 
     // 利用規約に同意する
     await page.locator("#terms").click();


### PR DESCRIPTION
# 変更の概要

fix: #135 

前回誤った部分を修正してしまっていたので改めてPRを出します

- `SignUpForm.tsx` の 生年月日をInputからSelectへ変更
  - 年齢チェック部分で既存コードを一部削除してる点がわかりにくいと思うので対象コードに↓でコメントします
- 誤って変更してしまった`ProfileForm.tsx` をInputのreadonlyへ元に戻す


https://github.com/user-attachments/assets/b326ebb7-a847-4acf-a84d-30b7b504148e



# 変更の背景
- issueが上がっていたため対応

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました