### PR TITLE
Feature/#566 - サインアップ画面のチェックボックスをひとつにまとめ、チェックボックスのサイズを大きくする

### DIFF
--- a/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
@@ -26,9 +26,7 @@ interface TwoStepSignUpFormProps {
 // フェーズ1: 同意・生年月日入力
 function ConsentPhase({
   isTermsAgreed,
-  isPrivacyAgreed,
   setIsTermsAgreed,
-  setIsPrivacyAgreed,
   selectedYear,
   selectedMonth,
   selectedDay,
@@ -43,9 +41,7 @@ function ConsentPhase({
   onNext,
 }: {
   isTermsAgreed: boolean;
-  isPrivacyAgreed: boolean;
   setIsTermsAgreed: (value: boolean) => void;
-  setIsPrivacyAgreed: (value: boolean) => void;
   selectedYear: number;
   selectedMonth: number;
   selectedDay: number;
@@ -59,7 +55,7 @@ function ConsentPhase({
   isAgeValid: boolean;
   onNext: () => void;
 }) {
-  const canProceed = isTermsAgreed && isPrivacyAgreed && isAgeValid;
+  const canProceed = isTermsAgreed && isAgeValid;
 
   return (
     <div className="flex flex-col gap-2 mt-2">
@@ -157,20 +153,7 @@ function ConsentPhase({
             >
               利用規約
             </Link>
-            に同意する
-          </Label>
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="privacy"
-            checked={isPrivacyAgreed}
-            onCheckedChange={(checked) => setIsPrivacyAgreed(checked === true)}
-          />
-          <Label
-            htmlFor="privacy"
-            className="text-sm font-normal cursor-pointer"
-          >
+            および
             <Link
               href="/privacy"
               className="text-primary underline hover:no-underline"
@@ -405,9 +388,7 @@ export default function TwoStepSignUpForm({
       {currentPhase === "consent" ? (
         <ConsentPhase
           isTermsAgreed={isTermsAgreed}
-          isPrivacyAgreed={isPrivacyAgreed}
           setIsTermsAgreed={setIsTermsAgreed}
-          setIsPrivacyAgreed={setIsPrivacyAgreed}
           selectedYear={selectedYear}
           selectedMonth={selectedMonth}
           selectedDay={selectedDay}

--- a/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
@@ -299,7 +299,6 @@ export default function TwoStepSignUpForm({
 
   // 同意状態
   const [isTermsAgreed, setIsTermsAgreed] = useState(false);
-  const [isPrivacyAgreed, setIsPrivacyAgreed] = useState(false);
 
   // 生年月日の状態
   const [selectedYear, setSelectedYear] = useState(1990);

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer h-6 w-6 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
       className,
     )}
     {...props}


### PR DESCRIPTION
# 変更の概要
- サインアップ画面の「利用規約」と「プライバシーポリシー」の同意についてのチェックボックスをひとつにまとめました
- チェックボックスのサイズを 4 → 6 と大きくしました


| before | after |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/426e1f07-f85a-44a9-9a76-f18fa11cd228) | ![image](https://github.com/user-attachments/assets/84d6d201-d843-4ce3-bd6a-bd70a3813100) |


# 変更の背景
- [maesho/前田彰太](https://team-mirai-volunteer.slack.com/team/U08SWKWMCMQ)さん提案
  - 70代の方のサインアップの様子を観察したところ、次の課題があった
    - 利用規約に同意する&プライバシーポリシーに同意するの左の丸いチェックボタンが押しずらそうだった
    - 老眼&指がカサカサでタップしずらそうだった
- closes #566

※ ボタン文言の調整については murai さんが既に対応されていたため、本PRではチェックボックスの調整のみを行っています

## レビュワー動作確認

- [ ] チェックボックスのサイズが大きくなっていること
- [ ] チェックボックスをクリックすると、「次へ進む」ボタンがクリックできるようになること

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - サインアップの同意ステップで、プライバシー同意チェックボックスを削除し、利用規約への同意のみで進行可能になりました。プライバシーポリシーへのリンクは利用規約のリンク内に統合されました。

- **スタイル**
  - チェックボックスのサイズが大きくなり、視認性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->