### PR TITLE
fix: ミッション提出取り消し時のXP減算を実装してレベルアップ無限バグを修正

### DIFF
--- a/lib/services/userLevel.ts
+++ b/lib/services/userLevel.ts
@@ -96,7 +96,11 @@ export async function getOrInitializeUserLevel(
 async function processXpTransaction(
   userId: string,
   xpAmount: number,
-  sourceType: "MISSION_COMPLETION" | "BONUS" | "PENALTY",
+  sourceType:
+    | "MISSION_COMPLETION"
+    | "BONUS"
+    | "PENALTY"
+    | "MISSION_CANCELLATION",
   sourceId?: string,
   description?: string,
 ): Promise<{ success: boolean; userLevel?: UserLevel; error?: string }> {
@@ -162,7 +166,11 @@ async function processXpTransaction(
 export async function grantXp(
   userId: string,
   xpAmount: number,
-  sourceType: "MISSION_COMPLETION" | "BONUS" | "PENALTY" = "BONUS",
+  sourceType:
+    | "MISSION_COMPLETION"
+    | "BONUS"
+    | "PENALTY"
+    | "MISSION_CANCELLATION" = "BONUS",
   sourceId?: string,
   description?: string,
 ): Promise<{ success: boolean; userLevel?: UserLevel; error?: string }> {
@@ -290,7 +298,11 @@ export async function grantXpBatch(
   transactions: Array<{
     userId: string;
     xpAmount: number;
-    sourceType: "MISSION_COMPLETION" | "BONUS" | "PENALTY";
+    sourceType:
+      | "MISSION_COMPLETION"
+      | "BONUS"
+      | "PENALTY"
+      | "MISSION_CANCELLATION";
     sourceId?: string;
     description?: string;
   }>,

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -68,20 +68,6 @@ export type Database = {
             referencedRelation: "missions";
             referencedColumns: ["id"];
           },
-          {
-            foreignKeyName: "achievements_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "activity_timeline_view";
-            referencedColumns: ["user_id"];
-          },
-          {
-            foreignKeyName: "achievements_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "public_user_profiles";
-            referencedColumns: ["id"];
-          },
         ];
       };
       daily_action_summary: {
@@ -258,20 +244,6 @@ export type Database = {
             referencedRelation: "activity_timeline_view";
             referencedColumns: ["id"];
           },
-          {
-            foreignKeyName: "mission_artifacts_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "activity_timeline_view";
-            referencedColumns: ["user_id"];
-          },
-          {
-            foreignKeyName: "mission_artifacts_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "public_user_profiles";
-            referencedColumns: ["id"];
-          },
         ];
       };
       missions: {
@@ -409,6 +381,30 @@ export type Database = {
         };
         Relationships: [];
       };
+      user_referral: {
+        Row: {
+          created_at: string | null;
+          del_flg: boolean;
+          referral_code: string;
+          updated_at: string | null;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string | null;
+          del_flg?: boolean;
+          referral_code: string;
+          updated_at?: string | null;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string | null;
+          del_flg?: boolean;
+          referral_code?: string;
+          updated_at?: string | null;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       weekly_event_count_by_prefecture_summary: {
         Row: {
           count: number;
@@ -477,37 +473,6 @@ export type Database = {
           xp_amount?: number;
         };
         Relationships: [];
-      };
-      user_referral: {
-        Row: {
-          user_id: string;
-          referral_code: string;
-          del_flg: boolean;
-          created_at: string | null;
-          updated_at: string | null;
-        };
-        Insert: {
-          user_id: string;
-          referral_code: string;
-          del_flg?: boolean;
-          created_at?: string | null;
-          updated_at?: string | null;
-        };
-        Update: {
-          referral_code?: string;
-          del_flg?: boolean;
-          created_at?: string | null;
-          updated_at?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "user_referral_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: true;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-        ];
       };
     };
     Views: {

--- a/supabase/migrations/20250609000000_add_mission_cancellation_source_type.sql
+++ b/supabase/migrations/20250609000000_add_mission_cancellation_source_type.sql
@@ -1,0 +1,13 @@
+-- XP取引のsource_typeにMISSION_CANCELLATIONを追加
+-- ミッション提出取り消し時のXP減算用
+
+-- 既存のCHECK制約を削除
+ALTER TABLE xp_transactions
+DROP CONSTRAINT IF EXISTS xp_transactions_source_type_check;
+
+-- 新しいCHECK制約を追加（MISSION_CANCELLATIONを含む）
+ALTER TABLE xp_transactions
+ADD CONSTRAINT xp_transactions_source_type_check
+CHECK (source_type IN ('MISSION_COMPLETION', 'BONUS', 'PENALTY', 'MISSION_CANCELLATION'));
+
+COMMENT ON CONSTRAINT xp_transactions_source_type_check ON xp_transactions IS 'MISSION_COMPLETION: ミッション達成時のXP付与, BONUS: ボーナスXP付与, PENALTY: 罰則によるXP減算, MISSION_CANCELLATION: ミッション提出取り消しによるXP減算';

--- a/tests/services/userLevel.test.ts
+++ b/tests/services/userLevel.test.ts
@@ -1,4 +1,3 @@
-import { getLevelProgress, getXpToNextLevel } from "@/lib/services/userLevel";
 import {
   calculateLevel,
   calculateMissionXp,
@@ -153,69 +152,5 @@ describe("XPからユーザーのレベルを計算", () => {
 
   it("XPが最大レベル1000の必要XPを超える場合はレベル1000", () => {
     expect(calculateLevel(totalXp(1001))).toBe(1000);
-  });
-});
-
-describe("次のレベルまでのXP計算", () => {
-  it("XPが0の場合、次のレベルまでのXPは40", () => {
-    expect(getXpToNextLevel(0)).toBe(40);
-  });
-
-  it("XPが40の場合、次のレベルまでのXPは55", () => {
-    expect(getXpToNextLevel(40)).toBe(55);
-  });
-
-  it("XPが100の場合、次のレベルまでのXPは65", () => {
-    expect(getXpToNextLevel(100)).toBe(65);
-  });
-
-  it("XPが750の場合、次のレベルまでのXPは150", () => {
-    expect(getXpToNextLevel(750)).toBe(150);
-  });
-});
-
-describe("レベル進捗率計算", () => {
-  it("レベル1のXPが0の場合は進捗率0", () => {
-    expect(getLevelProgress(0)).toBe(0);
-  });
-
-  it("レベル1のXPが20の場合は進捗率0.5", () => {
-    expect(getLevelProgress(20)).toBe(0.5);
-  });
-
-  it("レベル1のXPが39の場合は進捗率ほぼ1", () => {
-    expect(getLevelProgress(39)).toBe(39 / 40);
-  });
-
-  it("レベル2のXPが40の場合は進捗率0", () => {
-    expect(getLevelProgress(40)).toBe(0);
-  });
-
-  it("レベル2のXPが94の場合は進捗率ほぼ1", () => {
-    expect(getLevelProgress(94)).toBeGreaterThan(0.9);
-  });
-
-  it("レベル3のXPが95の場合は進捗率0", () => {
-    expect(getLevelProgress(95)).toBe(0);
-  });
-
-  it("レベル5のXPが300の場合は進捗率0.5", () => {
-    expect(getLevelProgress(300)).toBe(0.5);
-  });
-
-  it("レベル10のXPが900の場合は進捗率0", () => {
-    expect(getLevelProgress(900)).toBe(0);
-  });
-
-  it("レベル20のXPが3325の場合は進捗率0", () => {
-    expect(getLevelProgress(3325)).toBe(0);
-  });
-
-  it("レベル50のXPが19600の場合は進捗率0", () => {
-    expect(getLevelProgress(19600)).toBe(0);
-  });
-
-  it("レベル100のXPが76725の場合は進捗率0", () => {
-    expect(getLevelProgress(76725)).toBe(0);
   });
 });

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -1,0 +1,65 @@
+import { getLevelProgress, getXpToNextLevel } from "@/lib/utils/utils";
+
+describe("次のレベルまでのXP計算", () => {
+  it("XPが0の場合、次のレベルまでのXPは40", () => {
+    expect(getXpToNextLevel(0)).toBe(40);
+  });
+
+  it("XPが40の場合、次のレベルまでのXPは55", () => {
+    expect(getXpToNextLevel(40)).toBe(55);
+  });
+
+  it("XPが100の場合、次のレベルまでのXPは65", () => {
+    expect(getXpToNextLevel(100)).toBe(65);
+  });
+
+  it("XPが750の場合、次のレベルまでのXPは150", () => {
+    expect(getXpToNextLevel(750)).toBe(150);
+  });
+});
+
+describe("レベル進捗率計算", () => {
+  it("レベル1のXPが0の場合は進捗率0", () => {
+    expect(getLevelProgress(0)).toBe(0);
+  });
+
+  it("レベル1のXPが20の場合は進捗率0.5", () => {
+    expect(getLevelProgress(20)).toBe(0.5);
+  });
+
+  it("レベル1のXPが39の場合は進捗率ほぼ1", () => {
+    expect(getLevelProgress(39)).toBe(39 / 40);
+  });
+
+  it("レベル2のXPが40の場合は進捗率0", () => {
+    expect(getLevelProgress(40)).toBe(0);
+  });
+
+  it("レベル2のXPが94の場合は進捗率ほぼ1", () => {
+    expect(getLevelProgress(94)).toBeGreaterThan(0.9);
+  });
+
+  it("レベル3のXPが95の場合は進捗率0", () => {
+    expect(getLevelProgress(95)).toBe(0);
+  });
+
+  it("レベル5のXPが300の場合は進捗率0.5", () => {
+    expect(getLevelProgress(300)).toBe(0.5);
+  });
+
+  it("レベル10のXPが900の場合は進捗率0", () => {
+    expect(getLevelProgress(900)).toBe(0);
+  });
+
+  it("レベル20のXPが3325の場合は進捗率0", () => {
+    expect(getLevelProgress(3325)).toBe(0);
+  });
+
+  it("レベル50のXPが19600の場合は進捗率0", () => {
+    expect(getLevelProgress(19600)).toBe(0);
+  });
+
+  it("レベル100のXPが76725の場合は進捗率0", () => {
+    expect(getLevelProgress(76725)).toBe(0);
+  });
+});


### PR DESCRIPTION
# 変更の概要
- ミッション取り消し時にXPを減算
- MISSION_CANCELLATIONという新しいsource_typeをxp_transactionsに追加

# 変更の背景
- https://github.com/team-mirai-volunteer/action-board/issues/369

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました