### PR TITLE
fix: 現状は生年月日を取得しているためプライバシーポリシーの文言を修正

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -16,7 +16,7 @@ export default function PrivacyPolicy() {
             1. 個人情報の定義
           </h2>
           <p className="text-gray-700 leading-relaxed">
-            本ポリシーにおける「個人情報」とは、個人情報保護法に基づき、生存する個人に関する情報であって、氏名、メールアドレス、生年、郵便番号、SNSアカウントその他の記述等により特定の個人を識別できる情報、ならびに他の情報と照合することで特定個人を識別できる情報を指します。
+            本ポリシーにおける「個人情報」とは、個人情報保護法に基づき、生存する個人に関する情報であって、氏名、メールアドレス、生年月日、郵便番号、SNSアカウントその他の記述等により特定の個人を識別できる情報、ならびに他の情報と照合することで特定個人を識別できる情報を指します。
           </p>
         </section>
 
@@ -29,7 +29,7 @@ export default function PrivacyPolicy() {
           </p>
           <ul className="list-disc pl-6 space-y-2 text-gray-700">
             <li>ニックネーム</li>
-            <li>生年</li>
+            <li>生年月日</li>
             <li>郵便番号</li>
             <li>メールアドレス</li>
             <li>SNSアカウント</li>


### PR DESCRIPTION
# 変更の概要
- 実態に即したプライバシーポリシーに直した

# 変更の背景
- 現状生年月日をプロフィールで入力しているため

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました