### PR TITLE
chore: 生年月日入力欄に非公開の注意書きを追加

### DIFF
--- a/app/(protected)/settings/profile/ProfileForm.tsx
+++ b/app/(protected)/settings/profile/ProfileForm.tsx
@@ -189,6 +189,7 @@ export default function ProfileForm({
 
           <div className="space-y-2">
             <Label htmlFor="date_of_birth">生年月日</Label>
+            <p className="text-sm text-gray-500">この項目は公開されません</p>
             <Input
               type="date"
               name="date_of_birth"


### PR DESCRIPTION
# 変更の概要
- プロフィール設定画面の生年月日フィールドに「この項目は公開されません」という注意文を追加

# 変更の背景
- ユーザーに対して入力した生年月日が他者に公開されないことを明示するため
- Issue #476 に対応し、該当Issueに変更を加えた画面のスクリーンショットも添付済み
- closes #476

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プロフィールフォームの「生年月日」ラベル下に「この項目は公開されません」という説明文を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->