### PR TITLE
getLevelProgress to use getXpToNextLevel and add tests for level progress calculation

### DIFF
--- a/lib/services/userLevel.ts
+++ b/lib/services/userLevel.ts
@@ -278,11 +278,9 @@ export function getXpToNextLevel(currentXp: number): number {
  */
 export function getLevelProgress(currentXp: number): number {
   const currentLevel = calculateLevel(currentXp);
-  const currentLevelXp = xpDelta(currentLevel);
-  const nextLevelXp = xpDelta(currentLevel + 1);
-  const levelXpRange = nextLevelXp - currentLevelXp;
-  const progressXp = currentXp - currentLevelXp;
-  return Math.max(0, Math.min(1, progressXp / levelXpRange));
+  const xpToNext = getXpToNextLevel(currentXp);
+  const levelXpRange = xpDelta(currentLevel);
+  return Math.max(0, Math.min(1, (levelXpRange - xpToNext) / levelXpRange));
 }
 
 /**

--- a/tests/services/userLevel.test.ts
+++ b/tests/services/userLevel.test.ts
@@ -1,6 +1,7 @@
 import {
   calculateLevel,
   calculateMissionXp,
+  getLevelProgress,
   getXpToNextLevel,
   totalXp,
   xpDelta,
@@ -171,5 +172,51 @@ describe("次のレベルまでのXP計算", () => {
 
   it("XPが750の場合、次のレベルまでのXPは150", () => {
     expect(getXpToNextLevel(750)).toBe(150);
+  });
+});
+
+describe("レベル進捗率計算", () => {
+  it("レベル1のXPが0の場合は進捗率0", () => {
+    expect(getLevelProgress(0)).toBe(0);
+  });
+
+  it("レベル1のXPが20の場合は進捗率0.5", () => {
+    expect(getLevelProgress(20)).toBe(0.5);
+  });
+
+  it("レベル1のXPが39の場合は進捗率ほぼ1", () => {
+    expect(getLevelProgress(39)).toBe(39 / 40);
+  });
+
+  it("レベル2のXPが40の場合は進捗率0", () => {
+    expect(getLevelProgress(40)).toBe(0);
+  });
+
+  it("レベル2のXPが94の場合は進捗率ほぼ1", () => {
+    expect(getLevelProgress(94)).toBeGreaterThan(0.9);
+  });
+
+  it("レベル3のXPが95の場合は進捗率0", () => {
+    expect(getLevelProgress(95)).toBe(0);
+  });
+
+  it("レベル5のXPが300の場合は進捗率0.5", () => {
+    expect(getLevelProgress(300)).toBe(0.5);
+  });
+
+  it("レベル10のXPが900の場合は進捗率0", () => {
+    expect(getLevelProgress(900)).toBe(0);
+  });
+
+  it("レベル20のXPが3325の場合は進捗率0", () => {
+    expect(getLevelProgress(3325)).toBe(0);
+  });
+
+  it("レベル50のXPが19600の場合は進捗率0", () => {
+    expect(getLevelProgress(19600)).toBe(0);
+  });
+
+  it("レベル100のXPが76725の場合は進捗率0", () => {
+    expect(getLevelProgress(76725)).toBe(0);
   });
 });


### PR DESCRIPTION
# 変更の概要
- 次のレベルまでの進捗率を「次のレベル到達に必要なXP」と「（現在のXPを元に計算した）次のレベル到達に必要なXP」を使用するようにする

# 変更の背景
- この[内容](https://github.com/team-mirai-volunteer/action-board/pull/313#issue-3123874373)と同じく、計算ロジックに「現在のXP」を使うと値がおかしくなる

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました