### PR TITLE
「公式YouTubeチャンネルを登録しよう」ミッションのページに登録ボタンを埋め込む

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "source.organizeImports.biome": "explicit"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   },
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "source.organizeImports.biome": "explicit"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"

--- a/app/missions/[id]/_components/YouTubeSubscribeButton.tsx
+++ b/app/missions/[id]/_components/YouTubeSubscribeButton.tsx
@@ -6,6 +6,10 @@ type Props = {
 };
 
 export function YouTubeSubscribeButton({ channelId, className }: Props) {
+  const handleScriptError = () => {
+    console.error("Failed to load YouTube platform script");
+  };
+
   return (
     <div className={className}>
       <div
@@ -13,10 +17,14 @@ export function YouTubeSubscribeButton({ channelId, className }: Props) {
         data-channelid={channelId}
         data-layout="full"
         data-count="default"
+        role="button"
+        aria-label={`YouTube チャンネル ${channelId} を購読`}
+        tabIndex={0}
       />
       <Script
         src="https://apis.google.com/js/platform.js"
         strategy="afterInteractive"
+        onError={handleScriptError}
       />
     </div>
   );

--- a/app/missions/[id]/_components/YouTubeSubscribeButton.tsx
+++ b/app/missions/[id]/_components/YouTubeSubscribeButton.tsx
@@ -1,0 +1,23 @@
+import Script from "next/script";
+
+type Props = {
+  channelId: string;
+  className?: string;
+};
+
+export function YouTubeSubscribeButton({ channelId, className }: Props) {
+  return (
+    <div className={className}>
+      <div
+        className="g-ytsubscribe"
+        data-channelid={channelId}
+        data-layout="full"
+        data-count="default"
+      />
+      <Script
+        src="https://apis.google.com/js/platform.js"
+        strategy="afterInteractive"
+      />
+    </div>
+  );
+}

--- a/components/mission/MissionDetails.tsx
+++ b/components/mission/MissionDetails.tsx
@@ -5,18 +5,13 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DifficultyBadge } from "@/components/ui/difficulty-badge";
 import { MissionIcon } from "@/components/ui/mission-icon";
+import { YOUTUBE_MISSION_CONFIG } from "@/lib/constants";
 import { dateFormatter } from "@/lib/formatter";
 import type { Tables } from "@/lib/types/supabase";
 
 type MissionDetailsProps = {
   mission: Tables<"missions">;
 };
-
-// YouTubeチャンネル登録ミッションID
-const youtubeMissionId = "9071a1eb-e272-43be-9c6b-e08b258a41c3";
-
-// 安野たかひろYouTubeチャンネルID
-const youtubeChannelId = "UCiMwbmcCSMORJ-85XWhStBw";
 
 export function MissionDetails({ mission }: MissionDetailsProps) {
   return (
@@ -50,9 +45,11 @@ export function MissionDetails({ mission }: MissionDetailsProps) {
         />
 
         {/* YouTubeチャンネル登録ミッションの場合のみ、YouTube登録ボタンを表示 */}
-        {mission.id === youtubeMissionId && (
+        {mission.id === YOUTUBE_MISSION_CONFIG.MISSION_ID && (
           <div className="flex justify-center mt-6">
-            <YouTubeSubscribeButton channelId={youtubeChannelId} />
+            <YouTubeSubscribeButton
+              channelId={YOUTUBE_MISSION_CONFIG.CHANNEL_ID}
+            />
           </div>
         )}
       </CardContent>

--- a/components/mission/MissionDetails.tsx
+++ b/components/mission/MissionDetails.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { YouTubeSubscribeButton } from "@/app/missions/[id]/_components/YouTubeSubscribeButton";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DifficultyBadge } from "@/components/ui/difficulty-badge";
@@ -10,6 +11,12 @@ import type { Tables } from "@/lib/types/supabase";
 type MissionDetailsProps = {
   mission: Tables<"missions">;
 };
+
+// YouTubeチャンネル登録ミッションID
+const youtubeMissionId = "9071a1eb-e272-43be-9c6b-e08b258a41c3";
+
+// 安野たかひろYouTubeチャンネルID
+const youtubeChannelId = "UCiMwbmcCSMORJ-85XWhStBw";
 
 export function MissionDetails({ mission }: MissionDetailsProps) {
   return (
@@ -41,6 +48,13 @@ export function MissionDetails({ mission }: MissionDetailsProps) {
             }
           }}
         />
+
+        {/* YouTubeチャンネル登録ミッションの場合のみ、YouTube登録ボタンを表示 */}
+        {mission.id === youtubeMissionId && (
+          <div className="flex justify-center mt-6">
+            <YouTubeSubscribeButton channelId={youtubeChannelId} />
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,2 +1,10 @@
 // ポスティングミッションで1枚のポスティングで付与するポイント
 export const POSTING_POINTS_PER_UNIT = 10;
+
+// YouTubeチャンネル登録ミッションの設定
+export const YOUTUBE_MISSION_CONFIG = {
+  // YouTubeチャンネル登録ミッションID
+  MISSION_ID: "9071a1eb-e272-43be-9c6b-e08b258a41c3",
+  // 安野たかひろYouTubeチャンネルID
+  CHANNEL_ID: "UCiMwbmcCSMORJ-85XWhStBw",
+} as const;


### PR DESCRIPTION
# 変更の概要
- 「公式YouTubeチャンネルを登録しよう」ミッションのページに登録ボタンを埋め込みました。
- issue にあった「できれば登録と同時に達成にさせたい」については、下記理由から実装しておりません。
  - チャンネル登録イベントを JavaScript で検知する方法はないため、チャンネル登録を検知したらミッションも完了とする実装ができない
  - YouTube 公式の埋め込みボタンではなく、こちらで用意したボタンから「ミッション達成報告」「チャンネル登録ページへの遷移」を同時に行うことも可能かもしれませんが、下記の理由でやや微妙に感じました:
    - チャンネル登録しなくても達成報告ができてしまう
    - 時系列が「達成報告→登録」の順になりそうなので、登録したことで達成できた感が薄くなる

# 変更の背景
- closes #516

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクリーンショット
<img width="491" alt="スクリーンショット 2025-06-21 0 03 47" src="https://github.com/user-attachments/assets/acc903df-fd22-4157-a788-d8dc81d7dc3b" />

# ボタンオプションの選定について
ボタンは下記のように「シンプルにする」「チャンネル登録者数を隠す」こともできます。
いずれも隠す必要はないと判断して上記スクリーンショットのボタンを採用しました。
<img width="135" alt="スクリーンショット 2025-06-21 0 16 04" src="https://github.com/user-attachments/assets/5e9cd121-fdb2-4e28-b82f-ffec9fe63819" />
<img width="340" alt="スクリーンショット 2025-06-21 0 16 14" src="https://github.com/user-attachments/assets/f0d6f4d1-28ce-4374-800a-021e9c1e7024" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 特定のミッション詳細ページにYouTubeチャンネルの「チャンネル登録」ボタンを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->