### PR TITLE
fix: 利用規約から日本国内に居住していることについての文言を省く

### DIFF
--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -27,7 +27,6 @@ export default function TermsOfService() {
           </p>
           <ul className="list-disc pl-6 space-y-2 text-gray-700 mb-3">
             <li>満18歳以上であること</li>
-            <li>日本国内に居住していること</li>
             <li>本規約に同意し、遵守する意思を有すること</li>
             <li>法令および公序良俗に反しない行動を取ることができること</li>
           </ul>


### PR DESCRIPTION
# 変更の概要
- タイトル通り

# 変更の背景
- closes #409 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました