### PR TITLE
feat: Custom SMTP設定をsupabase/config.tomlに追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ SUPABASE_SERVICE_ROLE_KEY=service-role-key
 
 # 開発時は空でもかまいません
 NEXT_PUBLIC_SENTRY_DSN=your-project-dsn
+
+# 以下の設定はクラウドでホストされている本番・STG環境でのみ利用される
+# 正しい値ではないので注意
+SMTP_HOST=smtp.mailgun.org
+SMTP_USER=example@mailgun.org
+SMTP_PASS=password
+SMTP_ADMIN_EMAIL=noreply@example.com
+SMTP_SENDER_NAME=test_sender

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -165,14 +165,14 @@ otp_length = 6
 otp_expiry = 3600
 
 # Use a production-ready SMTP server
-# [auth.email.smtp]
-# enabled = true
-# host = "smtp.sendgrid.net"
-# port = 587
-# user = "apikey"
-# pass = "env(SENDGRID_API_KEY)"
-# admin_email = "admin@email.com"
-# sender_name = "Admin"
+[auth.email.smtp]
+enabled = true
+host = "env(SMTP_HOST)"
+port = 587
+user = "env(SMTP_USER)"
+pass = "env(SMTP_PASS)"
+admin_email = "env(SMTP_ADMIN_EMAIL)"
+sender_name = "env(SMTP_SENDER_NAME)"
 
 # Uncomment to customize email template
 # [auth.email.template.invite]


### PR DESCRIPTION
# 変更の概要
- Supabaseのクラウドホスティング環境で新規登録ユーザーにメールを送るためにCustom SMTP設定が必要である。それを環境変数経由で取り回すように対応
- ChatGPT曰く、config.tomlにある[auth.email.smtp]は、Supabaseのクラウド環境でのみ有効になるらしい。そのため、enabled = trueと設定している。

# 変更の背景
- #167 
- #168

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました