### PR TITLE
fix: viewport設定でエラーが出るのでnext.jsのdocにしたがって修正

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,14 @@ const geistSans = Geist({
 //metadata.tsxでmetadataを管理
 export const generateMetadata = generateRootMetadata;
 
+// Next.js 15でのviewport設定
+export const viewport = {
+  width: "device-width",
+  initialScale: 1.0,
+  maximumScale: 1.0,
+  userScalable: false,
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -50,8 +50,6 @@ export function createDefaultMetadata(): Metadata {
   return {
     title: config.title,
     description: config.description,
-    viewport:
-      "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no",
     openGraph: {
       title: config.title,
       description: config.description,
@@ -77,8 +75,6 @@ export function createOgpMetadata(imageUrl: string): Metadata {
   return {
     title: config.title,
     description: config.description,
-    viewport:
-      "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no",
     openGraph: {
       title: config.title,
       description: config.description,


### PR DESCRIPTION
# 変更の概要
- Unsupported metadata viewport is configured in metadata export in /.  
  Please move it to viewport export instead.                              
   Read more:                                                              
   https://nextjs.org/docs/app/api-reference/functions/generate-viewport   
というwarningが表示されたので、上記URLにしたがって修正

# 変更の背景
- #242

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました