### PR TITLE
biomeの設定でplaywright-reportを無視する

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,12 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": ["**/.next/**", "**/node_modules/**", "**/supabase/.temp/**"]
+    "ignore": [
+      "**/.next/**",
+      "**/node_modules/**",
+      "**/supabase/.temp/**",
+      "**/playwright-report/**"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
# 変更の概要
- biomeの設定でplaywright-reportを無視するために`biome.json`を修正

# 変更の背景
- `npm run test:e2e`を実行すると`playwright-report`フォルダが作成される。しかし、biomeはそのフォルダ内のファイルも対象となる。そのため、`biome:check:write`に時間がかかり処理が終わらない。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました