### PR TITLE
クリア上限なしのミッションでも、あとからシェアできるようにする

### DIFF
--- a/app/missions/[id]/_components/MissionFormWrapper.tsx
+++ b/app/missions/[id]/_components/MissionFormWrapper.tsx
@@ -69,9 +69,10 @@ export function MissionFormWrapper({
   };
 
   const completed =
-    (hasReachedUserMaxAchievements &&
-      mission?.max_achievement_count !== null) ||
-    (userAchievementCount > 0 && mission.max_achievement_count === null);
+    hasReachedUserMaxAchievements && mission?.max_achievement_count !== null;
+
+  const isCompletedForUnlimitedMission =
+    userAchievementCount > 0 && mission.max_achievement_count === null;
 
   return (
     <>
@@ -87,24 +88,6 @@ export function MissionFormWrapper({
           <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800">
             <AlertCircle className="h-4 w-4 flex-shrink-0" />
             <span className="text-sm">{errorMessage}</span>
-          </div>
-        )}
-
-        {completed && (
-          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center">
-            <p className="text-sm font-medium text-gray-800">
-              このミッションは達成済みです。
-            </p>
-            <Button
-              onClick={(e) => {
-                e.preventDefault();
-                setIsDialogOpen(true);
-              }}
-              className="mt-2"
-              variant="outline"
-            >
-              シェアする
-            </Button>
           </div>
         )}
 
@@ -141,6 +124,24 @@ export function MissionFormWrapper({
               成果物の内容が認められない場合、ミッションの達成が取り消される場合があります。正確な内容をご記入ください。
             </p>
           </>
+        )}
+
+        {(completed || isCompletedForUnlimitedMission) && (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center">
+            <p className="text-sm font-medium text-gray-800">
+              このミッションは達成済みです。
+            </p>
+            <Button
+              onClick={(e) => {
+                e.preventDefault();
+                setIsDialogOpen(true);
+              }}
+              className="mt-2"
+              variant="outline"
+            >
+              シェアする
+            </Button>
+          </div>
         )}
       </form>
 

--- a/app/missions/[id]/_components/MissionFormWrapper.tsx
+++ b/app/missions/[id]/_components/MissionFormWrapper.tsx
@@ -102,16 +102,15 @@ export function MissionFormWrapper({
             </div>
           )}
 
-        <ArtifactForm
-          key={formKey}
-          mission={mission}
-          authUser={authUser}
-          disabled={isButtonDisabled || isSubmitting}
-          submittedArtifactImagePath={null}
-        />
-
         {!completed && (
           <>
+            <ArtifactForm
+              key={formKey}
+              mission={mission}
+              authUser={authUser}
+              disabled={isButtonDisabled || isSubmitting}
+              submittedArtifactImagePath={null}
+            />
             <SubmitButton
               pendingText="登録中..."
               size="lg"

--- a/app/missions/[id]/_components/MissionFormWrapper.tsx
+++ b/app/missions/[id]/_components/MissionFormWrapper.tsx
@@ -69,7 +69,9 @@ export function MissionFormWrapper({
   };
 
   const completed =
-    hasReachedUserMaxAchievements && mission?.max_achievement_count !== null;
+    (hasReachedUserMaxAchievements &&
+      mission?.max_achievement_count !== null) ||
+    (userAchievementCount > 0 && mission.max_achievement_count === null);
 
   return (
     <>


### PR DESCRIPTION
# 変更の概要
- クリア上限のないミッションにおいても、一度達成したらシェアできるようにする。

# 変更の背景
- 達成回数が決まっているミッションしかシェア画面が出ない現状だった。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

### 動作確認
下記のように、他のページと同様に表示されるように修正しているのですが、達成報告の箇所に組み込む方が適切でしょうか？
![image](https://github.com/user-attachments/assets/aa00208c-6100-4cc2-8d09-80e127c8037a)

fixes #316 