### PR TITLE
ミッション達成のOGP画像を表示するロジックの修正

### DIFF
--- a/app/missions/[id]/_components/MissionCompleteDialog.tsx
+++ b/app/missions/[id]/_components/MissionCompleteDialog.tsx
@@ -42,9 +42,14 @@ export function MissionCompleteDialog({ isOpen, onClose, mission }: Props) {
           <DialogDescription className="text-center">
             {message}
           </DialogDescription>
-          {mission.ogp_image_url && (
-            <img src={mission.ogp_image_url} alt="ミッションクリア" />
-          )}
+          <img
+            src={
+              mission.ogp_image_url
+                ? mission.ogp_image_url
+                : `/api/missions/${mission.id}/og?type=complete`
+            }
+            alt="ミッションクリア"
+          />
         </DialogHeader>
 
         <div className="flex flex-col gap-3 py-4">


### PR DESCRIPTION
# 変更の概要
- https://github.com/team-mirai-volunteer/action-board/pull/534 で動的生成するようになったが、表示側のロジックでは、DB の ogp_image_url  を使っている状態だった
https://github.com/team-mirai-volunteer/action-board/blob/081248ccae2f5fc98c38f0ed598c254016a53b8e/app/missions/%5Bid%5D/_components/MissionCompleteDialog.tsx#L45-L47
- 参考：ogp_image_url を削除した場合の表示
  - ![スクリーンショット 2025-06-21 15 39 28](https://github.com/user-attachments/assets/270f2720-21e9-45ae-9c2a-a0de27de9b11)
- missions テーブルの ogp_image_url が null の場合には動的生成するというロジックに修正した
  - 生成する場合は、少し時間がかかるため、ogp_image_url がある場合はそれを使うようにしている
- 参考：修正後は ogp_image_url がなくても OPG 画像が表示される
- ![スクリーンショット 2025-06-21 15 44 19](https://github.com/user-attachments/assets/276e8abd-b5d9-48ef-a605-ca28c611a0eb)


# 変更の背景
- missions テーブルの ogp_image_url が null の場合、OGP 画像が表示されない
- closes なし

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ミッションクリア時の画像が常に表示されるようになりました。指定された画像がない場合は自動生成された画像が表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->