### PR TITLE
 biome v2 が出たことによるCIエラーへの対処。CIのbiomeのバージョンを1.9.4に固定

### DIFF
--- a/.github/workflows/check_biome.yaml
+++ b/.github/workflows/check_biome.yaml
@@ -12,6 +12,6 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: latest
+          version: 1.9.4
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
# 変更の概要

- biome v2 が出たことによるCIエラーへの対処
- CIのbiomeのバージョンを1.9.4に固定

# 変更の背景

- biome v2 が出たことによるCIエラーへの対処

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました