### PR TITLE
「(必須)」のフォントがリンク入力フォームで大きくなる問題を修正

### DIFF
--- a/components/mission/ArtifactForm.tsx
+++ b/components/mission/ArtifactForm.tsx
@@ -61,8 +61,10 @@ export function ArtifactForm({
         {/* リンク入力フォーム */}
         {artifactConfig.key === ARTIFACT_TYPES.LINK.key && (
           <div className="space-y-2">
-            <Label htmlFor="artifactLink">{mission.artifact_label}</Label>
-            <span className="artifactText">(必須)</span>
+            <Label htmlFor="artifactLink">
+              {mission.artifact_label}
+              <span className="artifactText"> (必須)</span>
+            </Label>
             <Input
               type="url"
               name="artifactLink"
@@ -79,7 +81,7 @@ export function ArtifactForm({
           <div className="space-y-2">
             <Label htmlFor="artifactText">
               {mission.artifact_label}
-              <span className="artifactText">(必須)</span>
+              <span className="artifactText"> (必須)</span>
             </Label>
             <Input
               name="artifactText"

--- a/components/mission/ImageUploader.tsx
+++ b/components/mission/ImageUploader.tsx
@@ -74,7 +74,7 @@ export function ImageUploader({
     <div className="space-y-2">
       <Label htmlFor="artifactImage">
         画像ファイル
-        <span className="text-sm artifactDescription">(必須)</span>
+        <span className="text-sm artifactDescription"> (必須)</span>
       </Label>
       <Input
         type="file"


### PR DESCRIPTION
# 変更の概要
- リンク入力フォームで「(必須)」を `<Label>` 内に移動
- 「(必須)」の直前に半角スペースを入れました

# 変更の背景
- closes #455 455

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクリーンショット

## 適用前
<img width="460" alt="スクリーンショット 2025-06-15 12 28 40" src="https://github.com/user-attachments/assets/922a81ac-9ea3-4ba5-b5c5-e0ed0b25fa40" />

## 適用後
<img width="462" alt="スクリーンショット 2025-06-15 12 28 56" src="https://github.com/user-attachments/assets/d018f2b7-6177-44e5-9d04-aa70b850a80e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - フォームの必須ラベル表示のスペースと配置を調整し、ラベルと「(必須)」の表示がより見やすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->