### PR TITLE
fix: パスワードリセットメールのリンク押下時に正しくパスワードリセット画面が表示されるようにした

### DIFF
--- a/app/(protected)/reset-password/page.tsx
+++ b/app/(protected)/reset-password/page.tsx
@@ -10,28 +10,28 @@ export default async function ResetPassword(props: {
   const searchParams = await props.searchParams;
   return (
     <form className="flex flex-col w-full max-w-md p-4 gap-2 [&>input]:mb-4">
-      <h1 className="text-2xl font-medium">Reset password</h1>
+      <h1 className="text-2xl font-medium">パスワードリセット</h1>
       <p className="text-sm text-foreground/60">
-        Please enter your new password below.
+        新しいパスワードを入力してください。
       </p>
-      <Label htmlFor="password">New password</Label>
+      <Label htmlFor="password">新しいパスワード</Label>
       <Input
         type="password"
         name="password"
-        placeholder="New password"
+        placeholder="新しいパスワード"
         required
         autoComplete="new-password"
       />
-      <Label htmlFor="confirmPassword">Confirm password</Label>
+      <Label htmlFor="confirmPassword">パスワード確認</Label>
       <Input
         type="password"
         name="confirmPassword"
-        placeholder="Confirm password"
+        placeholder="パスワード確認"
         required
         autoComplete="new-password"
       />
       <SubmitButton formAction={resetPasswordAction}>
-        Reset password
+        パスワードをリセット
       </SubmitButton>
       <FormMessage message={searchParams} />
     </form>

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -207,7 +207,7 @@ export const forgotPasswordAction = async (formData: FormData) => {
   }
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${origin}/auth/callback?redirect_to=/protected/reset-password`,
+    redirectTo: `${origin}/auth/callback?redirect_to=/reset-password`,
   });
 
   if (error) {


### PR DESCRIPTION
# 変更の概要
- パスワードリセット時に届いたメールのリンクを踏んだ際に、ページが表示されるようにした
- パスワードリセット画面が全体的に英語であったので、いったん日本語に変更した

# 変更の背景
- closes #241

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました