### PR TITLE
追加ミッション: サポーターSlackに入ろう

### DIFF
--- a/supabase/migrations/20250611082230_add_mission_join_slack.sql
+++ b/supabase/migrations/20250611082230_add_mission_join_slack.sql
@@ -1,0 +1,14 @@
+INSERT INTO missions (id, title, icon_url, content, difficulty, event_date, required_artifact_type, max_achievement_count, ogp_image_url, artifact_label)
+VALUES
+  (
+    gen_random_uuid(),
+    'サポーターSlackに入ろう',
+    '/img/mission_fallback.svg',
+    'チームみらいサポーターのSlackに参加しよう！開発・デザイン・動画編集・記事化・オフィスワークなどなど、実際に手を動かし、サポーター作業に関わることにご興味・関心があるチームサポーターの方は、ぜひ「Slack」にご参加ください。',
+    1,
+    NULL,
+    'TEXT',
+    1,
+    'https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//16_slack_join.png',
+    '登録したメールアドレス'
+  )

--- a/supabase/migrations/20250611082230_add_mission_join_slack.sql
+++ b/supabase/migrations/20250611082230_add_mission_join_slack.sql
@@ -4,7 +4,7 @@ VALUES
     gen_random_uuid(),
     'サポーターSlackに入ろう',
     '/img/mission_fallback.svg',
-    'チームみらいサポーターのSlackに参加しよう！開発・デザイン・動画編集・記事化・オフィスワークなどなど、実際に手を動かし、サポーター作業に関わることにご興味・関心があるチームサポーターの方は、ぜひ「Slack」にご参加ください。',
+    '<a href="https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-36k0jx72s-EUWYKNTYTjbZhUnNjCqduA">チームみらいサポーターのSlack</a>に参加しよう！開発・デザイン・動画編集・記事化・オフィスワークなどなど、実際に手を動かし、サポーター作業に関わることにご興味・関心があるチームサポーターの方は、ぜひ「Slack」にご参加ください。',
     1,
     NULL,
     'TEXT',


### PR DESCRIPTION
# 変更の概要
- 追加ミッション: サポーターSlackに入ろう

# 変更の背景
- https://team-mirai.notion.site/Slack-20af6f56bae18057a13ed6e7cd198a11
- closes #378

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# その他気になったこと
- icon_url が mission_fallback.svg のミッションと mission_fallback_icon.svg のミッションがあるようで、使い分けがよくわかりませんでしたが、本番で使われているのは前者のみのようですし前者のほうが新しくできたもののようなので、後者が前者ができるまでに仮で使われていたものなのかと判断して前者を設定しました。この判断が正しければ後者を設定しているレコードは書き換え、後者のアイコンも削除して良いと思いました。
- content はチームみらい運営から送られたサポーター向けメールの文章を元にしています。
- content に Slack ワークスペースへのリンクを張るかを悩み、張りませんでした。アクションボードは公開されているため、サポーター外のメンバーもアクセスできるからです。同時に LINEオープンチャットの URL が公開されているのは良いのかなと疑問に思いました。運営の承認を挟むので問題ないという判断でしょうか？Slack は運営の承認挟んでましたっけ？
- 「Slack に入ろう」だけでなく、Slack に入った後の「「はじめに」の案内を読もう」「自己紹介しよう」「開発チャンネルに参加しよう」などのミッションもあっても良さそうに思いました。複数を一つのミッションにまとめても良いかも知れません。