### PR TITLE
make setCommits false in next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -55,10 +55,6 @@ export default withSentryConfig(nextConfig, {
 
   release: {
     name: process.env.SENTRY_RELEASE,
-    setCommits: {
-      auto: true,
-      ignoreMissing: true,
-      ignoreEmpty: true,
-    },
+    setCommits: false,
   },
 });


### PR DESCRIPTION
# 変更の概要
- build 時に .git の情報を参照しないようにする。

# 変更の背景
- 必要な情報は外から渡している & cloud build 時には .git は渡さないようにしているので取れなくてエラーになる

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました