### PR TITLE
ポスティングミッションのみ、枚数の表示に変更

### DIFF
--- a/app/missions/[id]/page.tsx
+++ b/app/missions/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   notoSansJP,
 } from "@/lib/metadata";
 import {
+  getAllUsersPostingCount,
   getUserMissionRanking,
   getUserPostingCount,
 } from "@/lib/services/missionsRanking";
@@ -94,6 +95,7 @@ export default async function MissionPage({ params }: Props) {
   // ミッションタイプに応じてbadgeTextを生成、ポスティングミッションの場合はポスティング枚数を取得
   const isPostingMission = mission.required_artifact_type === "POSTING";
   const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
+  const allUsersPostingCount = await getAllUsersPostingCount();
   let badgeText = "";
 
   if (userWithMissionRanking) {
@@ -134,7 +136,8 @@ export default async function MissionPage({ params }: Props) {
                     limit={10}
                     showDetailedInfo={true}
                     mission={mission}
-                    badgeText={badgeText}
+                    isPostingMission={isPostingMission}
+                    allUsersPostingCount={allUsersPostingCount}
                   />
                 </div>
               </>

--- a/app/missions/[id]/page.tsx
+++ b/app/missions/[id]/page.tsx
@@ -91,9 +91,18 @@ export default async function MissionPage({ params }: Props) {
     ? await getUserMissionRanking(id, user.id)
     : null;
 
-  // ポスティングミッションの場合は、ポスティング枚数を取得
-  const postingMission = mission.required_artifact_type === "POSTING";
+  // ミッションタイプに応じてbadgeTextを生成、ポスティングミッションの場合はポスティング枚数を取得
+  const isPostingMission = mission.required_artifact_type === "POSTING";
   const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
+  let badgeText = "";
+
+  if (userWithMissionRanking) {
+    if (isPostingMission) {
+      badgeText = `${userPostingCount.toLocaleString()}枚`;
+    } else {
+      badgeText = `${(userWithMissionRanking.user_achievement_count ?? 0).toLocaleString()}回`;
+    }
+  }
 
   return (
     <div className="container mx-auto max-w-4xl p-4">
@@ -117,8 +126,7 @@ export default async function MissionPage({ params }: Props) {
                   <CurrentUserCardMission
                     currentUser={userWithMissionRanking}
                     mission={mission}
-                    userPostingCount={userPostingCount}
-                    postingMission={postingMission}
+                    badgeText={badgeText}
                   />
                 </div>
                 <div className="mt-6">
@@ -126,8 +134,7 @@ export default async function MissionPage({ params }: Props) {
                     limit={10}
                     showDetailedInfo={true}
                     mission={mission}
-                    userPostingCount={userPostingCount}
-                    postingMission={postingMission}
+                    badgeText={badgeText}
                   />
                 </div>
               </>

--- a/app/missions/[id]/page.tsx
+++ b/app/missions/[id]/page.tsx
@@ -15,7 +15,10 @@ import {
   defaultUrl,
   notoSansJP,
 } from "@/lib/metadata";
-import { getUserMissionRanking } from "@/lib/services/missionsRanking";
+import {
+  getUserMissionRanking,
+  getUserPostingCount,
+} from "@/lib/services/missionsRanking";
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { LogIn, Shield } from "lucide-react";
 import type { Metadata } from "next";
@@ -88,6 +91,11 @@ export default async function MissionPage({ params }: Props) {
     ? await getUserMissionRanking(id, user.id)
     : null;
 
+  // ポスティングミッションの場合は、ポスティング枚数を取得
+  const postingMission =
+    mission.title === "チームみらいの機関誌をポスティングしよう";
+  const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
+
   return (
     <div className="container mx-auto max-w-4xl p-4">
       <div className="flex flex-col gap-6 max-w-lg mx-auto">
@@ -110,6 +118,8 @@ export default async function MissionPage({ params }: Props) {
                   <CurrentUserCardMission
                     currentUser={userWithMissionRanking}
                     mission={mission}
+                    userPostingCount={userPostingCount}
+                    postingMission={postingMission}
                   />
                 </div>
                 <div className="mt-6">
@@ -117,6 +127,8 @@ export default async function MissionPage({ params }: Props) {
                     limit={10}
                     showDetailedInfo={true}
                     mission={mission}
+                    userPostingCount={userPostingCount}
+                    postingMission={postingMission}
                   />
                 </div>
               </>

--- a/app/missions/[id]/page.tsx
+++ b/app/missions/[id]/page.tsx
@@ -92,8 +92,7 @@ export default async function MissionPage({ params }: Props) {
     : null;
 
   // ポスティングミッションの場合は、ポスティング枚数を取得
-  const postingMission =
-    mission.title === "チームみらいの機関誌をポスティングしよう";
+  const postingMission = mission.required_artifact_type === "POSTING";
   const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
 
   return (

--- a/app/missions/[id]/page.tsx
+++ b/app/missions/[id]/page.tsx
@@ -16,7 +16,6 @@ import {
   notoSansJP,
 } from "@/lib/metadata";
 import {
-  getAllUsersPostingCount,
   getUserMissionRanking,
   getUserPostingCount,
 } from "@/lib/services/missionsRanking";
@@ -95,7 +94,6 @@ export default async function MissionPage({ params }: Props) {
   // ミッションタイプに応じてbadgeTextを生成、ポスティングミッションの場合はポスティング枚数を取得
   const isPostingMission = mission.required_artifact_type === "POSTING";
   const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
-  const allUsersPostingCount = await getAllUsersPostingCount();
   let badgeText = "";
 
   if (userWithMissionRanking) {
@@ -137,7 +135,6 @@ export default async function MissionPage({ params }: Props) {
                     showDetailedInfo={true}
                     mission={mission}
                     isPostingMission={isPostingMission}
-                    allUsersPostingCount={allUsersPostingCount}
                   />
                 </div>
               </>

--- a/app/ranking/ranking-mission/page.tsx
+++ b/app/ranking/ranking-mission/page.tsx
@@ -33,8 +33,8 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
     .order("difficulty", { ascending: true }); // その後、難易度の昇順でソート
 
   const postingMission =
-    missions?.find((m) => m.id === resolvedSearchParams.missionId)?.title ===
-    "チームみらいの機関誌をポスティングしよう";
+    missions?.find((m) => m.id === resolvedSearchParams.missionId)
+      ?.required_artifact_type === "POSTING";
   const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
 
   // エラーハンドリング

--- a/app/ranking/ranking-mission/page.tsx
+++ b/app/ranking/ranking-mission/page.tsx
@@ -2,7 +2,10 @@ import { CurrentUserCardMission } from "@/components/ranking/current-user-card-m
 import { MissionSelect } from "@/components/ranking/mission-select";
 import RankingMission from "@/components/ranking/ranking-mission";
 import { RankingTabs } from "@/components/ranking/ranking-tabs";
-import { getUserMissionRanking } from "@/lib/services/missionsRanking";
+import {
+  getUserMissionRanking,
+  getUserPostingCount,
+} from "@/lib/services/missionsRanking";
 import { createClient } from "@/lib/supabase/server";
 
 interface PageProps {
@@ -28,6 +31,11 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
     .is("max_achievement_count", null)
     .order("is_featured", { ascending: false }) // is_featuredがtrueのものを先頭に
     .order("difficulty", { ascending: true }); // その後、難易度の昇順でソート
+
+  const postingMission =
+    missions?.find((m) => m.id === resolvedSearchParams.missionId)?.title ===
+    "チームみらいの機関誌をポスティングしよう";
+  const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
 
   // エラーハンドリング
   if (missionsError) {
@@ -81,13 +89,20 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
             <CurrentUserCardMission
               currentUser={userRanking}
               mission={selectedMission}
+              userPostingCount={userPostingCount}
+              postingMission={postingMission}
             />
           </section>
         )}
 
         <section className="py-4 bg-white">
           {/* ミッション別ランキング */}
-          <RankingMission limit={100} mission={selectedMission} />
+          <RankingMission
+            limit={100}
+            mission={selectedMission}
+            userPostingCount={userPostingCount}
+            postingMission={postingMission}
+          />
         </section>
       </RankingTabs>
     </div>

--- a/app/ranking/ranking-mission/page.tsx
+++ b/app/ranking/ranking-mission/page.tsx
@@ -3,7 +3,6 @@ import { MissionSelect } from "@/components/ranking/mission-select";
 import RankingMission from "@/components/ranking/ranking-mission";
 import { RankingTabs } from "@/components/ranking/ranking-tabs";
 import {
-  getAllUsersPostingCount,
   getUserMissionRanking,
   getUserPostingCount,
 } from "@/lib/services/missionsRanking";
@@ -74,7 +73,6 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
   // ミッションタイプに応じてbadgeTextを生成、ポスティングミッションの場合はポスティング枚数を取得
   const isPostingMission = selectedMission.required_artifact_type === "POSTING";
   const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
-  const allUsersPostingCount = await getAllUsersPostingCount();
   let badgeText = "";
 
   if (userRanking) {
@@ -110,7 +108,6 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
             limit={100}
             mission={selectedMission}
             isPostingMission={isPostingMission}
-            allUsersPostingCount={allUsersPostingCount}
           />
         </section>
       </RankingTabs>

--- a/app/ranking/ranking-mission/page.tsx
+++ b/app/ranking/ranking-mission/page.tsx
@@ -32,11 +32,6 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
     .order("is_featured", { ascending: false }) // is_featuredがtrueのものを先頭に
     .order("difficulty", { ascending: true }); // その後、難易度の昇順でソート
 
-  const postingMission =
-    missions?.find((m) => m.id === resolvedSearchParams.missionId)
-      ?.required_artifact_type === "POSTING";
-  const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
-
   // エラーハンドリング
   if (missionsError) {
     console.error("ミッション取得エラー:", missionsError);
@@ -75,6 +70,19 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
     userRanking = await getUserMissionRanking(selectedMission.id, user.id);
   }
 
+  // ミッションタイプに応じてbadgeTextを生成、ポスティングミッションの場合はポスティング枚数を取得
+  const isPostingMission = selectedMission.required_artifact_type === "POSTING";
+  const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
+  let badgeText = "";
+
+  if (userRanking) {
+    if (isPostingMission) {
+      badgeText = `${userPostingCount.toLocaleString()}枚`;
+    } else {
+      badgeText = `${(userRanking.user_achievement_count ?? 0).toLocaleString()}回`;
+    }
+  }
+
   return (
     <div className="flex flex-col min-h-screen py-4 w-full">
       <RankingTabs>
@@ -89,8 +97,7 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
             <CurrentUserCardMission
               currentUser={userRanking}
               mission={selectedMission}
-              userPostingCount={userPostingCount}
-              postingMission={postingMission}
+              badgeText={badgeText}
             />
           </section>
         )}
@@ -100,8 +107,7 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
           <RankingMission
             limit={100}
             mission={selectedMission}
-            userPostingCount={userPostingCount}
-            postingMission={postingMission}
+            badgeText={badgeText}
           />
         </section>
       </RankingTabs>

--- a/app/ranking/ranking-mission/page.tsx
+++ b/app/ranking/ranking-mission/page.tsx
@@ -3,6 +3,7 @@ import { MissionSelect } from "@/components/ranking/mission-select";
 import RankingMission from "@/components/ranking/ranking-mission";
 import { RankingTabs } from "@/components/ranking/ranking-tabs";
 import {
+  getAllUsersPostingCount,
   getUserMissionRanking,
   getUserPostingCount,
 } from "@/lib/services/missionsRanking";
@@ -73,6 +74,7 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
   // ミッションタイプに応じてbadgeTextを生成、ポスティングミッションの場合はポスティング枚数を取得
   const isPostingMission = selectedMission.required_artifact_type === "POSTING";
   const userPostingCount = user ? await getUserPostingCount(user.id) : 0;
+  const allUsersPostingCount = await getAllUsersPostingCount();
   let badgeText = "";
 
   if (userRanking) {
@@ -107,7 +109,8 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
           <RankingMission
             limit={100}
             mission={selectedMission}
-            badgeText={badgeText}
+            isPostingMission={isPostingMission}
+            allUsersPostingCount={allUsersPostingCount}
           />
         </section>
       </RankingTabs>

--- a/components/ranking/current-user-card-mission.tsx
+++ b/components/ranking/current-user-card-mission.tsx
@@ -11,11 +11,15 @@ import { Badge } from "../ui/badge";
 interface CurrentUserCardProps {
   currentUser: UserMissionRanking | null;
   mission: Tables<"missions">;
+  userPostingCount?: number;
+  postingMission?: boolean;
 }
 
 export const CurrentUserCardMission: React.FC<CurrentUserCardProps> = ({
   currentUser,
   mission,
+  userPostingCount,
+  postingMission,
 }) => {
   if (!currentUser) {
     return null;
@@ -26,6 +30,7 @@ export const CurrentUserCardMission: React.FC<CurrentUserCardProps> = ({
     name: formatUserDisplayName(currentUser.name),
     address_prefecture: formatUserPrefecture(currentUser.address_prefecture),
   };
+
   return (
     <div className="max-w-6xl mx-auto">
       <Card className="border-teal-200 bg-teal-50">
@@ -56,7 +61,11 @@ export const CurrentUserCardMission: React.FC<CurrentUserCardProps> = ({
                   "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"
                 }
               >
-                {(displayUser?.user_achievement_count ?? 0).toLocaleString()}回
+                {(postingMission
+                  ? (userPostingCount ?? 0)
+                  : (displayUser?.user_achievement_count ?? 0)
+                ).toLocaleString()}
+                {postingMission ? "枚" : "回"}
               </Badge>
               <span className="font-bold text-lg">
                 {(displayUser.total_points ?? 0).toLocaleString()}pt

--- a/components/ranking/current-user-card-mission.tsx
+++ b/components/ranking/current-user-card-mission.tsx
@@ -11,15 +11,13 @@ import { Badge } from "../ui/badge";
 interface CurrentUserCardProps {
   currentUser: UserMissionRanking | null;
   mission: Tables<"missions">;
-  userPostingCount?: number;
-  postingMission?: boolean;
+  badgeText: string;
 }
 
 export const CurrentUserCardMission: React.FC<CurrentUserCardProps> = ({
   currentUser,
   mission,
-  userPostingCount,
-  postingMission,
+  badgeText,
 }) => {
   if (!currentUser) {
     return null;
@@ -61,11 +59,7 @@ export const CurrentUserCardMission: React.FC<CurrentUserCardProps> = ({
                   "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"
                 }
               >
-                {(postingMission
-                  ? (userPostingCount ?? 0)
-                  : (displayUser?.user_achievement_count ?? 0)
-                ).toLocaleString()}
-                {postingMission ? "枚" : "回"}
+                {badgeText}
               </Badge>
               <span className="font-bold text-lg">
                 {(displayUser.total_points ?? 0).toLocaleString()}pt

--- a/components/ranking/ranking-item.tsx
+++ b/components/ranking/ranking-item.tsx
@@ -13,7 +13,8 @@ interface RankingItemProps {
     id: string;
     name: string;
   };
-  badgeText?: string;
+  isPostingMission?: boolean;
+  allUsersPostingCount?: Array<{ user_id: string; posting_count: number }>;
 }
 
 function getRankIcon(rank: number | null) {
@@ -50,7 +51,8 @@ export function RankingItem({
   userWithMission,
   showDetailedInfo = false,
   mission,
-  badgeText,
+  isPostingMission,
+  allUsersPostingCount,
 }: RankingItemProps) {
   return (
     <Link
@@ -76,7 +78,15 @@ export function RankingItem({
                 "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"
               }
             >
-              {badgeText}
+              {/* ポスティングミッションの場合はポスティング枚数を表示 */}
+              {isPostingMission
+                ? `${allUsersPostingCount
+                    ?.find(
+                      (postingUser) =>
+                        postingUser.user_id === userWithMission?.user_id,
+                    )
+                    ?.posting_count?.toLocaleString()}枚`
+                : `${(userWithMission?.user_achievement_count ?? 0).toLocaleString()}回`}
             </Badge>
             <span className="font-bold text-lg">
               {(userWithMission?.total_points ?? 0).toLocaleString()}pt

--- a/components/ranking/ranking-item.tsx
+++ b/components/ranking/ranking-item.tsx
@@ -13,6 +13,8 @@ interface RankingItemProps {
     id: string;
     name: string;
   };
+  userPostingCount?: number;
+  postingMission?: boolean;
 }
 
 function getRankIcon(rank: number | null) {
@@ -49,6 +51,8 @@ export function RankingItem({
   userWithMission,
   showDetailedInfo = false,
   mission,
+  userPostingCount,
+  postingMission,
 }: RankingItemProps) {
   return (
     <Link
@@ -74,8 +78,12 @@ export function RankingItem({
                 "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"
               }
             >
-              {(userWithMission?.user_achievement_count ?? 0).toLocaleString()}
-              回
+              {/* ポスティングミッションの場合はポスティング枚数を表示 */}
+              {(postingMission
+                ? (userPostingCount ?? 0)
+                : (userWithMission?.user_achievement_count ?? 0)
+              ).toLocaleString()}
+              {postingMission ? "枚" : "回"}
             </Badge>
             <span className="font-bold text-lg">
               {(userWithMission?.total_points ?? 0).toLocaleString()}pt

--- a/components/ranking/ranking-item.tsx
+++ b/components/ranking/ranking-item.tsx
@@ -1,7 +1,6 @@
 // TOPページ用のランキングコンポーネント
 import { Badge } from "@/components/ui/badge";
 import type { UserMissionRanking } from "@/lib/services/missionsRanking";
-import { getTopUsersPostingCount } from "@/lib/services/missionsRanking";
 import type { UserRanking } from "@/lib/services/ranking";
 import { Crown, Medal, Trophy } from "lucide-react";
 import Link from "next/link";
@@ -14,8 +13,7 @@ interface RankingItemProps {
     id: string;
     name: string;
   };
-  isPostingMission?: boolean;
-  allUsersPostingCount?: Array<{ user_id: string; posting_count: number }>;
+  badgeText?: string;
 }
 
 function getRankIcon(rank: number | null) {
@@ -47,19 +45,13 @@ function getLevelBadgeColor(level: number | null) {
   return "text-emerald-700 bg-emerald-100";
 }
 
-export async function RankingItem({
+export function RankingItem({
   user,
   userWithMission,
   showDetailedInfo = false,
   mission,
-  isPostingMission,
+  badgeText,
 }: RankingItemProps) {
-  // isPostingMissionがtrueの場合のみgetTopUsersPostingCountを呼び出す
-  const userIds = userWithMission?.user_id ? [userWithMission.user_id] : [];
-  const topUsersPostingCount = isPostingMission
-    ? await getTopUsersPostingCount(userIds)
-    : [];
-
   return (
     <Link
       href={`/users/${user.user_id}`}
@@ -84,12 +76,7 @@ export async function RankingItem({
                 "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"
               }
             >
-              {/* ポスティングミッションの場合はポスティング枚数を表示 */}
-              {isPostingMission
-                ? `${topUsersPostingCount
-                    .find((user) => user.user_id === userWithMission?.user_id)
-                    ?.posting_count?.toLocaleString()}枚`
-                : `${(userWithMission?.user_achievement_count ?? 0).toLocaleString()}回`}
+              {badgeText}
             </Badge>
             <span className="font-bold text-lg">
               {(userWithMission?.total_points ?? 0).toLocaleString()}pt

--- a/components/ranking/ranking-item.tsx
+++ b/components/ranking/ranking-item.tsx
@@ -1,6 +1,7 @@
 // TOPページ用のランキングコンポーネント
 import { Badge } from "@/components/ui/badge";
 import type { UserMissionRanking } from "@/lib/services/missionsRanking";
+import { getTopUsersPostingCount } from "@/lib/services/missionsRanking";
 import type { UserRanking } from "@/lib/services/ranking";
 import { Crown, Medal, Trophy } from "lucide-react";
 import Link from "next/link";
@@ -46,14 +47,19 @@ function getLevelBadgeColor(level: number | null) {
   return "text-emerald-700 bg-emerald-100";
 }
 
-export function RankingItem({
+export async function RankingItem({
   user,
   userWithMission,
   showDetailedInfo = false,
   mission,
   isPostingMission,
-  allUsersPostingCount,
 }: RankingItemProps) {
+  // isPostingMissionがtrueの場合のみgetTopUsersPostingCountを呼び出す
+  const userIds = userWithMission?.user_id ? [userWithMission.user_id] : [];
+  const topUsersPostingCount = isPostingMission
+    ? await getTopUsersPostingCount(userIds)
+    : [];
+
   return (
     <Link
       href={`/users/${user.user_id}`}
@@ -80,11 +86,8 @@ export function RankingItem({
             >
               {/* ポスティングミッションの場合はポスティング枚数を表示 */}
               {isPostingMission
-                ? `${allUsersPostingCount
-                    ?.find(
-                      (postingUser) =>
-                        postingUser.user_id === userWithMission?.user_id,
-                    )
+                ? `${topUsersPostingCount
+                    .find((user) => user.user_id === userWithMission?.user_id)
                     ?.posting_count?.toLocaleString()}枚`
                 : `${(userWithMission?.user_achievement_count ?? 0).toLocaleString()}回`}
             </Badge>

--- a/components/ranking/ranking-item.tsx
+++ b/components/ranking/ranking-item.tsx
@@ -13,8 +13,7 @@ interface RankingItemProps {
     id: string;
     name: string;
   };
-  userPostingCount?: number;
-  postingMission?: boolean;
+  badgeText?: string;
 }
 
 function getRankIcon(rank: number | null) {
@@ -51,8 +50,7 @@ export function RankingItem({
   userWithMission,
   showDetailedInfo = false,
   mission,
-  userPostingCount,
-  postingMission,
+  badgeText,
 }: RankingItemProps) {
   return (
     <Link
@@ -78,12 +76,7 @@ export function RankingItem({
                 "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"
               }
             >
-              {/* ポスティングミッションの場合はポスティング枚数を表示 */}
-              {(postingMission
-                ? (userPostingCount ?? 0)
-                : (userWithMission?.user_achievement_count ?? 0)
-              ).toLocaleString()}
-              {postingMission ? "枚" : "回"}
+              {badgeText}
             </Badge>
             <span className="font-bold text-lg">
               {(userWithMission?.total_points ?? 0).toLocaleString()}pt

--- a/components/ranking/ranking-mission.tsx
+++ b/components/ranking/ranking-mission.tsx
@@ -10,12 +10,16 @@ interface RankingTopProps {
   limit?: number;
   showDetailedInfo?: boolean; // 詳細情報を表示するかどうか
   mission?: Tables<"missions">;
+  userPostingCount?: number;
+  postingMission?: boolean;
 }
 
 export default async function RankingMission({
   mission,
   limit = 10,
   showDetailedInfo = false,
+  userPostingCount,
+  postingMission,
 }: RankingTopProps) {
   if (!mission) {
     return null;
@@ -42,6 +46,8 @@ export default async function RankingMission({
                 mission={
                   mission ? { id: mission.id, name: mission.title } : undefined
                 }
+                userPostingCount={userPostingCount}
+                postingMission={postingMission}
               />
             ))}
           </div>

--- a/components/ranking/ranking-mission.tsx
+++ b/components/ranking/ranking-mission.tsx
@@ -10,16 +10,14 @@ interface RankingTopProps {
   limit?: number;
   showDetailedInfo?: boolean; // 詳細情報を表示するかどうか
   mission?: Tables<"missions">;
-  userPostingCount?: number;
-  postingMission?: boolean;
+  badgeText: string;
 }
 
 export default async function RankingMission({
   mission,
   limit = 10,
   showDetailedInfo = false,
-  userPostingCount,
-  postingMission,
+  badgeText,
 }: RankingTopProps) {
   if (!mission) {
     return null;
@@ -46,8 +44,7 @@ export default async function RankingMission({
                 mission={
                   mission ? { id: mission.id, name: mission.title } : undefined
                 }
-                userPostingCount={userPostingCount}
-                postingMission={postingMission}
+                badgeText={badgeText}
               />
             ))}
           </div>

--- a/components/ranking/ranking-mission.tsx
+++ b/components/ranking/ranking-mission.tsx
@@ -11,7 +11,6 @@ interface RankingTopProps {
   showDetailedInfo?: boolean; // 詳細情報を表示するかどうか
   mission?: Tables<"missions">;
   isPostingMission?: boolean;
-  allUsersPostingCount?: Array<{ user_id: string; posting_count: number }>;
 }
 
 export default async function RankingMission({
@@ -19,7 +18,6 @@ export default async function RankingMission({
   limit = 10,
   showDetailedInfo = false,
   isPostingMission,
-  allUsersPostingCount,
 }: RankingTopProps) {
   if (!mission) {
     return null;
@@ -47,7 +45,6 @@ export default async function RankingMission({
                   mission ? { id: mission.id, name: mission.title } : undefined
                 }
                 isPostingMission={isPostingMission}
-                allUsersPostingCount={allUsersPostingCount}
               />
             ))}
           </div>

--- a/components/ranking/ranking-mission.tsx
+++ b/components/ranking/ranking-mission.tsx
@@ -10,14 +10,16 @@ interface RankingTopProps {
   limit?: number;
   showDetailedInfo?: boolean; // 詳細情報を表示するかどうか
   mission?: Tables<"missions">;
-  badgeText: string;
+  isPostingMission?: boolean;
+  allUsersPostingCount?: Array<{ user_id: string; posting_count: number }>;
 }
 
 export default async function RankingMission({
   mission,
   limit = 10,
   showDetailedInfo = false,
-  badgeText,
+  isPostingMission,
+  allUsersPostingCount,
 }: RankingTopProps) {
   if (!mission) {
     return null;
@@ -44,7 +46,8 @@ export default async function RankingMission({
                 mission={
                   mission ? { id: mission.id, name: mission.title } : undefined
                 }
-                badgeText={badgeText}
+                isPostingMission={isPostingMission}
+                allUsersPostingCount={allUsersPostingCount}
               />
             ))}
           </div>

--- a/components/ranking/ranking-mission.tsx
+++ b/components/ranking/ranking-mission.tsx
@@ -1,6 +1,9 @@
 // TOPページ用のランキングコンポーネント
 import { Card } from "@/components/ui/card";
-import { getMissionRanking } from "@/lib/services/missionsRanking";
+import {
+  getMissionRanking,
+  getTopUsersPostingCount,
+} from "@/lib/services/missionsRanking";
 import type { Tables } from "@/lib/types/supabase";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
@@ -25,6 +28,27 @@ export default async function RankingMission({
 
   const rankings = await getMissionRanking(mission.id, limit);
 
+  // ポスティングミッションの場合のみ、上位ユーザーの投稿数を取得
+  const topUsersPostingCount =
+    isPostingMission && rankings.length > 0
+      ? await getTopUsersPostingCount(
+          rankings.map((user) => user.user_id ?? ""),
+        )
+      : [];
+
+  // バッジテキストの生成
+  let badgeText = "";
+  if (rankings.length > 0) {
+    if (isPostingMission) {
+      const topUserPostingCount = topUsersPostingCount.find(
+        (user) => user.user_id === rankings[0].user_id,
+      );
+      badgeText = `${(topUserPostingCount?.posting_count ?? 0).toLocaleString()}枚`;
+    } else {
+      badgeText = `${(rankings[0].user_achievement_count ?? 0).toLocaleString()}回`;
+    }
+  }
+
   return (
     <div className="max-w-6xl mx-auto">
       <div className="flex flex-col gap-6">
@@ -44,7 +68,7 @@ export default async function RankingMission({
                 mission={
                   mission ? { id: mission.id, name: mission.title } : undefined
                 }
-                isPostingMission={isPostingMission}
+                badgeText={badgeText}
               />
             ))}
           </div>

--- a/lib/services/missionsRanking.ts
+++ b/lib/services/missionsRanking.ts
@@ -117,19 +117,21 @@ export async function getUserPostingCount(userId: string): Promise<number> {
   return typeof data === "number" ? data : 0;
 }
 
-export async function getAllUsersPostingCount(): Promise<
-  Array<{ user_id: string; posting_count: number }>
-> {
+export async function getTopUsersPostingCount(
+  userIds: string[],
+): Promise<{ user_id: string; posting_count: number }[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase.rpc("get_all_users_posting_count");
+  const { data, error } = await supabase.rpc("get_top_users_posting_count", {
+    user_ids: userIds,
+  });
 
   if (error) {
-    console.error("Failed to fetch all users posting count:", error);
+    console.error("Failed to fetch users posting count:", error);
     throw new Error(
-      `全ユーザーのポスティング枚数取得に失敗しました: ${error.message}`,
+      `ユーザーのポスティング枚数取得に失敗しました: ${error.message}`,
     );
   }
 
   // dataがnullやundefinedの場合は空配列を返す
-  return (data as Array<{ user_id: string; posting_count: number }>) || [];
+  return (data as { user_id: string; posting_count: number }[]) || [];
 }

--- a/lib/services/missionsRanking.ts
+++ b/lib/services/missionsRanking.ts
@@ -116,3 +116,20 @@ export async function getUserPostingCount(userId: string): Promise<number> {
   // dataがnullやundefinedの場合は0を返す
   return typeof data === "number" ? data : 0;
 }
+
+export async function getAllUsersPostingCount(): Promise<
+  Array<{ user_id: string; posting_count: number }>
+> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc("get_all_users_posting_count");
+
+  if (error) {
+    console.error("Failed to fetch all users posting count:", error);
+    throw new Error(
+      `全ユーザーのポスティング枚数取得に失敗しました: ${error.message}`,
+    );
+  }
+
+  // dataがnullやundefinedの場合は空配列を返す
+  return (data as Array<{ user_id: string; posting_count: number }>) || [];
+}

--- a/lib/services/missionsRanking.ts
+++ b/lib/services/missionsRanking.ts
@@ -99,3 +99,20 @@ export async function getUserMissionRanking(
     throw error;
   }
 }
+
+export async function getUserPostingCount(userId: string): Promise<number> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc("get_user_posting_count", {
+    target_user_id: userId,
+  });
+
+  if (error) {
+    console.error("Failed to fetch user posting count:", error);
+    throw new Error(
+      `ポスティング活動枚数の取得に失敗しました: ${error.message}`,
+    );
+  }
+
+  // dataがnullやundefinedの場合は0を返す
+  return typeof data === "number" ? data : 0;
+}

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -580,6 +580,13 @@ export type Database = {
       };
     };
     Functions: {
+      get_all_users_posting_count: {
+        Args: Record<PropertyKey, never>;
+        Returns: {
+          user_id: string;
+          posting_count: number;
+        }[];
+      };
       get_mission_ranking: {
         Args: { mission_id: string; limit_count?: number };
         Returns: {

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -580,13 +580,6 @@ export type Database = {
       };
     };
     Functions: {
-      get_all_users_posting_count: {
-        Args: Record<PropertyKey, never>;
-        Returns: {
-          user_id: string;
-          posting_count: number;
-        }[];
-      };
       get_mission_ranking: {
         Args: { mission_id: string; limit_count?: number };
         Returns: {
@@ -611,6 +604,13 @@ export type Database = {
           level: number;
           xp: number;
           updated_at: string;
+        }[];
+      };
+      get_top_users_posting_count: {
+        Args: { user_ids: string[] };
+        Returns: {
+          user_id: string;
+          posting_count: number;
         }[];
       };
       get_user_by_email: {

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -606,6 +606,14 @@ export type Database = {
           updated_at: string;
         }[];
       };
+      get_user_by_email: {
+        Args: { user_email: string };
+        Returns: {
+          id: string;
+          email: string;
+          user_metadata: Json;
+        }[];
+      };
       get_user_mission_ranking: {
         Args: { mission_id: string; user_id: string };
         Returns: {
@@ -619,6 +627,10 @@ export type Database = {
           total_points: number;
           rank: number;
         }[];
+      };
+      get_user_posting_count: {
+        Args: { target_user_id: string };
+        Returns: number;
       };
       get_user_prefecture_ranking: {
         Args: { prefecture: string; target_user_id: string };

--- a/supabase/migrations/20250620074305_add_get_user_posting_count.sql
+++ b/supabase/migrations/20250620074305_add_get_user_posting_count.sql
@@ -1,0 +1,19 @@
+-- ポスティング枚数合計を取得するRPC関数
+CREATE OR REPLACE FUNCTION public.get_user_posting_count(target_user_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  total_count INTEGER := 0;
+BEGIN
+  SELECT COALESCE(SUM(pa.posting_count), 0)
+    INTO total_count
+    FROM posting_activities pa
+    JOIN mission_artifacts ma ON pa.mission_artifact_id = ma.id
+    WHERE ma.user_id = target_user_id;
+  RETURN total_count;
+END;
+$$;
+
+-- ダウングレード用: 関数削除
+-- DROP FUNCTION IF EXISTS public.get_user_posting_count(UUID);

--- a/supabase/migrations/20250621110502_add_get_all_user_posting_count.sql
+++ b/supabase/migrations/20250621110502_add_get_all_user_posting_count.sql
@@ -1,0 +1,20 @@
+-- 全てのユーザーのポスティング枚数合計を取得するRPC関数
+CREATE OR REPLACE FUNCTION public.get_all_users_posting_count()
+RETURNS TABLE(user_id UUID, posting_count BIGINT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    ma.user_id,
+    COALESCE(SUM(pa.posting_count), 0) as posting_count
+  FROM mission_artifacts ma
+  LEFT JOIN posting_activities pa ON ma.id = pa.mission_artifact_id
+  GROUP BY ma.user_id
+  ORDER BY posting_count DESC;
+END;
+$$;
+
+-- ダウングレード用: 関数削除
+-- DROP FUNCTION IF EXISTS public.get_all_users_posting_count();

--- a/supabase/migrations/20250621110502_add_get_all_user_posting_count.sql
+++ b/supabase/migrations/20250621110502_add_get_all_user_posting_count.sql
@@ -12,6 +12,7 @@ BEGIN
   FROM mission_artifacts ma
   LEFT JOIN posting_activities pa ON ma.id = pa.mission_artifact_id
   GROUP BY ma.user_id
+  HAVING COALESCE(SUM(pa.posting_count), 0) > 1
   ORDER BY posting_count DESC;
 END;
 $$;

--- a/supabase/migrations/20250621110502_add_get_top_users_posting_count.sql
+++ b/supabase/migrations/20250621110502_add_get_top_users_posting_count.sql
@@ -11,6 +11,7 @@ BEGIN
     COALESCE(SUM(pa.posting_count), 0) as posting_count
   FROM mission_artifacts ma
   LEFT JOIN posting_activities pa ON ma.id = pa.mission_artifact_id
+  WHERE ma.user_id = ANY(user_ids)
   GROUP BY ma.user_id
   HAVING COALESCE(SUM(pa.posting_count), 0) > 1
   ORDER BY posting_count DESC;

--- a/supabase/migrations/20250621110502_add_get_top_users_posting_count.sql
+++ b/supabase/migrations/20250621110502_add_get_top_users_posting_count.sql
@@ -1,5 +1,5 @@
 -- 全てのユーザーのポスティング枚数合計を取得するRPC関数
-CREATE OR REPLACE FUNCTION public.get_all_users_posting_count()
+CREATE OR REPLACE FUNCTION public.get_top_users_posting_count(user_ids UUID[])
 RETURNS TABLE(user_id UUID, posting_count BIGINT)
 LANGUAGE plpgsql
 SECURITY DEFINER


### PR DESCRIPTION
# 変更の概要
- ポスティングミッションのみ、達成回数ではなく、枚数の表示に変更

# 変更の背景
- 動作確認

https://github.com/user-attachments/assets/c158c230-0b7b-47cc-86f1-7974ba9132fd


- closes #557 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ミッションが「投稿型」の場合、ランキングやユーザーカードに「投稿数（枚）」が表示されるようになりました。
  - 通常ミッションの場合は、従来通り「達成回数（回）」が表示されます。

- **改善**
  - ランキング表示がミッションの種類に応じて柔軟に切り替わるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->