### PR TITLE
hotfix: スマホでのLINEログイン認証状態エラーを修正

### DIFF
--- a/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
@@ -212,8 +212,8 @@ function LoginSelectionPhase({
     try {
       setIsLoading(true);
       setError(null);
-      // sessionStorageにサインアップデータを保存
-      sessionStorage.setItem(
+      // ローカルストレージにサインアップデータを保存（モバイル対応）
+      localStorage.setItem(
         "lineLoginData",
         JSON.stringify({
           dateOfBirth: formattedDate,

--- a/app/auth/line-callback/page.tsx
+++ b/app/auth/line-callback/page.tsx
@@ -58,7 +58,7 @@ function LineCallbackContent() {
 
         const code = searchParams.get("code");
         const state = searchParams.get("state");
-        const storedState = sessionStorage.getItem("lineLoginState");
+        const storedState = localStorage.getItem("lineLoginState");
 
         // CSRF対策: stateの検証
         if (!state || state !== storedState) {
@@ -69,8 +69,8 @@ function LineCallbackContent() {
           throw new Error("認証コードが取得できませんでした");
         }
 
-        // セッションストレージからサインアップ時のデータを取得
-        const storedData = sessionStorage.getItem("lineLoginData");
+        // ローカルストレージからサインアップ時のデータを取得
+        const storedData = localStorage.getItem("lineLoginData");
         const loginData = storedData ? JSON.parse(storedData) : {};
 
         // Server Actionを呼び出し
@@ -81,9 +81,9 @@ function LineCallbackContent() {
         );
 
         if (result.success) {
-          // セッションストレージをクリア
-          sessionStorage.removeItem("lineLoginState");
-          sessionStorage.removeItem("lineLoginData");
+          // ローカルストレージをクリア
+          localStorage.removeItem("lineLoginState");
+          localStorage.removeItem("lineLoginData");
 
           // サーバーコンポーネントを強制的に再レンダリング
           router.refresh();

--- a/lib/auth/line-auth.ts
+++ b/lib/auth/line-auth.ts
@@ -17,8 +17,8 @@ export async function signInWithLine() {
   const redirectUri = `${window.location.origin}/api/auth/callback/line`;
   const state = crypto.randomUUID();
 
-  // stateをセッションストレージに保存（CSRF対策）
-  sessionStorage.setItem("lineLoginState", state);
+  // stateをローカルストレージに保存（CSRF対策、モバイル対応）
+  localStorage.setItem("lineLoginState", state);
 
   const authUrl = new URL("https://access.line.me/oauth2/v2.1/authorize");
   authUrl.searchParams.set("response_type", "code");


### PR DESCRIPTION
# 変更の概要
- スマホからのLINEログインで「認証状態が無効です」エラーが発生する問題を修正
- sessionStorageからlocalStorageに変更してモバイルでの別タブ問題を解決

# 変更の背景
- スマホでLINEログインすると新しいタブで開かれ、元のタブのsessionStorageにアクセスできない
- CSRF保護のstateトークンが別タブで取得できず認証に失敗していた
- localStorageに変更することで、タブ間でのデータ共有を可能にした
- closes #467（関連するクロスブラウザ認証問題の一部）

# 緊急対応について
- 本番環境でスマホユーザーがLINEログインできない緊急事態のためhotfixとして対応

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - LINEログイン時のサインアップデータとCSRF保護用トークンの保存先を`sessionStorage`から`localStorage`に変更し、モバイル端末での動作を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->