### PR TITLE
feat: ユーザー詳細ページにミッション達成のサマリを表示

### DIFF
--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -1,6 +1,8 @@
 import Levels from "@/components/levels";
 import { Card } from "@/components/ui/card";
-import { createClient } from "@/lib/supabase/client";
+import { UserMissionAchievements } from "@/components/user-mission-achievements";
+import { getUserMissionAchievements } from "@/lib/services/userMissionAchievement";
+import { createClient } from "@/lib/supabase/server";
 import UserDetailActivities from "./user-detail-activities";
 
 const PAGE_SIZE = 20;
@@ -15,7 +17,7 @@ type Props = {
 
 export default async function UserDetailPage({ params }: Props) {
   const { id } = await params;
-  const supabase = createClient();
+  const supabase = await createClient();
 
   // ユーザー情報取得
   const { data: user } = await supabase
@@ -37,6 +39,9 @@ export default async function UserDetailPage({ params }: Props) {
     .from("activity_timeline_view")
     .select("*", { count: "exact" })
     .eq("user_id", id);
+
+  // ミッション達成状況取得
+  const missionAchievements = await getUserMissionAchievements(id);
 
   return (
     <div className="flex flex-col items-stretch max-w-xl gap-4 py-8">
@@ -75,6 +80,9 @@ export default async function UserDetailPage({ params }: Props) {
           </div>
         )}
       </div>
+      <Card className="w-full p-4 mt-4">
+        <UserMissionAchievements achievements={missionAchievements} />
+      </Card>
       <Card className="w-full p-4 mt-4">
         <div className="flex flex-row justify-between items-center mb-2">
           <span className="text-lg font-bold">活動タイムライン</span>

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -80,9 +80,11 @@ export default async function UserDetailPage({ params }: Props) {
           </div>
         )}
       </div>
-      <Card className="w-full p-4 mt-4">
-        <UserMissionAchievements achievements={missionAchievements} />
-      </Card>
+      {missionAchievements.length > 0 && (
+        <Card className="w-full p-4 mt-4">
+          <UserMissionAchievements achievements={missionAchievements} />
+        </Card>
+      )}
       <Card className="w-full p-4 mt-4">
         <div className="flex flex-row justify-between items-center mb-2">
           <span className="text-lg font-bold">活動タイムライン</span>

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -1,7 +1,10 @@
 import Levels from "@/components/levels";
 import { Card } from "@/components/ui/card";
 import { UserMissionAchievements } from "@/components/user-mission-achievements";
-import { getUserMissionAchievements } from "@/lib/services/userMissionAchievement";
+import {
+  getUserRepeatableMissionAchievements,
+  getUserTotalAchievementCount,
+} from "@/lib/services/userMissionAchievement";
 import { createClient } from "@/lib/supabase/server";
 import UserDetailActivities from "./user-detail-activities";
 
@@ -41,7 +44,8 @@ export default async function UserDetailPage({ params }: Props) {
     .eq("user_id", id);
 
   // ミッション達成状況取得
-  const missionAchievements = await getUserMissionAchievements(id);
+  const missionAchievements = await getUserRepeatableMissionAchievements(id);
+  const totalAchievementCount = await getUserTotalAchievementCount(id);
 
   return (
     <div className="flex flex-col items-stretch max-w-xl gap-4 py-8">
@@ -80,9 +84,12 @@ export default async function UserDetailPage({ params }: Props) {
           </div>
         )}
       </div>
-      {missionAchievements.length > 0 && (
+      {totalAchievementCount > 0 && (
         <Card className="w-full p-4 mt-4">
-          <UserMissionAchievements achievements={missionAchievements} />
+          <UserMissionAchievements
+            achievements={missionAchievements}
+            totalCount={totalAchievementCount}
+          />
         </Card>
       )}
       <Card className="w-full p-4 mt-4">

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -1,10 +1,7 @@
 import Levels from "@/components/levels";
 import { Card } from "@/components/ui/card";
 import { UserMissionAchievements } from "@/components/user-mission-achievements";
-import {
-  getUserRepeatableMissionAchievements,
-  getUserTotalAchievementCount,
-} from "@/lib/services/userMissionAchievement";
+import { getUserRepeatableMissionAchievements } from "@/lib/services/userMissionAchievement";
 import { createClient } from "@/lib/supabase/server";
 import UserDetailActivities from "./user-detail-activities";
 
@@ -31,25 +28,20 @@ export default async function UserDetailPage({ params }: Props) {
   if (!user) return <div>ユーザーが見つかりません</div>;
 
   // 並列でデータを取得
-  const [
-    { data: timeline },
-    { count },
-    missionAchievements,
-    totalAchievementCount,
-  ] = await Promise.all([
-    supabase
-      .from("activity_timeline_view")
-      .select("*")
-      .eq("user_id", id)
-      .order("created_at", { ascending: false })
-      .limit(PAGE_SIZE),
-    supabase
-      .from("activity_timeline_view")
-      .select("*", { count: "exact" })
-      .eq("user_id", id),
-    getUserRepeatableMissionAchievements(id),
-    getUserTotalAchievementCount(id),
-  ]);
+  const [{ data: timeline }, { count }, missionAchievements] =
+    await Promise.all([
+      supabase
+        .from("activity_timeline_view")
+        .select("*")
+        .eq("user_id", id)
+        .order("created_at", { ascending: false })
+        .limit(PAGE_SIZE),
+      supabase
+        .from("activity_timeline_view")
+        .select("*", { count: "exact" })
+        .eq("user_id", id),
+      getUserRepeatableMissionAchievements(id),
+    ]);
 
   return (
     <div className="flex flex-col items-stretch max-w-xl gap-4 py-8">
@@ -88,11 +80,11 @@ export default async function UserDetailPage({ params }: Props) {
           </div>
         )}
       </div>
-      {totalAchievementCount > 0 && (
+      {(count || 0) > 0 && (
         <Card className="w-full p-4 mt-4">
           <UserMissionAchievements
             achievements={missionAchievements}
-            totalCount={totalAchievementCount}
+            totalCount={count || 0}
           />
         </Card>
       )}

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -8,7 +8,7 @@ export default async function Hero() {
 
   if (user) {
     try {
-      return <Levels userId={user.id} />;
+      return <Levels userId={user.id} clickable={true} />;
     } catch (error) {
       console.error("Error fetching user levels:", error);
     }

--- a/components/levels.tsx
+++ b/components/levels.tsx
@@ -1,17 +1,20 @@
 import { getUserLevel } from "@/lib/services/userLevel";
 import { getProfile } from "@/lib/services/users";
 import { MapPin } from "lucide-react";
+import Link from "next/link";
 import { LevelProgress } from "./level-progress";
 import UserAvatar from "./user-avatar";
 
 interface LevelsProps {
   userId: string;
   hideProgress?: boolean;
+  clickable?: boolean;
 }
 
 export default async function Levels({
   userId,
   hideProgress = false,
+  clickable = false,
 }: LevelsProps) {
   const profile = await getProfile(userId);
 
@@ -21,33 +24,47 @@ export default async function Levels({
 
   const userLevel = await getUserLevel(userId);
 
-  return (
-    <section className="bg-gradient-hero flex justify-center py-6 px-4">
-      <div className="w-full max-w-md flex flex-col items-stretch bg-white rounded-md p-6">
-        <div className="flex items-center">
-          <UserAvatar userProfile={profile} size="lg" />
-          <div className="flex flex-col ml-6">
-            <div className="text-lg font-bold leading-none">{profile.name}</div>
-            <div className="flex items-center mt-2">
-              <div className="flex items-baseline">
-                <div className="text-sm font-bold">LV.</div>
-                <div className="text-xxl font-bold ml-1 leading-none">
-                  {userLevel ? userLevel.level : "1"}
-                </div>
+  const cardContent = (
+    <div
+      className={`w-full max-w-md flex flex-col items-stretch bg-white rounded-md p-6 ${clickable ? "hover:bg-gray-50 transition-colors cursor-pointer" : ""}`}
+    >
+      <div className="flex items-center">
+        <UserAvatar userProfile={profile} size="lg" />
+        <div className="flex flex-col ml-6">
+          <div className="text-lg font-bold leading-none">{profile.name}</div>
+          <div className="flex items-center mt-2">
+            <div className="flex items-baseline">
+              <div className="text-sm font-bold">LV.</div>
+              <div className="text-xxl font-bold ml-1 leading-none">
+                {userLevel ? userLevel.level : "1"}
               </div>
-              <div className="flex ml-4 text-sm items-center">
-                <MapPin className="w-4 h-4 mr-0.5" />
-                {profile.address_prefecture}
-              </div>
+            </div>
+            <div className="flex ml-4 text-sm items-center">
+              <MapPin className="w-4 h-4 mr-0.5" />
+              {profile.address_prefecture}
             </div>
           </div>
         </div>
-        {!hideProgress && (
-          <div className="mt-4 flex flex-col items-start">
-            <LevelProgress userLevel={userLevel} />
-          </div>
-        )}
       </div>
+      {!hideProgress && (
+        <div className="mt-4 flex flex-col items-start">
+          <LevelProgress userLevel={userLevel} />
+        </div>
+      )}
+    </div>
+  );
+
+  if (clickable) {
+    return (
+      <section className="bg-gradient-hero flex justify-center py-6 px-4">
+        <Link href={`/users/${userId}`}>{cardContent}</Link>
+      </section>
+    );
+  }
+
+  return (
+    <section className="bg-gradient-hero flex justify-center py-6 px-4">
+      {cardContent}
     </section>
   );
 }

--- a/components/levels.tsx
+++ b/components/levels.tsx
@@ -57,7 +57,12 @@ export default async function Levels({
   if (clickable) {
     return (
       <section className="bg-gradient-hero flex justify-center py-6 px-4">
-        <Link href={`/users/${userId}`}>{cardContent}</Link>
+        <Link
+          href={`/users/${userId}`}
+          aria-label={`${profile.name}さんのプロフィールへ`}
+        >
+          {cardContent}
+        </Link>
       </section>
     );
   }

--- a/components/levels.tsx
+++ b/components/levels.tsx
@@ -26,7 +26,7 @@ export default async function Levels({
 
   const cardContent = (
     <div
-      className={`w-full max-w-md flex flex-col items-stretch bg-white rounded-md p-6 ${clickable ? "hover:bg-gray-50 transition-colors cursor-pointer" : ""}`}
+      className={`w-full max-w-md flex flex-col items-stretch bg-white rounded-md p-6 ${clickable ? "hover:bg-gray-50 transition-colors" : ""}`}
     >
       <div className="flex items-center">
         <UserAvatar userProfile={profile} size="lg" />
@@ -60,6 +60,7 @@ export default async function Levels({
         <Link
           href={`/users/${userId}`}
           aria-label={`${profile.name}さんのプロフィールへ`}
+          className="w-full max-w-md"
         >
           {cardContent}
         </Link>

--- a/components/user-mission-achievements/index.tsx
+++ b/components/user-mission-achievements/index.tsx
@@ -1,0 +1,40 @@
+import type { MissionAchievementSummary } from "@/lib/services/userMissionAchievement";
+import { MissionAchievementCard } from "./mission-card";
+import { MissionAchievementTotalCard } from "./total-card";
+
+interface UserMissionAchievementsProps {
+  achievements: MissionAchievementSummary[];
+}
+
+export function UserMissionAchievements({
+  achievements,
+}: UserMissionAchievementsProps) {
+  const totalCount = achievements.reduce(
+    (sum, achievement) => sum + achievement.achievement_count,
+    0,
+  );
+
+  return (
+    <div className="w-full">
+      <div className="flex flex-row justify-between items-center mb-4">
+        <span className="text-lg font-bold">ミッション達成状況</span>
+      </div>
+      {achievements.length === 0 ? (
+        <div className="text-center text-gray-500">
+          まだミッションを達成していません
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <MissionAchievementTotalCard totalCount={totalCount} />
+          {achievements.map((achievement) => (
+            <MissionAchievementCard
+              key={achievement.mission_id}
+              title={achievement.mission_title}
+              count={achievement.achievement_count}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/user-mission-achievements/index.tsx
+++ b/components/user-mission-achievements/index.tsx
@@ -19,22 +19,16 @@ export function UserMissionAchievements({
       <div className="flex flex-row justify-between items-center mb-4">
         <span className="text-lg font-bold">ミッション達成状況</span>
       </div>
-      {achievements.length === 0 ? (
-        <div className="text-center text-gray-500">
-          まだミッションを達成していません
-        </div>
-      ) : (
-        <div className="flex flex-col gap-2">
-          <MissionAchievementTotalCard totalCount={totalCount} />
-          {achievements.map((achievement) => (
-            <MissionAchievementCard
-              key={achievement.mission_id}
-              title={achievement.mission_title}
-              count={achievement.achievement_count}
-            />
-          ))}
-        </div>
-      )}
+      <div className="flex flex-col gap-2">
+        <MissionAchievementTotalCard totalCount={totalCount} />
+        {achievements.map((achievement) => (
+          <MissionAchievementCard
+            key={achievement.mission_id}
+            title={achievement.mission_title}
+            count={achievement.achievement_count}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/user-mission-achievements/index.tsx
+++ b/components/user-mission-achievements/index.tsx
@@ -4,16 +4,13 @@ import { MissionAchievementTotalCard } from "./total-card";
 
 interface UserMissionAchievementsProps {
   achievements: MissionAchievementSummary[];
+  totalCount: number;
 }
 
 export function UserMissionAchievements({
   achievements,
+  totalCount,
 }: UserMissionAchievementsProps) {
-  const totalCount = achievements.reduce(
-    (sum, achievement) => sum + achievement.achievement_count,
-    0,
-  );
-
   return (
     <div className="w-full">
       <div className="flex flex-row justify-between items-center mb-4">

--- a/components/user-mission-achievements/mission-card.tsx
+++ b/components/user-mission-achievements/mission-card.tsx
@@ -1,0 +1,23 @@
+import { Card } from "@/components/ui/card";
+
+interface MissionAchievementCardProps {
+  title: string;
+  count: number;
+}
+
+export function MissionAchievementCard({
+  title,
+  count,
+}: MissionAchievementCardProps) {
+  return (
+    <Card className="p-4">
+      <div className="flex justify-between items-center">
+        <div className="text-sm font-bold text-gray-700 flex-1">{title}</div>
+        <div className="flex items-baseline gap-2 ml-4">
+          <span className="text-2xl font-bold text-teal-600">{count}</span>
+          <span className="text-base font-bold text-gray-700">回</span>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/components/user-mission-achievements/mission-card.tsx
+++ b/components/user-mission-achievements/mission-card.tsx
@@ -12,7 +12,9 @@ export function MissionAchievementCard({
   return (
     <Card className="p-4">
       <div className="flex justify-between items-center">
-        <div className="text-sm font-bold text-gray-700 flex-1">{title}</div>
+        <div className="text-sm font-bold text-gray-700 flex-1 min-w-0 truncate">
+          {title}
+        </div>
         <div className="flex items-baseline gap-2 ml-4">
           <span className="text-2xl font-bold text-teal-600">{count}</span>
           <span className="text-base font-bold text-gray-700">回</span>

--- a/components/user-mission-achievements/total-card.tsx
+++ b/components/user-mission-achievements/total-card.tsx
@@ -1,0 +1,27 @@
+import { Card } from "@/components/ui/card";
+
+interface MissionAchievementTotalCardProps {
+  totalCount: number;
+}
+
+export function MissionAchievementTotalCard({
+  totalCount,
+}: MissionAchievementTotalCardProps) {
+  return (
+    <Card className="relative overflow-hidden border-2 border-emerald-200 rounded-2xl shadow-sm transition-all duration-300 p-4 bg-gradient-to-br from-white to-emerald-50">
+      <div className="absolute top-0 right-0 w-32 h-32 bg-gradient-to-br from-emerald-200 to-teal-200 rounded-full opacity-20 -mr-16 -mt-16" />
+      <div className="relative flex justify-between items-center">
+        <div className="flex items-center gap-1">
+          <span className="text-gray-700">🏆</span>
+          <span className="text-base font-bold text-gray-700">総達成数</span>
+        </div>
+        <div className="flex items-baseline gap-1">
+          <span className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-emerald-600 to-teal-600">
+            {totalCount}
+          </span>
+          <span className="text-xl font-bold text-gray-700">回</span>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/lib/services/userMissionAchievement.ts
+++ b/lib/services/userMissionAchievement.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+import { createClient as createServerClient } from "@/lib/supabase/server";
+
+export interface MissionAchievementSummary {
+  mission_id: string;
+  mission_title: string;
+  achievement_count: number;
+}
+
+export async function getUserMissionAchievements(
+  userId: string,
+): Promise<MissionAchievementSummary[]> {
+  try {
+    const supabase = await createServerClient();
+
+    const { data, error } = await supabase
+      .from("achievements")
+      .select(`
+        mission_id,
+        missions!inner (
+          id,
+          title,
+          max_achievement_count
+        )
+      `)
+      .eq("user_id", userId)
+      .is("missions.max_achievement_count", null);
+
+    if (error) {
+      console.error("Failed to fetch user mission achievements:", error);
+      throw new Error(
+        `ユーザーのミッション達成状況の取得に失敗しました: ${error.message}`,
+      );
+    }
+
+    if (!data) return [];
+
+    const achievementCounts = data.reduce(
+      (acc, achievement) => {
+        const missionId = achievement.mission_id;
+        if (!missionId || !achievement.missions) return acc;
+
+        if (!acc[missionId]) {
+          acc[missionId] = {
+            mission_id: missionId,
+            mission_title: achievement.missions.title,
+            achievement_count: 0,
+          };
+        }
+        acc[missionId].achievement_count += 1;
+        return acc;
+      },
+      {} as Record<string, MissionAchievementSummary>,
+    );
+
+    return Object.values(achievementCounts).filter(
+      (achievement) => achievement.achievement_count > 0,
+    );
+  } catch (error) {
+    console.error("User mission achievements service error:", error);
+    return [];
+  }
+}

--- a/lib/services/userMissionAchievement.ts
+++ b/lib/services/userMissionAchievement.ts
@@ -11,54 +11,47 @@ export interface MissionAchievementSummary {
 export async function getUserMissionAchievements(
   userId: string,
 ): Promise<MissionAchievementSummary[]> {
-  try {
-    const supabase = await createServerClient();
+  const supabase = await createServerClient();
 
-    const { data, error } = await supabase
-      .from("achievements")
-      .select(`
-        mission_id,
-        missions!inner (
-          id,
-          title,
-          max_achievement_count
-        )
-      `)
-      .eq("user_id", userId)
-      .is("missions.max_achievement_count", null);
+  const { data, error } = await supabase
+    .from("achievements")
+    .select(`
+      mission_id,
+      missions!inner (
+        id,
+        title,
+        max_achievement_count
+      )
+    `)
+    .eq("user_id", userId)
+    .is("missions.max_achievement_count", null);
 
-    if (error) {
-      console.error("Failed to fetch user mission achievements:", error);
-      throw new Error(
-        `ユーザーのミッション達成状況の取得に失敗しました: ${error.message}`,
-      );
-    }
-
-    if (!data) return [];
-
-    const achievementCounts = data.reduce(
-      (acc, achievement) => {
-        const missionId = achievement.mission_id;
-        if (!missionId || !achievement.missions) return acc;
-
-        if (!acc[missionId]) {
-          acc[missionId] = {
-            mission_id: missionId,
-            mission_title: achievement.missions.title,
-            achievement_count: 0,
-          };
-        }
-        acc[missionId].achievement_count += 1;
-        return acc;
-      },
-      {} as Record<string, MissionAchievementSummary>,
-    );
-
-    return Object.values(achievementCounts).filter(
-      (achievement) => achievement.achievement_count > 0,
-    );
-  } catch (error) {
-    console.error("User mission achievements service error:", error);
+  if (error) {
+    console.error("Failed to fetch user mission achievements:", error);
     return [];
   }
+
+  if (!data) return [];
+
+  const achievementCounts = data.reduce(
+    (acc, achievement) => {
+      const missionId = achievement.mission_id;
+      if (!missionId || !achievement.missions) return acc;
+
+      if (!acc[missionId]) {
+        acc[missionId] = {
+          mission_id: missionId,
+          mission_title: achievement.missions.title,
+          achievement_count: 0,
+        };
+      }
+      acc[missionId].achievement_count += 1;
+      return acc;
+    },
+    {} as Record<string, MissionAchievementSummary>,
+  );
+
+  return Object.values(achievementCounts).filter(
+    (achievement) => achievement.achievement_count > 0,
+  );
 }

--- a/lib/services/userMissionAchievement.ts
+++ b/lib/services/userMissionAchievement.ts
@@ -8,7 +8,7 @@ export interface MissionAchievementSummary {
   achievement_count: number;
 }
 
-export async function getUserMissionAchievements(
+export async function getUserRepeatableMissionAchievements(
   userId: string,
 ): Promise<MissionAchievementSummary[]> {
   const supabase = await createServerClient();
@@ -54,4 +54,22 @@ export async function getUserMissionAchievements(
   return Object.values(achievementCounts).filter(
     (achievement) => achievement.achievement_count > 0,
   );
+}
+
+export async function getUserTotalAchievementCount(
+  userId: string,
+): Promise<number> {
+  const supabase = await createServerClient();
+
+  const { count, error } = await supabase
+    .from("achievements")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId);
+
+  if (error) {
+    console.error("Failed to fetch user total achievement count:", error);
+    return 0;
+  }
+
+  return count || 0;
 }

--- a/lib/services/userMissionAchievement.ts
+++ b/lib/services/userMissionAchievement.ts
@@ -55,21 +55,3 @@ export async function getUserRepeatableMissionAchievements(
     (achievement) => achievement.achievement_count > 0,
   );
 }
-
-export async function getUserTotalAchievementCount(
-  userId: string,
-): Promise<number> {
-  const supabase = await createServerClient();
-
-  const { count, error } = await supabase
-    .from("achievements")
-    .select("*", { count: "exact", head: true })
-    .eq("user_id", userId);
-
-  if (error) {
-    console.error("Failed to fetch user total achievement count:", error);
-    return 0;
-  }
-
-  return count || 0;
-}


### PR DESCRIPTION
Refs #179

# 変更の概要
-  他アカウントのユーザー詳細ページにミッション達成状況を表示
- Issueにスクリーンショット貼っています。
- ダッシュボードの本人のユーザーカード（上部に表示されている）をクリックでユーザー詳細ページを表示する。
  → 実装


# 変更の背景
- closes #179 

# やっていないこと
- ~~ダッシュボードの本人のユーザーカード（上部に表示されている）をクリックでユーザー詳細ページを表示する。~~
  → 実装

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ユーザー詳細ページに「ミッション達成状況」セクションを追加し、各ユーザーのミッションごとの達成回数や総達成数を表示できるようになりました。
  - ミッションごとの達成状況をカード形式で一覧表示します。
  - ユーザーレベル表示コンポーネントがクリック可能になり、ユーザープロフィールページへのリンクとして利用可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->