### PR TITLE
#431: ミッションのテキスト内リンクを別タブにする

### DIFF
--- a/supabase/migrations/20250616141811_fix_mission_link_tab.sql
+++ b/supabase/migrations/20250616141811_fix_mission_link_tab.sql
@@ -1,0 +1,48 @@
+UPDATE missions SET
+  content = '推し候補の魅力を、もっと多くの人に届けよう。<a href="https://www.youtube.com/channel/UCiMwbmcCSMORJ-85XWhStBw" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTube動画</a>や、チームみらいの候補者が出演している動画から、心に響いたワンシーンを切り抜いてショート動画にしてみよう。<br />SNSでの拡散や、仲間との共有も大歓迎！あなたの編集が、新しい支持を生み出すかもしれません。'
+WHERE id = '05814416-9cd8-4582-a940-ced9a832efee';
+
+UPDATE missions SET
+  content = '新党チームみらい党首・<a href="https://x.com/takahiroanno" target="_blank" rel="noopener noreferrer">安野たかひろの公式X（旧Twitter）</a>をフォローして発信をチェック！政策への想いや、未来を描く視点が日々の投稿から伝わってきます。'
+WHERE id = '0f4f16e5-35eb-4756-a966-607895a61b0e';
+
+UPDATE missions SET
+  content = '<a href="https://note.com/annotakahiro24" target="_blank" rel="noopener noreferrer">公式note</a>をフォローして、チームみらいの活動の裏側や候補者の考え、政策に込めた想いをもっと深く知ろう！政治活動ストーリーや解説記事など、SNSでは語りきれない情報が満載です。'
+WHERE id = '1776d950-34f4-44e6-a5c5-2e40fa9038a3';
+
+UPDATE missions SET
+  content = '最新の政策情報やイベント情報、サポーターの動きなどをチェックするなら、まずは<a href="https://x.com/team_mirai_jp" target="_blank" rel="noopener noreferrer">公式X（旧Twitter）</a>をフォロー！参加者の投稿や注目の提案も流れてきます。'
+WHERE id = '2c5f7173-48be-4989-9d1b-c749fd56ae44';
+
+UPDATE missions SET
+  content = 'AIと一緒に、あなたの意見を政策にしよう。<a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">いどばた政策</a>は、AIとチャットしながら政策に意見を出せる新しい仕組みです。気になるテーマに質問したり、自分の考えを提案としてまとめると、実際に「チームみらい」へ提出されます。提案にはURLが付き、どう検討されたかも追跡できます。'
+WHERE id = '41dedf9a-2290-4609-bb73-5469ee8dd909';
+
+UPDATE missions SET
+  content = '<a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">いどばた政策</a>でマニフェストを読み、気になった政策や共感した提案について、あなたの言葉でSNSに感想を発信してみよう。難しく考えなくてOK。「ここがいいな」「もっとこうしてほしい」など、素直な声が広がることで、政治はもっと身近になります。'
+WHERE id = '56c03661-8243-42c6-bf81-9dba56c5abfe';
+
+UPDATE missions SET
+  content = 'あなたの得意や関心にあわせて、チームみらいの<a href="https://silent-tent-c92.notion.site/1f9f6f56bae1802aa4e9ff90f1308062" target="_blank" rel="noopener noreferrer">目的別LINEオープンチャット</a>に参加しよう！ ポスター掲示、SNS発信、マニフェスト改善、動画の切り抜きなど、テーマごとのチャットで、仲間とつながって活動を深められます。'
+WHERE id = '6b6190c7-909d-4188-a2dc-039a68bbbe64';
+
+UPDATE missions SET
+  content = 'AIや政治の話をもっとわかりやすく。<a href="https://www.youtube.com/channel/UCiMwbmcCSMORJ-85XWhStBw" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>を登録して、政策解説、候補者のトーク、生配信アーカイブなど、多彩な動画をチェックしよう！難しそうな話題もわかりやすく解説しています。'
+WHERE id = '9071a1eb-e272-43be-9c6b-e08b258a41c3';
+
+UPDATE missions SET
+  content = 'チームみらいでは、サポーターの皆さんと一緒に、イベントや街頭演説をつくりあげています。イベント会場の調整や当日のスタッフ対応、街頭演説での運営補助など、さまざまなかたちで運営を支えてくれる方を<a href="https://www.notion.so/team-mirai/20af6f56bae180db8f5cc80612bf359a?source=copy_link" target="_blank" rel="noopener noreferrer">募集</a>しています！ <br />成果物として、イベント内で公開されるイベントコードを入力ください。'
+WHERE id = '95188747-5529-2515-b30c-2c1d21313247';
+
+UPDATE missions SET
+  content = '<a href="https://line.me/R/ti/p/@465hhyop?oat_content=url&ts=05062204" target="_blank" rel="noopener noreferrer">チームみらいのLINEアカウント</a>を友達に追加して、最新情報をLINEでサクッと受け取ろう。イベント情報や動画の更新もLINEでお届けします。登録しておくと見逃しがありません！'
+WHERE id = 'e7a03d8b-ef29-406f-b2fb-065285855997';
+
+UPDATE missions SET
+  content = 'チームみらいでは、オンライン・オフライン両方で、サポーター向けのイベントを<a href="https://www.notion.so/1f8f6f56bae180fd96e2f809bf1ca0bf?v=1f8f6f56bae181239689000c7e1d858e&source=copy_link#1fef6f56bae1800ab385f544ea22062a" target="_blank" rel="noopener noreferrer">多数開催中</a>！ 全国各地の交流会、政策トーク、新メンバー説明会など、初めての方でも安心して参加できます。仲間とつながり、リアルな場や画面越しで未来を語ろう！<br />成果物として、イベント内で公開されるイベントコードを入力ください。'
+WHERE id = 'f95c8971-af0d-4192-bf51-986781fcbb0e';
+
+UPDATE missions SET
+  content = '<a href="https://silent-tent-c92.notion.site/1f9f6f56bae180d19ebcf176d8338ba3" target="_blank" rel="noopener noreferrer">チームみらいの都道府県別LINEオープンチャット</a>に参加してあなたの地域で、政治や政策について気軽に話せる仲間を見つけよう！ イベント情報の共有や、地域ならではの課題を話し合える場として活用されています。'
+WHERE id = 'fd9da44a-d5ba-4bbf-a1c0-98a0142ee029';
+


### PR DESCRIPTION
# 変更の概要
- missions テーブルの content の a タグで `target="_blank" rel="noopener noreferrer"` がついていないものに対して、`target="_blank" rel="noopener noreferrer"`を追加しました。

# 変更の背景
- 別タブで開かないことで、元いたミッションを見失ってしまう
- closes #431 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# 変更点

## 現在
![スクリーンショット 2025-06-17 0 03 32](https://github.com/user-attachments/assets/54f30a4a-40c4-40dd-8b12-994e69ed9877)
## 修正後
![スクリーンショット 2025-06-17 0 05 01](https://github.com/user-attachments/assets/c974dad1-bbb1-4018-9eac-ed481a9c3fb7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 「チームみらい」の各ミッションに、YouTubeや公式SNS、LINEオープンチャット、政策プラットフォームなど外部リソースへのリンクを含む新しい案内文を追加しました。  
  - 各リンクは新しいタブで開くようになり、より安全にアクセスできます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->