### PR TITLE
ポスティングミッションの達成報告を郵便番号へ修正（#470）

### DIFF
--- a/components/mission/ArtifactForm.tsx
+++ b/components/mission/ArtifactForm.tsx
@@ -115,7 +115,7 @@ export function ArtifactForm({
 
             <div className="space-y-2">
               <Label htmlFor="locationText">
-                ポスティング場所の郵便番号（ハイフンなし）{" "}
+                ポスティング場所の郵便番号（ハイフンなし）
                 <span className="text-red-500">*</span>
               </Label>
               <Input
@@ -128,7 +128,7 @@ export function ArtifactForm({
                 placeholder="例：1540017"
               />
               <p className="text-xs text-gray-500">
-                市区町村レベルまでの住所を入力してください
+                対象エリアの郵便番号をご入力ください
               </p>
             </div>
           </div>

--- a/components/mission/ArtifactForm.tsx
+++ b/components/mission/ArtifactForm.tsx
@@ -115,7 +115,8 @@ export function ArtifactForm({
 
             <div className="space-y-2">
               <Label htmlFor="locationText">
-                ポスティング場所 <span className="text-red-500">*</span>
+                ポスティング場所の郵便番号（ハイフンなし）{" "}
+                <span className="text-red-500">*</span>
               </Label>
               <Input
                 type="text"
@@ -124,7 +125,7 @@ export function ArtifactForm({
                 required
                 maxLength={100}
                 disabled={disabled}
-                placeholder="例：東京都世田谷区代田1丁目"
+                placeholder="例：1540017"
               />
               <p className="text-xs text-gray-500">
                 市区町村レベルまでの住所を入力してください


### PR DESCRIPTION
# 変更の概要
- タイトルを地名から郵便番号へ修正
- 例示を修正
- フォーム下の特記事項を修正

# 変更の背景
- 収集したい対象に変更があったため
- closes #470

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - 「ポスティング場所」入力欄のラベルとプレースホルダーが「郵便番号（ハイフンなし）」指定に変更されました。
  - 補助テキストも、住所入力から郵便番号入力の案内に更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->