### PR TITLE
MyAvatarからUserAvatarに置き換えてアバター表示を統一

### DIFF
--- a/components/levels.tsx
+++ b/components/levels.tsx
@@ -1,10 +1,8 @@
 import { getUserLevel } from "@/lib/services/userLevel";
 import { getProfile } from "@/lib/services/users";
-import { ChevronRight, MapPin } from "lucide-react";
-import Link from "next/link";
+import { MapPin } from "lucide-react";
 import { LevelProgress } from "./level-progress";
-import MyAvatar from "./my-avatar";
-import { Button } from "./ui/button";
+import UserAvatar from "./user-avatar";
 
 interface LevelsProps {
   userId: string;
@@ -27,7 +25,7 @@ export default async function Levels({
     <section className="bg-gradient-hero flex justify-center py-6 px-4">
       <div className="w-full max-w-md flex flex-col items-stretch bg-white rounded-md p-6">
         <div className="flex items-center">
-          <MyAvatar className="w-16 h-16" />
+          <UserAvatar userProfile={profile} size="lg" />
           <div className="flex flex-col ml-6">
             <div className="text-lg font-bold leading-none">{profile.name}</div>
             <div className="flex items-center mt-2">


### PR DESCRIPTION
# 変更の概要
- 他人のユーザー詳細ページのアイコンが自分のが表示されていたので、他人のユーザーのアイコンに設定

# 変更の背景
- https://github.com/team-mirai-volunteer/action-board/issues/368

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました