### PR TITLE
feat: 利用規約とプライバシーポリシーを追加

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,200 @@
+export default function PrivacyPolicy() {
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">
+          プライバシーポリシー
+        </h1>
+        <p className="text-gray-700 leading-relaxed">
+          政治団体「チームみらい」（以下「当団体」といいます）は、当団体が提供するウェブサービス「アクションボード」（以下「本サービス」といいます）において取得する個人情報を、以下の方針に基づき適切に取り扱います。
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            1. 個人情報の定義
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            本ポリシーにおける「個人情報」とは、個人情報保護法に基づき、生存する個人に関する情報であって、氏名、メールアドレス、生年、郵便番号、SNSアカウントその他の記述等により特定の個人を識別できる情報、ならびに他の情報と照合することで特定個人を識別できる情報を指します。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            2. 取得する情報
+          </h2>
+          <p className="text-gray-700 leading-relaxed mb-3">
+            当団体は、本サービスの利用にあたり、ユーザーから以下の情報を取得する場合があります。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-gray-700">
+            <li>ニックネーム</li>
+            <li>生年</li>
+            <li>郵便番号</li>
+            <li>メールアドレス</li>
+            <li>SNSアカウント</li>
+            <li>ソーシャルログイン情報</li>
+            <li>
+              ミッション成果物（写真・動画のURL、SNS投稿リンク、位置情報等）
+            </li>
+            <li>アクセスログ（IPアドレス、ブラウザ情報、Cookie情報等）</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            3. 利用目的
+          </h2>
+          <p className="text-gray-700 leading-relaxed mb-3">
+            取得した個人情報は、以下の目的に限り利用いたします。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-gray-700">
+            <li>本サービスの提供・運営のため</li>
+            <li>ユーザー認証およびログイン管理のため</li>
+            <li>ポイント集計・ランキング機能提供のため</li>
+            <li>ミッション実施状況の確認および不正防止のため</li>
+            <li>地域に応じた演説会・説明会などのお知らせ送信のため</li>
+            <li>アクセス状況の分析およびサービス改善のため</li>
+            <li>
+              法令上必要な対応および当団体の政治活動に必要な範囲での活用のため
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            4. Cookie等の利用
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            当団体は、ユーザーの利便性向上および本サービスの運営に必要な範囲でCookie等の技術を使用します。また、Google
+            LLCが提供するGoogle
+            Analyticsを利用し、アクセス状況を解析する場合があります。Googleによる情報の取扱いについてはGoogleプライバシーポリシーをご参照ください。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            5. 第三者提供
+          </h2>
+          <p className="text-gray-700 leading-relaxed mb-3">
+            当団体は、以下の場合を除き、ユーザーの個人情報を第三者に提供することはありません。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-gray-700">
+            <li>ユーザー本人の同意がある場合</li>
+            <li>法令に基づく場合</li>
+            <li>人の生命・身体・財産の保護に緊急の必要がある場合</li>
+            <li>利用目的の達成に必要な範囲内で外部委託業者に提供する場合</li>
+            <li>
+              政治資金規正法その他の法令に基づき、収支報告書等に記載・公開される場合
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            6. ミッション成果物の取り扱い
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            ユーザーが提出したミッションの成果物（写真、動画URL、SNS投稿リンク、位置情報等）は、当団体内部での確認・記録・不正防止の目的に限って利用され、ユーザーの事前の同意がない限り公開されることはありません。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            7. 個人情報の保管期間
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            取得した個人情報は、政治資金規正法その他の関連法令に基づき、原則として取得日から7年間保管します。保管期間終了後は、当団体の責任において適切な方法により速やかに廃棄・削除いたします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            8. 安全管理措置
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            当団体は、個人情報の漏えい、滅失、毀損、不正アクセス等を防止するため、アクセス権限管理、データ暗号化、従業員教育等、技術的・組織的な安全管理措置を講じます。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            9. 開示・訂正・削除等の請求
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            ユーザーは、自己の個人情報について、開示・訂正・追加・削除・利用停止等を請求することができます。請求に際しては、本人確認を行った上で、合理的な期間内に対応いたします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            10. 非公式サービスへの注意
+          </h2>
+          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+            <p className="text-gray-700 leading-relaxed">
+              当団体は、本サービスの一部のソースコードをOSSとして公開する場合があります。そのため、当団体以外の者による非公式サービスが存在する可能性があります。公式のサービスは、公式ドメイン（
+              <a
+                href="https://action.team-mir.ai/"
+                className="text-blue-600 hover:text-blue-800 underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                https://action.team-mir.ai/
+              </a>
+              ）でのみ提供されます。
+              <span className="text-red-600 font-medium">
+                非公式サービスにおける情報提供、入力、被害等について、当団体は一切の責任を負いかねます。
+              </span>
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            11. プライバシーポリシーの変更
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            当団体は、本ポリシーを必要に応じて改定します。改定後の内容は本サービス上に掲示することで効力を生じるものとします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            12. お問い合わせ
+          </h2>
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+            <p className="text-gray-700 leading-relaxed mb-2">
+              本ポリシーに関するお問い合わせは、以下の連絡先までお願いいたします。
+            </p>
+            <div className="space-y-1">
+              <p className="font-medium text-gray-900">チームみらい</p>
+              <p className="text-gray-700">
+                <a
+                  href="mailto:info@team-mir.ai"
+                  className="text-blue-600 hover:text-blue-800 underline"
+                >
+                  info@team-mir.ai
+                </a>
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            13. 準拠法および管轄
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            本ポリシーは日本法に準拠し、本サービスに関する一切の紛争については、東京地方裁判所を第一審の専属的合意管轄裁判所とします。
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-12 pt-8 border-t border-gray-200">
+        <p className="text-sm text-gray-500 text-center">
+          最終更新日: {new Date().toLocaleDateString("ja-JP")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,178 @@
+export default function TermsOfService() {
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">利用規約</h1>
+        <p className="text-gray-700 leading-relaxed">
+          この利用規約（以下「本規約」といいます）は、政治団体「チームみらい」（以下「当団体」といいます）が提供するウェブサービス「アクションボード」（以下「本サービス」といいます）の利用条件を定めるものです。本サービスのご利用にあたっては、本規約に同意いただく必要があります。同意いただけない場合は、本サービスをご利用いただけません。
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            1. サービスの目的と性質
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            本サービスは、ユーザーが当団体の活動を支援することを目的として提供されるものであり、特定の活動をユーザーの任意で行うことに対し、ポイントを付与するなどのゲーミフィケーション要素を備えています。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            2. 利用資格
+          </h2>
+          <p className="text-gray-700 leading-relaxed mb-3">
+            本サービスの利用は、以下の条件をすべて満たす方に限られます。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-gray-700 mb-3">
+            <li>満18歳以上であること</li>
+            <li>日本国内に居住していること</li>
+            <li>本規約に同意し、遵守する意思を有すること</li>
+            <li>法令および公序良俗に反しない行動を取ることができること</li>
+          </ul>
+          <p className="text-red-600 font-medium">
+            18歳未満の方のご利用はできません。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            3. ユーザー登録とアカウント管理
+          </h2>
+          <div className="space-y-3 text-gray-700 leading-relaxed">
+            <p>
+              本サービスを利用するには、当団体所定の方法による登録が必要です。登録情報は正確かつ最新のものでなければなりません。
+            </p>
+            <p>
+              ユーザーは、自己の責任においてアカウントおよびパスワードを管理し、第三者に利用させてはなりません。
+            </p>
+            <p>
+              当団体は、虚偽の登録など不正があると判断した場合、アカウントを停止・削除することができます。
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            4. ポイントおよびランキング制度
+          </h2>
+          <div className="space-y-3 text-gray-700 leading-relaxed">
+            <p>
+              ユーザーは、当団体が定める方法により、所定の政治活動に協力することでポイントを取得できます。
+            </p>
+            <p>
+              ポイントは地域ごとのランキング表示などに使用されますが、金銭的価値は一切なく、換金・譲渡・財産的利用はできません。
+            </p>
+            <p>
+              当団体は、ポイント制度やランキング機能を予告なく変更または廃止することができます。
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            5. 禁止事項
+          </h2>
+          <p className="text-gray-700 leading-relaxed mb-3">
+            ユーザーは、以下の行為を行ってはなりません。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-gray-700">
+            <li>法令または公序良俗に反する行為</li>
+            <li>政治活動及び選挙運動に関して法令により禁止されている行為</li>
+            <li>他人になりすます行為</li>
+            <li>
+              本サービスの全部または一部を改変・模倣し、誤認を招くような行為
+            </li>
+            <li>サーバへの過剰な負荷、システムへの妨害・改ざん・侵入行為</li>
+            <li>自動化ツール、ボット等による操作</li>
+            <li>他ユーザーの個人情報を無断で収集・利用する行為</li>
+            <li>その他、当団体が不適切と判断する一切の行為</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            6. 知的財産権とオープンソースの取り扱い
+          </h2>
+          <div className="space-y-3 text-gray-700 leading-relaxed">
+            <p>
+              本サービスの名称、ロゴ、デザイン、ランキング情報等に関する権利は、当団体または正当な権利者に帰属します。
+            </p>
+            <p>
+              本サービスの一部はオープンソースソフトウェア（OSS）として公開される場合があります。OSS部分はライセンスに従い利用可能ですが、当団体が公式に提供するサービスは、公式ドメイン（
+              <a
+                href="https://action.team-mir.ai/"
+                className="text-blue-600 hover:text-blue-800 underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                https://action.team-mir.ai/
+              </a>
+              ）を通じてのみ提供されます。
+            </p>
+            <p>
+              OSSコードを用いた非公式サービスにより生じた損害について、当団体は一切の責任を負いません。
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            7. ミッション成果物の取り扱い
+          </h2>
+          <div className="space-y-3 text-gray-700 leading-relaxed">
+            <p>
+              ユーザーは、ミッション達成に関する成果物（写真、動画URL、SNS投稿リンク、位置情報等）を当団体に提出することがあります。
+            </p>
+            <p>
+              成果物は内部記録・不正防止・ポイント認定の目的に限定して使用され、ユーザーの同意なく外部に公開されることはありません。
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            8. サービスの変更・中断・終了
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            当団体は、ユーザーへの通知の有無にかかわらず、本サービスの内容を変更・中止・終了することがあります。これにより生じた損害について、当団体は一切の責任を負いません。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            9. 免責事項
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            本サービスは現状有姿で提供され、当団体はその正確性・完全性・有用性を保証しません。システム障害、通信障害、データ損失、外部攻撃などによりユーザーに損害が生じた場合でも、当団体に故意または重過失がある場合を除き、責任を負いません。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            10. 規約の変更
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            当団体は、ユーザーの承諾を得ることなく、本規約を変更することができます。変更後の規約は、本サービス上で掲示された時点で効力を生じます。重要な変更については、登録メールアドレス等を通じて通知する場合があります。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-4 border-b-2 border-blue-500 pb-2">
+            11. 準拠法および管轄裁判所
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            本規約は日本法に準拠し、本サービスに関して発生する一切の紛争については、東京地方裁判所を第一審の専属的合意管轄裁判所とします。
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-12 pt-8 border-t border-gray-200">
+        <p className="text-sm text-gray-500 text-center">
+          最終更新日: {new Date().toLocaleDateString("ja-JP")}
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 変更の概要
- タイトル通り

PCでの表示

<img width="1170" alt="Screenshot 2025-05-31 at 9 49 50" src="https://github.com/user-attachments/assets/2c5fb380-4988-4440-8104-fe0ec2064acb" />
<img width="1163" alt="Screenshot 2025-05-31 at 9 48 19" src="https://github.com/user-attachments/assets/0bad2521-5e1a-4a7f-b442-7248c71f8670" />

モバイルでの表示

<img width="463" alt="Screenshot 2025-05-31 at 9 48 12" src="https://github.com/user-attachments/assets/bcaa5047-5049-4486-99fb-30aa298a39cd" />
<img width="481" alt="Screenshot 2025-05-31 at 9 48 23" src="https://github.com/user-attachments/assets/355ff17d-bdfb-449e-a807-0ab7853c3450" />


# 変更の背景
- Closes #38 
- Closes #40 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました