### PR TITLE
Slack URL を修正

### DIFF
--- a/supabase/migrations/20250619071652_fix_slack_url.sql
+++ b/supabase/migrations/20250619071652_fix_slack_url.sql
@@ -1,0 +1,8 @@
+-- 新規メンバー招待に最適化されたURLに更新
+UPDATE missions 
+SET content = REPLACE(
+  content, 
+  'https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-36k0jx72s-EUWYKNTYTjbZhUnNjCqduA',
+  'https://team-mirai-volunteer.slack.com/ssb/redirect'
+)
+WHERE content LIKE '%join.slack.com%';


### PR DESCRIPTION
# 変更の概要
- Slack の招待リンクの期限が切れていたようなので、期限切れの発生しない URL に修正しました。

# 変更の背景
- https://team-mirai.notion.site/Slack-216f6f56bae181d29fe4d3ce42b93079
- closes #545 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました