### PR TITLE
feat: パスワードリセット時の同一パスワードエラーメッセージを改善

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -341,7 +341,9 @@ export const resetPasswordAction = async (formData: FormData) => {
     encodedRedirect(
       "error",
       "/reset-password",
-      "パスワードの更新に失敗しました",
+      error.code === "same_password"
+        ? "新しいパスワードは現在のパスワードと異なるものを設定してください"
+        : "パスワードの更新に失敗しました",
     );
   }
 


### PR DESCRIPTION
# 変更の概要
- resetPasswordActionでerror.code === 'same_password'の場合に より分かりやすいエラーメッセージを表示するように修正
- ユーザーが現在のパスワードと同じパスワードを設定しようとした際に 適切なガイダンスを提供

# 変更の背景
- ユーザーからの[お問い合わせ](https://team-mirai-volunteer.slack.com/archives/C08UXTH5YMA/p1749802680645099)
- けど、本当にこれが原因かわからない

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました