### PR TITLE
feat: パスワードのリセット後、ログイン画面へリダイレクトするように

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -347,7 +347,7 @@ export const resetPasswordAction = async (formData: FormData) => {
     );
   }
 
-  encodedRedirect("success", "/reset-password", "パスワードを更新しました");
+  encodedRedirect("success", "/sign-in", "パスワードを更新しました");
 };
 
 export const signOutAction = async () => {


### PR DESCRIPTION
# 変更の概要

パスワードリセット完了後に、ログイン画面へリダイレクトするようにしました。

# 変更の背景

- closes #338

# CLAへの同意

- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
  内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
