### PR TITLE
都道府県別ランキングの実装

### DIFF
--- a/app/ranking/ranking-prefecture/page.tsx
+++ b/app/ranking/ranking-prefecture/page.tsx
@@ -1,0 +1,85 @@
+import { CurrentUserCardPrefecture } from "@/components/ranking/current-user-card-prefecture";
+import { PrefectureSelect } from "@/components/ranking/prefecture-select";
+import RankingPrefecture from "@/components/ranking/ranking-prefecture";
+import { RankingTabs } from "@/components/ranking/ranking-tabs";
+import { PREFECTURES } from "@/lib/address";
+import { getUserPrefecturesRanking } from "@/lib/services/prefecturesRanking";
+import { getMyProfile } from "@/lib/services/users";
+import { createClient } from "@/lib/supabase/server";
+
+interface PageProps {
+  searchParams: Promise<{
+    prefecture?: string;
+  }>;
+}
+
+export default async function RankingPrefecturePage({
+  searchParams,
+}: PageProps) {
+  const supabase = await createClient();
+  const resolvedSearchParams = await searchParams;
+
+  // ユーザー情報取得
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  // 都道府県一覧を取得
+  const prefectures = PREFECTURES;
+
+  // ユーザーのプロフィール情報を取得
+  let userProfile = null;
+  if (user) {
+    userProfile = await getMyProfile();
+  }
+
+  // 選択された都道府県を取得（URLパラメータをデコード）
+  const decodedPrefecture = resolvedSearchParams.prefecture
+    ? decodeURIComponent(resolvedSearchParams.prefecture)
+    : null;
+
+  const selectedPrefecture = decodedPrefecture
+    ? prefectures.find((p) => p === decodedPrefecture)
+    : userProfile?.address_prefecture || prefectures[0];
+
+  if (!selectedPrefecture) {
+    return <div className="p-4">選択された都道府県が見つかりません。</div>;
+  }
+
+  let userRanking = null;
+
+  if (user) {
+    // 現在のユーザーの都道府県別ランキングを探す
+    userRanking = await getUserPrefecturesRanking(selectedPrefecture, user.id);
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen py-4 w-full">
+      <RankingTabs>
+        {/* 都道府県選択 */}
+        <section className="py-4 bg-white">
+          <PrefectureSelect
+            prefectures={prefectures}
+            selectedPrefecture={selectedPrefecture}
+          />
+        </section>
+
+        {/* ユーザーのランキングカード */}
+        {userRanking && (
+          <section className="py-4 bg-white">
+            <CurrentUserCardPrefecture
+              currentUser={userRanking}
+              prefecture={selectedPrefecture}
+            />
+          </section>
+        )}
+
+        <section className="py-4 bg-white">
+          {/* 都道府県別ランキング */}
+          <RankingPrefecture limit={100} prefecture={selectedPrefecture} />
+        </section>
+      </RankingTabs>
+    </div>
+  );
+}

--- a/components/ranking/current-user-card-prefecture.tsx
+++ b/components/ranking/current-user-card-prefecture.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { UserRanking } from "@/lib/services/ranking";
+import {
+  formatUserDisplayName,
+  formatUserPrefecture,
+} from "@/lib/utils/ranking-utils";
+import { User } from "lucide-react";
+import { LevelBadge } from "./ranking-level-badge";
+
+interface CurrentUserCardProps {
+  currentUser: UserRanking | null;
+  prefecture: string;
+}
+
+export const CurrentUserCardPrefecture: React.FC<CurrentUserCardProps> = ({
+  currentUser,
+  prefecture,
+}) => {
+  if (!currentUser) {
+    return null;
+  }
+  const displayUser = {
+    ...currentUser,
+    rank: currentUser.rank || 0,
+    name: formatUserDisplayName(currentUser.name),
+    address_prefecture: formatUserPrefecture(currentUser.address_prefecture),
+    level: currentUser.level || 0,
+    xp: currentUser.xp || 0,
+  };
+  return (
+    <div className="max-w-6xl mx-auto px-4">
+      <Card className="border-teal-200 bg-teal-50">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg flex items-center gap-2">
+            <User className="w-5 h-5 text-teal-600" />
+            あなたのランク
+            <span className="ml-2 text-sm">{prefecture}</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-teal-200">
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 bg-teal-500 rounded-full flex items-center justify-center text-white font-bold text-sm">
+                {displayUser.rank}
+              </div>
+              <div>
+                <div className="font-semibold text-gray-900">
+                  {formatUserDisplayName(displayUser.name)}
+                </div>
+                <div className="text-sm text-gray-600">
+                  {formatUserPrefecture(displayUser.address_prefecture)}
+                </div>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="flex items-center gap-2 mb-1">
+                <LevelBadge level={displayUser.level} />
+                <div className="text-lg font-bold">
+                  {displayUser.xp.toLocaleString()}pt
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/components/ranking/prefecture-select.tsx
+++ b/components/ranking/prefecture-select.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface PrefectureSelectProps {
+  prefectures: string[];
+  selectedPrefecture?: string;
+}
+
+export function PrefectureSelect({
+  prefectures,
+  selectedPrefecture,
+}: PrefectureSelectProps) {
+  const router = useRouter();
+  const [currentPrefecture, setCurrentPrefecture] = useState<string>(
+    selectedPrefecture || "",
+  );
+
+  useEffect(() => {
+    if (selectedPrefecture) {
+      setCurrentPrefecture(selectedPrefecture);
+    }
+  }, [selectedPrefecture]);
+
+  const handlePrefectureChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const prefecture = e.target.value;
+    setCurrentPrefecture(prefecture);
+    router.push(`/ranking/ranking-prefecture?prefecture=${prefecture}`);
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-4">
+      <div className="relative">
+        <label
+          htmlFor="mission-select"
+          className="block text-sm font-medium text-gray-700 mb-2"
+        >
+          都道府県を選択
+        </label>
+        <div className="relative">
+          <select
+            id="mission-select"
+            value={currentPrefecture}
+            onChange={handlePrefectureChange}
+            className="w-full p-3 pl-4 pr-10 text-base border border-gray-300 rounded-lg 
+                     bg-white appearance-none cursor-pointer
+                     focus:outline-none focus:ring-2 focus:ring-teal-50 focus:border-teal-400
+                     hover:border-teal-400 transition-colors duration-200"
+          >
+            {prefectures.map((prefecture) => (
+              <option key={prefecture} value={prefecture}>
+                {prefecture}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="w-4 h-4 text-gray-500 absolute right-3 top-1/2 -translate-y-1/2" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ranking/ranking-prefecture.tsx
+++ b/components/ranking/ranking-prefecture.tsx
@@ -1,0 +1,54 @@
+// TOPページ用のランキングコンポーネント
+import { Card } from "@/components/ui/card";
+import { getPrefecturesRanking } from "@/lib/services/prefecturesRanking";
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { RankingItem } from "./ranking-item";
+
+interface RankingPrefectureProps {
+  limit?: number;
+  showDetailedInfo?: boolean; // 詳細情報を表示するかどうか
+  prefecture?: string;
+}
+
+export default async function RankingPrefecture({
+  prefecture,
+  limit = 10,
+  showDetailedInfo = false,
+}: RankingPrefectureProps) {
+  if (!prefecture) {
+    return null;
+  }
+
+  const rankings = await getPrefecturesRanking(prefecture, limit);
+
+  return (
+    <div className="max-w-6xl mx-auto px-4">
+      <div className="flex flex-col gap-6">
+        <div className="">
+          <h2 className="text-2xl md:text-4xl text-gray-900 mb-2 text-center">
+            🏅都道府県別トップ{limit}
+            {prefecture && <span className="ml-2 text-lg">{prefecture}</span>}
+          </h2>
+        </div>
+
+        <Card className="border-2 border-gray-200 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 bg-white">
+          <div className="space-y-1">
+            {rankings.map((user) => (
+              <RankingItem key={user.user_id} user={user} />
+            ))}
+          </div>
+        </Card>
+        {showDetailedInfo && (
+          <Link
+            href={`/ranking/ranking-prefecture?prefecture=${prefecture}`}
+            className="flex items-center text-teal-600 hover:text-teal-700 self-center"
+          >
+            トップ100を見る
+            <ChevronRight className="w-4 h-4 ml-1" />
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/ranking/ranking-tabs.tsx
+++ b/components/ranking/ranking-tabs.tsx
@@ -21,7 +21,7 @@ export function RankingTabs({ children }: RankingTabsProps) {
   };
 
   return (
-    <Tabs defaultValue={getTabValue()} className="w-full">
+    <Tabs value={getTabValue()} className="w-full">
       <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="overall" asChild>
           <Link href="/ranking">全体</Link>

--- a/components/ranking/ranking-tabs.tsx
+++ b/components/ranking/ranking-tabs.tsx
@@ -2,7 +2,7 @@
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 
 interface RankingTabsProps {
   children: React.ReactNode;
@@ -10,24 +10,30 @@ interface RankingTabsProps {
 
 export function RankingTabs({ children }: RankingTabsProps) {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const tab = searchParams.get("tab") || "overall";
-
   const isMissionPage = pathname.includes("ranking-mission");
+  const isPrefecturePage = pathname.includes("ranking-prefecture");
+
+  // パスに基づいてタブの値を決定
+  const getTabValue = () => {
+    if (isMissionPage) return "mission";
+    if (isPrefecturePage) return "prefecture";
+    return "overall";
+  };
 
   return (
-    <Tabs defaultValue={isMissionPage ? "mission" : tab} className="w-full">
-      <TabsList className="grid w-full grid-cols-2">
+    <Tabs defaultValue={getTabValue()} className="w-full">
+      <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="overall" asChild>
           <Link href="/ranking">全体</Link>
+        </TabsTrigger>
+        <TabsTrigger value="prefecture" asChild>
+          <Link href="/ranking/ranking-prefecture">都道府県別</Link>
         </TabsTrigger>
         <TabsTrigger value="mission" asChild>
           <Link href="/ranking/ranking-mission">ミッション別</Link>
         </TabsTrigger>
       </TabsList>
-      <TabsContent value={isMissionPage ? "mission" : "overall"}>
-        {children}
-      </TabsContent>
+      <TabsContent value={getTabValue()}>{children}</TabsContent>
     </Tabs>
   );
 }

--- a/lib/services/prefecturesRanking.ts
+++ b/lib/services/prefecturesRanking.ts
@@ -1,0 +1,93 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import type { UserRanking } from "./ranking";
+
+export async function getPrefecturesRanking(
+  prefecture: string,
+  limit = 10,
+): Promise<UserRanking[]> {
+  try {
+    const supabase = await createClient();
+
+    // データベース関数を使用して都道府県別ランキングを取得
+    const { data: rankings, error: rankingsError } = await supabase.rpc(
+      "get_prefecture_ranking",
+      {
+        prefecture: prefecture,
+        limit_count: limit,
+      },
+    );
+
+    if (rankingsError) {
+      console.error("Failed to fetch prefecture rankings:", rankingsError);
+      throw new Error(
+        `都道府県ランキングデータの取得に失敗しました: ${rankingsError.message}`,
+      );
+    }
+
+    if (!rankings || rankings.length === 0) {
+      return [];
+    }
+
+    // ランキングデータを変換
+    return rankings.map(
+      (ranking) =>
+        ({
+          user_id: ranking.user_id,
+          name: ranking.user_name,
+          address_prefecture: ranking.address_prefecture,
+          rank: ranking.rank,
+          level: ranking.level,
+          xp: ranking.xp,
+          updated_at: ranking.updated_at,
+        }) as UserRanking,
+    );
+  } catch (error) {
+    console.error("Prefecture ranking service error:", error);
+    throw error;
+  }
+}
+
+export async function getUserPrefecturesRanking(
+  prefecture: string,
+  userId: string,
+): Promise<UserRanking | null> {
+  try {
+    const supabase = await createClient();
+
+    // データベース関数を使用して特定ユーザーのランキングを取得
+    const { data: rankings, error: rankingsError } = await supabase.rpc(
+      "get_user_prefecture_ranking",
+      {
+        prefecture: prefecture,
+        target_user_id: userId,
+      },
+    );
+
+    if (rankingsError) {
+      console.error("Failed to fetch user prefecture ranking:", rankingsError);
+      throw new Error(
+        `ユーザーの都道府県ランキングデータの取得に失敗しました: ${rankingsError.message}`,
+      );
+    }
+
+    if (!rankings || rankings.length === 0) {
+      return null;
+    }
+
+    const ranking = rankings[0];
+    return {
+      user_id: ranking.user_id,
+      name: ranking.user_name,
+      address_prefecture: ranking.address_prefecture,
+      rank: ranking.rank,
+      level: ranking.level,
+      xp: ranking.xp,
+      updated_at: ranking.updated_at,
+    } as UserRanking;
+  } catch (error) {
+    console.error("User prefecture ranking service error:", error);
+    throw error;
+  }
+}

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -563,6 +563,18 @@ export type Database = {
           rank: number;
         }[];
       };
+      get_prefecture_ranking: {
+        Args: { prefecture: string; limit_count?: number };
+        Returns: {
+          user_id: string;
+          user_name: string;
+          address_prefecture: string;
+          rank: number;
+          level: number;
+          xp: number;
+          updated_at: string;
+        }[];
+      };
       get_user_mission_ranking: {
         Args: { mission_id: string; user_id: string };
         Returns: {
@@ -574,6 +586,18 @@ export type Database = {
           updated_at: string;
           clear_count: number;
           rank: number;
+        }[];
+      };
+      get_user_prefecture_ranking: {
+        Args: { prefecture: string; target_user_id: string };
+        Returns: {
+          user_id: string;
+          user_name: string;
+          address_prefecture: string;
+          rank: number;
+          level: number;
+          xp: number;
+          updated_at: string;
         }[];
       };
     };

--- a/supabase/migrations/20250613120529_add_getmission_ranking_function.sql
+++ b/supabase/migrations/20250613120529_add_getmission_ranking_function.sql
@@ -1,4 +1,4 @@
-create or replace function get_mission_ranking(mission_id uuid, limit_count Integer default 10)
+create or replace function get_mission_ranking(mission_id uuid, limit_count integer default 10)
 returns table (
   user_id uuid,
   user_name text,
@@ -6,8 +6,8 @@ returns table (
   level int,
   xp int,
   updated_at timestamp,
-  clear_count int,
-  rank int
+  clear_count bigint,
+  rank bigint
 )
 language sql
 as $$

--- a/supabase/migrations/20250614001740_add_get_user_mission_ranking_function.sql
+++ b/supabase/migrations/20250614001740_add_get_user_mission_ranking_function.sql
@@ -6,8 +6,8 @@ returns table (
   level int,
   xp int,
   updated_at timestamp,
-  clear_count int,
-  rank int
+  clear_count bigint,
+  rank bigint
 )
 language sql
 as $$

--- a/supabase/migrations/20250614032530_add_get_prefecture_ranking_function.sql
+++ b/supabase/migrations/20250614032530_add_get_prefecture_ranking_function.sql
@@ -32,5 +32,5 @@ returns table (
     ranked_users.updated_at
   from ranked_users
   order by ranked_users.rank
-  limit limit_count
+  limit get_prefecture_ranking.limit_count
 $$;

--- a/supabase/migrations/20250614032530_add_get_prefecture_ranking_function.sql
+++ b/supabase/migrations/20250614032530_add_get_prefecture_ranking_function.sql
@@ -1,0 +1,36 @@
+-- Create a function to get prefecture-based rankings
+create or replace function get_prefecture_ranking(prefecture text, limit_count integer default 10)
+returns table (
+  user_id uuid,
+  user_name text,
+  address_prefecture text,
+  rank bigint,
+  level integer,
+  xp integer,
+  updated_at timestamptz
+) language sql as $$
+  with ranked_users as (
+    select 
+      u.id as user_id,
+      u.name as user_name,
+      u.address_prefecture,
+      r.level,
+      r.xp,
+      r.updated_at,
+      rank() over (order by r.xp desc, r.updated_at desc) as rank
+    from public_user_profiles u
+    left join user_ranking_view r on u.id = r.user_id
+    where u.address_prefecture = get_prefecture_ranking.prefecture
+  )
+  select 
+    ranked_users.user_id,
+    ranked_users.user_name,
+    ranked_users.address_prefecture,
+    ranked_users.rank,
+    ranked_users.level,
+    ranked_users.xp,
+    ranked_users.updated_at
+  from ranked_users
+  order by ranked_users.rank
+  limit limit_count
+$$;

--- a/supabase/migrations/20250614033315_add_get_user_prefecture_ranking_function.sql
+++ b/supabase/migrations/20250614033315_add_get_user_prefecture_ranking_function.sql
@@ -1,0 +1,36 @@
+-- Create a function to get a specific user's prefecture ranking
+create or replace function get_user_prefecture_ranking(prefecture text, target_user_id uuid)
+returns table (
+  user_id uuid,
+  user_name text,
+  address_prefecture text,
+  rank bigint,
+  level integer,
+  xp integer,
+  updated_at timestamptz
+) language sql as $$
+  with ranked_users as (
+    select 
+      u.id as user_id,
+      u.name as user_name,
+      u.address_prefecture,
+      r.level,
+      r.xp,
+      r.updated_at,
+      rank() over (order by r.xp desc, r.updated_at desc) as rank
+    from public_user_profiles u
+    left join user_ranking_view r on u.id = r.user_id
+    where u.address_prefecture = get_user_prefecture_ranking.prefecture
+  )
+  select 
+    ranked_users.user_id,
+    ranked_users.user_name,
+    ranked_users.address_prefecture,
+    ranked_users.rank,
+    ranked_users.level,
+    ranked_users.xp,
+    ranked_users.updated_at
+  from ranked_users
+  where ranked_users.user_id = get_user_prefecture_ranking.target_user_id
+  order by ranked_users.rank;
+$$;


### PR DESCRIPTION
# 変更の概要
- 都道府県別ランキングの実装
- 以下がUXになります。（デフォルトの表示は、ユーザーの都道府県ランキングが表示されるようにしています。）  

https://github.com/user-attachments/assets/e69b8353-5f5b-4be3-ba23-69f3a39bf8e4

# 変更の背景
- closes #274 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 都道府県別ランキングページを追加し、ユーザーが都道府県ごとのランキングを閲覧可能に。
  - 都道府県選択用のスタイリッシュなドロップダウンメニューを実装。
  - ユーザー自身の都道府県内ランキングをカード形式で表示。
  - ランキングタブに「全体」「都道府県別」「ミッション別」の3つの切り替えを追加。

- **データベース**
  - 都道府県別ランキングおよびユーザー個別ランキング取得用の新しいSQL関数を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->