### PR TITLE
Pass ENVIRONMENT to Cloud Build Trigger

### DIFF
--- a/terraform/nextjs-app/cloud_build.tf
+++ b/terraform/nextjs-app/cloud_build.tf
@@ -108,6 +108,7 @@ resource "google_cloudbuild_trigger" "build_and_deploy" {
   substitutions = {
     _REGION                            = var.region
     _SERVICE_NAME                      = "${var.app_name}-${var.environment}"
+    _ENVIRONMENT                       = var.environment
     _REPOSITORY_NAME                   = var.repository_name
     _NEXT_PUBLIC_SUPABASE_URL          = var.NEXT_PUBLIC_SUPABASE_URL
     _NEXT_PUBLIC_SUPABASE_ANON_KEY     = var.NEXT_PUBLIC_SUPABASE_ANON_KEY


### PR DESCRIPTION
# 変更の概要
- build ステップで `_ENVIRONMENT` を参照できるようにする

# 変更の背景
- 秘匿情報以外はアプリ側で管理してしまったほうが開発サイクルがはやくなりそうなので、環境名を取得できるようにしておく

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました