### PR TITLE
feat: Xでチームみらいの投稿をリポストしようのミッションを追加

### DIFF
--- a/supabase/migrations/20250615015958_add_mission_x_repost.sql
+++ b/supabase/migrations/20250615015958_add_mission_x_repost.sql
@@ -1,0 +1,33 @@
+INSERT INTO "public"."missions"(
+    "id",
+    "title",
+    "icon_url",
+    "content",
+    "difficulty",
+    "event_date",
+    "required_artifact_type",
+    "max_achievement_count",
+    "created_at",
+    "updated_at",
+    "ogp_image_url",
+    "artifact_label",
+    "is_featured",
+    "is_hidden"
+)
+VALUES(
+    gen_random_uuid(),
+    'Xでチームみらいの投稿をリポストしよう',
+    '/img/mission_fallback.svg',
+    'Xでチームみらいの投稿をリポストしてみましょう！チームみらいが目指す社会を、もっと多くの人へ届けませんか？',
+    '2',
+    '2025-06-15',
+    'LINK',
+    null,
+    '2025-06-15 01:57:01+00',
+    '2025-06-15 01:57:03+00',
+    'https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//19_x_repost.png',
+    'リポストした投稿のURL',
+    'false',
+    'false'
+)
+;

--- a/supabase/migrations/20250615015958_add_mission_x_repost.sql
+++ b/supabase/migrations/20250615015958_add_mission_x_repost.sql
@@ -19,7 +19,7 @@ VALUES(
     'Xでチームみらいの投稿をリポストしよう',
     '/img/mission_fallback.svg',
     'Xでチームみらいの投稿をリポストしてみましょう！チームみらいが目指す社会を、もっと多くの人へ届けませんか？',
-    '2',
+    2,
     '2025-06-15',
     'LINK',
     null,
@@ -27,7 +27,7 @@ VALUES(
     '2025-06-15 01:57:03+00',
     'https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//19_x_repost.png',
     'リポストした投稿のURL',
-    'false',
-    'false'
+    false,
+    false
 )
 ;


### PR DESCRIPTION
# 変更の概要
- Xでチームみらいの投稿をリポストしようのミッションを追加

# 変更の背景
- issue消化
- closes #380 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<img width="537" alt="image" src="https://github.com/user-attachments/assets/0950e6c1-33ca-49ab-8235-c93846f49168" />
<img width="567" alt="image" src="https://github.com/user-attachments/assets/e77cb98d-8175-4d7e-b4c5-faf587c921da" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Team Miraiの投稿をXでリポストする新しいミッションが追加されました。ミッション内容、難易度、アイコン、OGP画像、提出物ラベルなどが設定されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->