### PR TITLE
feat: update font to hiragino sans.

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -65,7 +65,7 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN",
+    font-family: var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN",
       "Yu Gothic", Meiryo, sans-serif;
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import Navbar from "@/components/navbar";
+import { notoSansJP } from "@/lib/metadata";
 import { ThemeProvider } from "next-themes";
-import { Geist } from "next/font/google";
 import Footer from "./footer";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
@@ -8,11 +8,6 @@ import { generateRootMetadata } from "@/lib/metadata";
 import Script from "next/script";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
-
-const geistSans = Geist({
-  display: "swap",
-  subsets: ["latin"],
-});
 
 //metadata.tsxでmetadataを管理
 export const generateMetadata = generateRootMetadata;
@@ -31,7 +26,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja" className={geistSans.className} suppressHydrationWarning>
+    <html lang="ja" className={notoSansJP.variable} suppressHydrationWarning>
       <body className="bg-background text-foreground">
         {GA_ID && (
           <>

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -4,6 +4,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
+import { Noto_Sans_JP } from "next/font/google";
 
 const defaultUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
 
@@ -24,6 +25,14 @@ const config = {
     apple: "/apple-icon.png",
   },
 };
+
+// font-family設定
+export const notoSansJP = Noto_Sans_JP({
+  subsets: ["latin"],
+  variable: "--font-noto-sans-jp",
+  display: "swap",
+  weight: ["400", "500", "700"],
+});
 
 // ==========================================
 // URL検証（Supabase Storage対応）
@@ -69,6 +78,9 @@ export function createDefaultMetadata(): Metadata {
       images: [`${defaultUrl}${config.defaultImage}`],
     },
     icons: config.icons,
+    other: {
+      "font-family": notoSansJP.style.fontFamily,
+    },
   };
 }
 
@@ -95,6 +107,9 @@ export function createOgpMetadata(imageUrl: string): Metadata {
       images: [sanitizedImageUrl],
     },
     icons: config.icons,
+    other: {
+      "font-family": notoSansJP.style.fontFamily,
+    },
   };
 }
 


### PR DESCRIPTION
# 変更の概要
- geistフォントという英語向けのフォントが適用されていたので、hiragino sans JPに変更
- フォールバックフォントのhiragino kaku gothicはfont weight 400と700しか定義できず、もう少し細めのboldも使いたい部分があるので、hiragino sansを使用。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x ] CLAの内容を読み、同意しました