### PR TITLE
#474: 過去の達成履歴も削除できるようにしたい

### DIFF
--- a/app/missions/[id]/_components/SubmissionItem.tsx
+++ b/app/missions/[id]/_components/SubmissionItem.tsx
@@ -20,7 +20,7 @@ const SubmissionItem: React.FC<SubmissionItemProps> = ({
   userId,
   onCancelClick,
 }) => {
-  const canCancel = isLatest && userId && submission.user_id === userId;
+  const canCancel = userId && submission.user_id === userId;
 
   return (
     <li className="border p-4 rounded-lg shadow">


### PR DESCRIPTION
# 変更の概要
- ミッションの達成履歴ごとに「取り消す」ボタンを表示し、最新の達成履歴以外も取り消しできるようにしました
- 「取り消す」ボタンの表示条件に、`isLatest`が入っていましたが、それを削除しました

# 変更の背景
- 現状の「取り消す」ボタンだと最新の達成履歴のみ削除されるのか全履歴が削除されるのかわかりづらい
- closes #474 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクショ（３件登録している場合に、真ん中の達成履歴のみ取り消しできるようになった）

![スクリーンショット 2025-06-20 23 08 53](https://github.com/user-attachments/assets/3ee6d5c8-ecb2-4de9-b5c0-3b623c9d084b)
![スクリーンショット 2025-06-20 23 09 07](https://github.com/user-attachments/assets/2fde93a8-fac2-46ed-8530-75f5f360983d)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザー自身の全ての提出物に対してキャンセルボタンが有効になりました。最新の提出物でなくてもキャンセルが可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->