### PR TITLE
機関紙ポスティングのOGP画像のURL修正

### DIFF
--- a/supabase/migrations/20250612000000_fix_posting_mission_ogp_url.sql
+++ b/supabase/migrations/20250612000000_fix_posting_mission_ogp_url.sql
@@ -1,0 +1,6 @@
+-- ポスティングミッションのOGP画像URLを修正
+
+UPDATE missions 
+SET ogp_image_url = 'https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//15_posting.png'
+WHERE title = 'チームみらいの機関誌をポスティングしよう'
+  AND required_artifact_type = 'POSTING';


### PR DESCRIPTION
# 変更の概要
- 機関紙ポスティングのOGP画像のURL修正

# 変更の背景
- URLが想定と違ったので修正

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました