### PR TITLE
fix: パスワードリセット時の異なるブラウザでのリダイレクト修正 (#608)

### DIFF
--- a/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
@@ -212,8 +212,8 @@ function LoginSelectionPhase({
     try {
       setIsLoading(true);
       setError(null);
-      // sessionStorageにサインアップデータを保存
-      sessionStorage.setItem(
+      // ローカルストレージにサインアップデータを保存（モバイル対応）
+      localStorage.setItem(
         "lineLoginData",
         JSON.stringify({
           dateOfBirth: formattedDate,

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -15,12 +15,20 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (error) {
-      // PKCE Code Verifier エラーの場合、メール認証は完了している可能性が高い
+      // PKCE Code Verifier エラーの場合、type別に適切な画面にリダイレクト
       if (
         error.message?.includes("code verifier") ||
         error.code === "validation_failed"
       ) {
-        // ログイン画面に成功メッセージ付きでリダイレクト
+        const type = requestUrl.searchParams.get("type");
+
+        if (type === "recovery") {
+          // パスワードリセットの場合
+          const resetUrl = `${origin}/reset-password`;
+          return NextResponse.redirect(resetUrl);
+        }
+
+        // メール認証の場合
         const loginUrl = `${origin}/sign-in?success=${encodeURIComponent("メール認証が完了しました。このブラウザでログインしてください。")}`;
         return NextResponse.redirect(loginUrl);
       }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -15,14 +15,13 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (error) {
-      // PKCE Code Verifier エラーの場合、type別に適切な画面にリダイレクト
+      // PKCE Code Verifier エラーの場合、redirect_to別に適切な画面にリダイレクト
       if (
         error.message?.includes("code verifier") ||
         error.code === "validation_failed"
       ) {
-        const type = requestUrl.searchParams.get("type");
-
-        if (type === "recovery") {
+        // redirect_toパラメータからパスワードリセットかどうかを判定
+        if (redirectTo === "/reset-password") {
           // パスワードリセットの場合
           const resetUrl = `${origin}/reset-password`;
           return NextResponse.redirect(resetUrl);

--- a/app/auth/line-callback/page.tsx
+++ b/app/auth/line-callback/page.tsx
@@ -58,7 +58,7 @@ function LineCallbackContent() {
 
         const code = searchParams.get("code");
         const state = searchParams.get("state");
-        const storedState = sessionStorage.getItem("lineLoginState");
+        const storedState = localStorage.getItem("lineLoginState");
 
         // CSRF対策: stateの検証
         if (!state || state !== storedState) {
@@ -69,8 +69,8 @@ function LineCallbackContent() {
           throw new Error("認証コードが取得できませんでした");
         }
 
-        // セッションストレージからサインアップ時のデータを取得
-        const storedData = sessionStorage.getItem("lineLoginData");
+        // ローカルストレージからサインアップ時のデータを取得
+        const storedData = localStorage.getItem("lineLoginData");
         const loginData = storedData ? JSON.parse(storedData) : {};
 
         // Server Actionを呼び出し
@@ -81,9 +81,9 @@ function LineCallbackContent() {
         );
 
         if (result.success) {
-          // セッションストレージをクリア
-          sessionStorage.removeItem("lineLoginState");
-          sessionStorage.removeItem("lineLoginData");
+          // ローカルストレージをクリア
+          localStorage.removeItem("lineLoginState");
+          localStorage.removeItem("lineLoginData");
 
           // サーバーコンポーネントを強制的に再レンダリング
           router.refresh();

--- a/lib/auth/line-auth.ts
+++ b/lib/auth/line-auth.ts
@@ -17,8 +17,8 @@ export async function signInWithLine() {
   const redirectUri = `${window.location.origin}/api/auth/callback/line`;
   const state = crypto.randomUUID();
 
-  // stateをセッションストレージに保存（CSRF対策）
-  sessionStorage.setItem("lineLoginState", state);
+  // stateをローカルストレージに保存（CSRF対策、モバイル対応）
+  localStorage.setItem("lineLoginState", state);
 
   const authUrl = new URL("https://access.line.me/oauth2/v2.1/authorize");
   authUrl.searchParams.set("response_type", "code");


### PR DESCRIPTION
# 変更の概要
- redirect_toパラメータでパスワードリセットかどうかを判定するよう修正
- typeパラメータがSupabaseの認証フロー中に失われる問題に対応
- 異なるブラウザでパスワードリセットリンクを開いた際に適切に/reset-passwordページにリダイレクトされるよう改善

# 変更の背景
- パスワードリセットメールのリンクを異なるブラウザで開いた場合、PKCE verifierエラーにより/sign-inページにリダイレクトされてしまう問題があった
- 元々typeパラメータで判定していたが、Supabaseの認証フロー中でtypeパラメータが失われるため、より確実なredirect_toパラメータでの判定に変更
- closes #608

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました