### PR TITLE
パスワード要件を詳細に表示する #266

### DIFF
--- a/app/(auth-pages)/sign-up/SignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/SignUpForm.tsx
@@ -84,7 +84,13 @@ function SignUpFormContent({
         />
         <Label htmlFor="password">パスワード</Label>
         <p className="text-xs text-muted-foreground mb-2">
-          ※8文字以上で半角英数を含めてください。英数と一部記号が使えます。
+          ・8文字以上32文字以下
+          <br />
+          ・半角英数を含める
+          <br />
+          ・使用可能文字は英数と以下の記号
+          <br />
+          <p className="ml-3"> @+*/#$%&!- </p>
         </p>
         <Input
           type="password"


### PR DESCRIPTION
# 変更の概要
- signup画面におけるパスワードの入力可能文字および制限についてユーザーに提示

# 変更の背景
- サインアップボタンを押すまで、パスワード要件を満たしているのかどうかわからない。
- closes #266

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました