### PR TITLE
github org を team-mirai-volunteer を向くように変更 & その他細かいリファクタ

### DIFF
--- a/terraform/cloud_build.tf
+++ b/terraform/cloud_build.tf
@@ -1,7 +1,7 @@
 # GitHub Connection
 resource "google_cloudbuildv2_connection" "github_connection" {
   location = var.region
-  name     = "github-connection"
+  name     = "github-connection-team-mirai-volunteer"
 
   github_config {
     app_installation_id = var.github_app_installation_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,12 +1,12 @@
 # Enable required APIs
 resource "google_project_service" "required_apis" {
   for_each = toset([
-    "run.googleapis.com",             # Cloud Run API
+    "run.googleapis.com",              # Cloud Run API
     "artifactregistry.googleapis.com", # Artifact Registry API
-    "cloudbuild.googleapis.com",      # Cloud Build API
-    "secretmanager.googleapis.com",   # Secret Manager API
-    "compute.googleapis.com",         # Compute Engine API
-    "iam.googleapis.com"              # IAM API
+    "cloudbuild.googleapis.com",       # Cloud Build API
+    "secretmanager.googleapis.com",    # Secret Manager API
+    "compute.googleapis.com",          # Compute Engine API
+    "iam.googleapis.com"               # IAM API
   ])
 
   service            = each.key

--- a/terraform/nextjs-app/secrets.tf
+++ b/terraform/nextjs-app/secrets.tf
@@ -7,8 +7,8 @@ resource "google_secret_manager_secret" "supabase_service_role_key" {
   }
 }
 resource "google_secret_manager_secret_version" "supabase_service_role_key" {
-  secret      = google_secret_manager_secret.supabase_service_role_key.id
-  secret_data = var.SUPABASE_SERVICE_ROLE_KEY
+  secret         = google_secret_manager_secret.supabase_service_role_key.id
+  secret_data_wo = var.SUPABASE_SERVICE_ROLE_KEY
 }
 
 resource "google_secret_manager_secret" "supabase_access_token" {
@@ -19,8 +19,8 @@ resource "google_secret_manager_secret" "supabase_access_token" {
   }
 }
 resource "google_secret_manager_secret_version" "supabase_access_token" {
-  secret      = google_secret_manager_secret.supabase_access_token.id
-  secret_data = var.SUPABASE_ACCESS_TOKEN
+  secret         = google_secret_manager_secret.supabase_access_token.id
+  secret_data_wo = var.SUPABASE_ACCESS_TOKEN
 }
 
 resource "google_secret_manager_secret" "supabase_db_password" {
@@ -31,8 +31,8 @@ resource "google_secret_manager_secret" "supabase_db_password" {
   }
 }
 resource "google_secret_manager_secret_version" "supabase_db_password" {
-  secret      = google_secret_manager_secret.supabase_db_password.id
-  secret_data = var.SUPABASE_DB_PASSWORD
+  secret         = google_secret_manager_secret.supabase_db_password.id
+  secret_data_wo = var.SUPABASE_DB_PASSWORD
 }
 
 resource "google_secret_manager_secret" "supabase_smtp_pass" {
@@ -43,7 +43,7 @@ resource "google_secret_manager_secret" "supabase_smtp_pass" {
   }
 }
 resource "google_secret_manager_secret_version" "supabase_smtp_pass" {
-  secret      = google_secret_manager_secret.supabase_smtp_pass.id
-  secret_data = var.SUPABASE_SMTP_PASS
+  secret         = google_secret_manager_secret.supabase_smtp_pass.id
+  secret_data_wo = var.SUPABASE_SMTP_PASS
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,7 +49,7 @@ variable "github_oauth_token_secret_version" {
 variable "github_repository_remote_uri" {
   description = "GitHub repository remote URI"
   type        = string
-  default     = "https://github.com/team-mirai/action-board.git"
+  default     = "https://github.com/team-mirai-volunteer/action-board.git"
 }
 
 variable "application_domain_name" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -57,12 +57,6 @@ variable "application_domain_name" {
   type        = string
 }
 
-variable "repository_name" {
-  description = "Artifact Registry repository name"
-  type        = string
-  default     = "app"
-}
-
 variable "trigger_branch" {
   description = "Git branch pattern to trigger the build"
   type        = string


### PR DESCRIPTION
# 変更の概要
github org を team-mirai-volunteer を向くように変更 & その他細かいリファクタ


# 変更の背景
組織が変わったので github-connection を作成し直しました


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました