### PR TITLE
fix: codeownersの記法が間違っていたのを修正

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
-* muraikenta
-* ryan5500
-* tkurokawa
-* xarsh
+# Global code owners - all files in the repository
+* @muraikenta @ryan5500 @tkurokawa @xarsh @dotneet
+
+# Specific directory rules (examples)
+# /docs/ @muraikenta @ryan5500
+# /terraform/ @ryan5500 @tkurokawa
+# /supabase/ @ryan5500 @tkurokawa @xarsh


### PR DESCRIPTION
# 変更の概要
- タイトル通り

# 変更の背景
- https://team-mirai-volunteer.slack.com/archives/C08SNQ7D29L/p1748065690556769 このメッセージで、CODEOWNERSへの追加を確認。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました