### PR TITLE
fix: パスワードリセット時の異なるブラウザでのリダイレクト修正 (#608)

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -15,12 +15,19 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (error) {
-      // PKCE Code Verifier エラーの場合、メール認証は完了している可能性が高い
+      // PKCE Code Verifier エラーの場合、redirect_to別に適切な画面にリダイレクト
       if (
         error.message?.includes("code verifier") ||
         error.code === "validation_failed"
       ) {
-        // ログイン画面に成功メッセージ付きでリダイレクト
+        // redirect_toパラメータからパスワードリセットかどうかを判定
+        if (redirectTo === "/reset-password") {
+          // パスワードリセットの場合
+          const resetUrl = `${origin}/reset-password`;
+          return NextResponse.redirect(resetUrl);
+        }
+
+        // メール認証の場合
         const loginUrl = `${origin}/sign-in?success=${encodeURIComponent("メール認証が完了しました。このブラウザでログインしてください。")}`;
         return NextResponse.redirect(loginUrl);
       }


### PR DESCRIPTION
# 変更の概要
- redirect_toパラメータでパスワードリセットかどうかを判定するよう修正
- typeパラメータがSupabaseの認証フロー中に失われる問題に対応
- 異なるブラウザでパスワードリセットリンクを開いた際に適切に/reset-passwordページにリダイレクトされるよう改善

# 変更の背景
- パスワードリセットメールのリンクを異なるブラウザで開いた場合、PKCE verifierエラーにより/sign-inページにリダイレクトされてしまう問題があった
- 元々typeパラメータで判定していたが、Supabaseの認証フロー中でtypeパラメータが失われるため、より確実なredirect_toパラメータでの判定に変更
- closes #608

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました