### PR TITLE
add bq_user_password as env var (secret)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,6 +22,7 @@ steps:
       - SUPABASE_ACCESS_TOKEN
       - SUPABASE_DB_PASSWORD
       - SMTP_PASS
+      - BQ_USER_PASSWORD
 
   # Dockerイメージのビルド
   - name: 'gcr.io/cloud-builders/docker'
@@ -106,3 +107,5 @@ availableSecrets:
       env: LINE_CLIENT_SECRET
     - versionName: 'projects/${PROJECT_ID}/secrets/${_SERVICE_NAME}-hubspot-api-key/versions/latest'
       env: HUBSPOT_API_KEY
+    - versionName: 'projects/${PROJECT_ID}/secrets/${_SERVICE_NAME}-bq-user-password/versions/latest'
+      env: BQ_USER_PASSWORD

--- a/terraform/nextjs-app/cloud_build.tf
+++ b/terraform/nextjs-app/cloud_build.tf
@@ -64,6 +64,12 @@ resource "google_secret_manager_secret_iam_member" "hubspot_api_key_accessor" {
   member    = "serviceAccount:${google_service_account.cloud_build.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "bq_user_password_accessor" {
+  secret_id = google_secret_manager_secret.bq_user_password.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cloud_build.email}"
+}
+
 
 # Cloud Build trigger
 resource "google_cloudbuild_trigger" "build_and_deploy" {

--- a/terraform/nextjs-app/secrets.tf
+++ b/terraform/nextjs-app/secrets.tf
@@ -96,3 +96,16 @@ resource "google_secret_manager_secret_version" "hubspot_api_key" {
   secret         = google_secret_manager_secret.hubspot_api_key.id
   secret_data_wo = var.HUBSPOT_API_KEY
 }
+
+resource "google_secret_manager_secret" "bq_user_password" {
+  secret_id = "${var.app_name}-${var.environment}-bq-user-password"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "bq_user_password" {
+  secret         = google_secret_manager_secret.bq_user_password.id
+  secret_data_wo = var.BQ_USER_PASSWORD
+}

--- a/terraform/nextjs-app/variables.tf
+++ b/terraform/nextjs-app/variables.tf
@@ -164,3 +164,9 @@ variable "BATCH_ADMIN_KEY" {
   type        = string
   sensitive   = true
 }
+
+variable "BQ_USER_PASSWORD" {
+  description = "BigQuery user password for replication (sensitive)"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
# 変更の概要
- 環境変数 (BQ_USER_PASSWORD)の追加
- #590 の前にこちらをマージしないとsupabase migration は失敗する

# わからないところ
- secret が実際に入るのはどのタイミング？terraform apply後手動でstg/prdに追加？

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - BigQueryユーザーパスワードの新しいシークレット変数を追加し、Cloud Buildで安全に利用できるようになりました。  
- **運用改善**
  - BigQueryユーザーパスワード用のシークレット管理とアクセス権限設定が強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->