### PR TITLE
fix: レベル進捗表示のロジックを修正

### DIFF
--- a/components/level-progress.tsx
+++ b/components/level-progress.tsx
@@ -1,33 +1,13 @@
 import type { UserLevel } from "@/lib/services/userLevel";
-import { totalXp } from "@/lib/utils/utils";
 import React from "react";
 import { ProgressBarSimple } from "./ui/progress-bar-simple";
-import { ProgressCircle } from "./ui/progress-circle";
 
 interface LevelProgressProps {
   userLevel: UserLevel | null;
 }
 
 export function LevelProgress({ userLevel }: LevelProgressProps) {
-  const currentLevel = userLevel?.level ?? 1;
   const currentXp = userLevel?.xp ?? 0;
 
-  // 現在のレベルの開始XP（累計）
-  const currentLevelStartXp = totalXp(currentLevel);
-
-  // 次のレベルに必要なXP（累計）
-  const nextLevelRequiredXp = totalXp(currentLevel + 1);
-
-  // 現在のレベル内での進捗XP
-  const progressInCurrentLevel = currentXp - currentLevelStartXp;
-
-  // 現在のレベルで必要なXP範囲
-  const xpRangeForCurrentLevel = nextLevelRequiredXp - currentLevelStartXp;
-
-  return (
-    <ProgressBarSimple
-      current={progressInCurrentLevel}
-      max={xpRangeForCurrentLevel}
-    />
-  );
+  return <ProgressBarSimple currentXp={currentXp} />;
 }

--- a/components/ui/progress-bar-simple.tsx
+++ b/components/ui/progress-bar-simple.tsx
@@ -1,22 +1,21 @@
 "use client";
 
-import { cn } from "@/lib/utils/utils";
+import { cn, getLevelProgress, getXpToNextLevel } from "@/lib/utils/utils";
 import React from "react";
 
 interface ProgressBarSimpleProps {
-  current: number;
-  max: number;
+  currentXp: number;
   className?: string;
   showText?: boolean;
 }
 
 export function ProgressBarSimple({
-  current,
-  max,
+  currentXp,
   className,
   showText = true,
 }: ProgressBarSimpleProps) {
-  const percentage = Math.min((current / max) * 100, 100);
+  const xpToNextLevel = getXpToNextLevel(currentXp);
+  const progressPercentage = getLevelProgress(currentXp) * 100;
 
   return (
     <div className={cn("w-full", className)}>
@@ -24,7 +23,7 @@ export function ProgressBarSimple({
         <div className="flex text-sm mb-2">
           <span>次のレベルまで</span>
           <span className="font-bold">
-            {Math.round(current).toLocaleString()}
+            {Math.round(xpToNextLevel).toLocaleString()}
             ポイント🔥
           </span>
         </div>
@@ -32,7 +31,7 @@ export function ProgressBarSimple({
       <div className="w-full bg-gray-200 rounded-full h-3 shadow-inner">
         <div
           className="bg-gradient-to-r from-[#30baa7] to-[#47c991] h-3 rounded-full shadow-sm"
-          style={{ width: `${percentage}%` }}
+          style={{ width: `${progressPercentage}%` }}
         />
       </div>
     </div>


### PR DESCRIPTION
# 変更の概要
- LevelProgress コンポーネントのプロップス構造を簡素化
- ProgressBarSimple で直接XP値から進捗率を計算するよう変更
- utils関数 getLevelProgress と getXpToNextLevel を活用
- progressPercentage の計算ロジックを統一

# 変更の背景
- https://github.com/team-mirai-volunteer/action-board/issues/393

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました