### PR TITLE
イベント運営を手伝おうミッション追加（#401）

### DIFF
--- a/supabase/migrations/20250613222100_add_mission_event_manage.sql
+++ b/supabase/migrations/20250613222100_add_mission_event_manage.sql
@@ -1,0 +1,5 @@
+-- イベント運営ミッションを追加
+
+INSERT INTO missions (id, title, icon_url, content, difficulty, event_date, required_artifact_type, max_achievement_count, ogp_image_url, artifact_label)
+VALUES
+('95188747-5529-2515-b30c-2c1d21313247', 'イベント運営を手伝おう', '/img/mission_fallback.svg', 'チームみらいでは、サポーターの皆さんと一緒に、イベントや街頭演説をつくりあげています。イベント会場の調整や当日のスタッフ対応、街頭演説での運営補助など、さまざまなかたちで運営を支えてくれる方を<a href="https://www.notion.so/team-mirai/20af6f56bae180db8f5cc80612bf359a?source=copy_link">募集</a>しています！ <br />成果物として、イベント内で公開されるイベントコードを入力ください。', 4, NULL, 'TEXT', NULL, 'https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//13_event_support.png', 'イベントコード')

--- a/supabase/migrations/20250613222100_add_mission_event_manage.sql
+++ b/supabase/migrations/20250613222100_add_mission_event_manage.sql
@@ -2,4 +2,4 @@
 
 INSERT INTO missions (id, title, icon_url, content, difficulty, event_date, required_artifact_type, max_achievement_count, ogp_image_url, artifact_label)
 VALUES
-('95188747-5529-2515-b30c-2c1d21313247', 'イベント運営を手伝おう', '/img/mission_fallback.svg', 'チームみらいでは、サポーターの皆さんと一緒に、イベントや街頭演説をつくりあげています。イベント会場の調整や当日のスタッフ対応、街頭演説での運営補助など、さまざまなかたちで運営を支えてくれる方を<a href="https://www.notion.so/team-mirai/20af6f56bae180db8f5cc80612bf359a?source=copy_link">募集</a>しています！ <br />成果物として、イベント内で公開されるイベントコードを入力ください。', 4, NULL, 'TEXT', NULL, 'https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//13_event_support.png', 'イベントコード')
+('95188747-5529-2515-b30c-2c1d21313247', 'イベント運営を手伝おう', '/img/mission_fallback.svg', 'チームみらいでは、サポーターの皆さんと一緒に、イベントや街頭演説をつくりあげています。イベント会場の調整や当日のスタッフ対応、街頭演説での運営補助など、さまざまなかたちで運営を支えてくれる方を<a href="https://www.notion.so/team-mirai/20af6f56bae180db8f5cc80612bf359a?source=copy_link">募集</a>しています！ <br />成果物として、イベント内で公開されるイベントコードを入力ください。', 4, NULL, 'TEXT', NULL, 'https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//13_event_support.png', 'イベントコード');

--- a/tests/services/userLevel.test.ts
+++ b/tests/services/userLevel.test.ts
@@ -20,12 +20,16 @@ describe("userLevel service", () => {
         expect(calculateMissionXp(3)).toBe(200);
       });
 
+      it("難易度4（★4 Super hard）は400XP", () => {
+        expect(calculateMissionXp(4)).toBe(400);
+      });
+
       it("無効な難易度（0）はデフォルト50XP", () => {
         expect(calculateMissionXp(0)).toBe(50);
       });
 
-      it("難易度4（★4）はデフォルト400XP", () => {
-        expect(calculateMissionXp(4)).toBe(400);
+      it("無効な難易度（5）はデフォルト50XP", () => {
+        expect(calculateMissionXp(5)).toBe(50);
       });
 
       it("負の難易度はデフォルト50XP", () => {

--- a/tests/services/userLevel.test.ts
+++ b/tests/services/userLevel.test.ts
@@ -24,8 +24,8 @@ describe("userLevel service", () => {
         expect(calculateMissionXp(0)).toBe(50);
       });
 
-      it("無効な難易度（4）はデフォルト50XP", () => {
-        expect(calculateMissionXp(4)).toBe(50);
+      it("難易度4（★4）はデフォルト400XP", () => {
+        expect(calculateMissionXp(4)).toBe(400);
       });
 
       it("負の難易度はデフォルト50XP", () => {


### PR DESCRIPTION
# 変更の概要
- missionsテーブルへのデータ追加。

# 変更の背景
- 「イベント運営を手伝おう」ミッションを追加。
- closes #401 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 新しいミッション「イベント運営を手伝おう」を追加しました。イベントや街頭演説の運営サポートに参加し、イベントコードを入力することで達成できます。ミッション詳細ページには募集ページへのリンクも掲載しています。
- **修正**
  - ミッションの難易度4に対応し、獲得XPが400に変更されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->