### PR TITLE
#305 メールテンプレートのボタンの色を単色、emerald-600(#059669)相当に変更

### DIFF
--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -23,7 +23,7 @@
 <div style="text-align: center; margin: 32px 0;">
   <a href="{{ .ConfirmationURL }}" style="
     display: inline-block;
-    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    background-color: #059669;
     color: white;
     text-decoration: none;
     padding: 16px 32px;

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -28,7 +28,7 @@
 <div style="text-align: center; margin: 32px 0;">
   <a href="{{ .ConfirmationURL }}" style="
     display: inline-block;
-    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    background-color: #059669;
     color: white;
     text-decoration: none;
     padding: 16px 32px;

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -26,7 +26,7 @@
 <div style="text-align: center; margin: 32px 0;">
   <a href="{{ .ConfirmationURL }}" style="
     display: inline-block;
-    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    background-color: #059669;
     color: white;
     text-decoration: none;
     padding: 16px 32px;

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -26,7 +26,7 @@
 <div style="text-align: center; margin: 32px 0;">
   <a href="{{ .ConfirmationURL }}" style="
     display: inline-block;
-    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    background-color: #059669;
     color: white;
     text-decoration: none;
     padding: 16px 32px;

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -26,7 +26,7 @@
 <div style="text-align: center; margin: 32px 0;">
   <a href="{{ .ConfirmationURL }}" style="
     display: inline-block;
-    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    background-color: #059669;
     color: white;
     text-decoration: none;
     padding: 16px 32px;


### PR DESCRIPTION
# 変更の概要
- メールテンプレートのボタンの色を単色、emerald-600(#059669)相当に変更

# 変更の背景
- linear-gradientをサポートしていないメールソフトに対応するため

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

Yahoo!メール(Web)で表示されることを確認しました。
![image](https://github.com/user-attachments/assets/2c5b8558-fe38-4eb9-b40c-727cb17cabb0)

**以下は対応前**
![image](https://github.com/user-attachments/assets/f37213fe-fdc4-4170-a53a-caef2e244e1a)

