### PR TITLE
全体の上限回数ロジックを削除

### DIFF
--- a/app/missions/[id]/actions.ts
+++ b/app/missions/[id]/actions.ts
@@ -187,34 +187,6 @@ export const achieveMissionAction = async (formData: FormData) => {
         error: "あなたはこのミッションの達成回数の上限に達しています。",
       };
     }
-
-    // ミッション全体の達成回数を取得（全体の上限がある場合）
-    const { data: countData, error: countError } = await supabase
-      .from("mission_achievement_count_view")
-      .select("achievement_count")
-      .eq("mission_id", validatedMissionId)
-      .single();
-
-    if (countError) {
-      console.error(`Achievement count fetch error: ${countError.message}`);
-      return {
-        success: false,
-        error: "達成回数の取得に失敗しました。",
-      };
-    }
-
-    // ミッション全体の達成回数が上限に達しているかチェック
-    if (
-      countData &&
-      typeof countData.achievement_count === "number" &&
-      typeof missionData.max_achievement_count === "number" &&
-      countData.achievement_count >= missionData.max_achievement_count
-    ) {
-      return {
-        success: false,
-        error: "このミッションは全体の達成回数の上限に達しています。",
-      };
-    }
   }
 
   // ミッション達成を記録


### PR DESCRIPTION
# 変更の概要
本番で以下のエラーが発生していた。
<img width="405" alt="image" src="https://github.com/user-attachments/assets/76b11958-e150-46ff-b41e-1e9584951232" />

全体の上限回数と個人のクリア回数のロジックがごちゃまぜになってバグになっていた。
そもそも全体の上限回数をつける予定がないので、機能ごと削除しました。


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました