### PR TITLE
fix: ミッションの達成履歴の文言を修正

### DIFF
--- a/app/missions/[id]/_components/CancelSubmissionDialog.tsx
+++ b/app/missions/[id]/_components/CancelSubmissionDialog.tsx
@@ -28,7 +28,7 @@ const CancelSubmissionDialog: React.FC<CancelSubmissionDialogProps> = ({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>達成を取り消しますか？</DialogTitle>
+          <DialogTitle>達成を削除しますか？</DialogTitle>
           <DialogDescription>
             この操作は取り消すことができません。報告した履歴と関連データは削除されます。
           </DialogDescription>

--- a/app/missions/[id]/_components/SubmissionItem.tsx
+++ b/app/missions/[id]/_components/SubmissionItem.tsx
@@ -39,7 +39,7 @@ const SubmissionItem: React.FC<SubmissionItemProps> = ({
             size="xs"
             onClick={() => onCancelClick(submission.id)}
           >
-            取り消す
+            削除
           </Button>
         )}
       </div>


### PR DESCRIPTION
# 変更の概要
- ミッションの達成履歴の文言を修正

# 変更の背景
- 以下の2文で「取り消す」が異なる意味合いで使われているためわかりづらいと思います。
前者は「達成」を取り消す意味合い、後者は「達成を取り消すこと」を取り消す意味合い。
    - 達成を取り消しますか？
    - この操作は取り消すことができません
- closes #385 

## 修正後

![スクリーンショット 2025-06-15 12 39 50](https://github.com/user-attachments/assets/a06a00ce-92f8-45d8-a36f-15a05fb18e1e)

![スクリーンショット 2025-06-15 12 39 43](https://github.com/user-attachments/assets/a6846129-2e2c-4066-aa15-8ee533e18169)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました