### PR TITLE
紹介ミッション 同一アドレスサインアップ時達成テーブル登録スキップ

### DIFF
--- a/lib/validation/referral.ts
+++ b/lib/validation/referral.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/server";
 
 export async function isValidReferralCode(code: string): Promise<boolean> {
   const supabase = await createClient();
@@ -14,11 +15,12 @@ export async function isValidReferralCode(code: string): Promise<boolean> {
 export async function isEmailAlreadyUsedInReferral(
   email: string,
 ): Promise<boolean> {
-  const supabase = await createClient();
+  const supabase = await createServiceClient();
   const { data } = await supabase
     .from("mission_artifacts")
     .select("id")
     .eq("artifact_type", "REFERRAL")
-    .eq("text_content", email);
+    .eq("text_content", email.toLowerCase());
+
   return !!(data && data.length > 0);
 }


### PR DESCRIPTION
# 変更の概要
- バグ修正。紹介経由で、同一アドレスでのサインアップ時にachivements、mission_artifactsへデータが登録されないようにする

# 変更の背景
- バグ修正

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました