### PR TITLE
fix: (cherry-picke) 2e testを現在のアカウント登録フォームに対応

### DIFF
--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -46,10 +46,8 @@ test.describe("新しい認証フロー (Two-Step Signup)", () => {
     await day.press("Enter");
     await page.getByRole("option", { name: "14日" }).click();
 
-    // 利用規約に同意する
+    // 利用規約・プライバシーポリシーに同意する
     await page.locator("#terms").click();
-    // プライバシーポリシーに同意する
-    await page.locator("#privacy").click();
 
     // 次へ進むボタンをクリック
     await page.getByRole("button", { name: "次へ進む" }).click();
@@ -199,10 +197,8 @@ test.describe("新しい認証フロー (Two-Step Signup)", () => {
     const selectedDay = page.getByRole("option", { name: "31日" });
     await selectedDay.click();
 
-    // 利用規約に同意する
+    // 利用規約・プライバシーポリシーに同意する
     await page.locator("#terms").click();
-    // プライバシーポリシーに同意する
-    await page.locator("#privacy").click();
 
     // 年齢制限エラーメッセージが表示されることを確認
     await expect(
@@ -232,14 +228,12 @@ test.describe("新しい認証フロー (Two-Step Signup)", () => {
     await day2.press("Enter");
     await page.getByRole("option", { name: "14日" }).click();
 
-    // 利用規約のみ同意（プライバシーポリシーは未同意）
-    await page.locator("#terms").click();
-
+    // 利用規約・プライバシーポリシーに未同意
     // 次へ進むボタンが無効化されていることを確認
     await expect(page.getByRole("button", { name: "次へ進む" })).toBeDisabled();
 
-    // プライバシーポリシーにも同意
-    await page.locator("#privacy").click();
+    // 利用規約・プライバシーポリシーに同意
+    await page.locator("#terms").click();
 
     // 次へ進むボタンが有効化されることを確認
     await expect(page.getByRole("button", { name: "次へ進む" })).toBeEnabled();
@@ -310,7 +304,7 @@ test.describe("新しい認証フロー (Two-Step Signup)", () => {
     // /sign-upページにリダイレクトされることを確認
     await page.waitForURL("/sign-up", { timeout: 5000 });
     await expect(
-      page.getByRole("heading", { name: "アカウントを作成する" }),
+      page.getByRole("heading", { name: "アクションボードに登録" }),
     ).toBeVisible();
   });
 
@@ -320,7 +314,7 @@ test.describe("新しい認証フロー (Two-Step Signup)", () => {
 
     // 1. 必要な要素が表示されていることを確認
     await expect(
-      page.getByRole("heading", { name: "アカウントを作成する" }),
+      page.getByRole("heading", { name: "アクションボードに登録" }),
     ).toBeVisible();
     await expect(
       page.getByText("生年月日（満18歳以上である必要があります）"),
@@ -350,12 +344,8 @@ test.describe("新しい認証フロー (Two-Step Signup)", () => {
 
     await expect(page.getByRole("button", { name: "次へ進む" })).toBeDisabled();
 
-    // 4. 利用規約のみ同意して無効化されていることを確認
+    // 4. 利用規約・プライバシーポリシーに同意して有効化されることを確認
     await page.locator("#terms").click();
-    await expect(page.getByRole("button", { name: "次へ進む" })).toBeDisabled();
-
-    // 5. すべて入力すると有効化されることを確認
-    await page.locator("#privacy").click();
     await expect(page.getByRole("button", { name: "次へ進む" })).toBeEnabled();
   });
 
@@ -484,7 +474,6 @@ test.describe("新しい認証フロー (Two-Step Signup)", () => {
 
     // 利用規約・プライバシーポリシーに同意
     await page.locator("#terms").click();
-    await page.locator("#privacy").click();
 
     // 次へ進む
     await page.getByRole("button", { name: "次へ進む" }).click();


### PR DESCRIPTION
# 変更の概要
- e2eがCIでエラーになっている事象の解消（未マージのPRから該当のcommitをcherry-pickで対応）

# 変更の背景
- https://github.com/team-mirai-volunteer/action-board/pull/483/files#diff-8f1889bfac6070d194fba683302f3c90c1bd1901fff8f758b00483c5236cb8cf

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - サインアップフローの同意チェックボックス操作を簡素化し、「利用規約」と「プライバシーポリシー」への同意を1つのチェックボックスでまとめて検証するよう変更しました。
  - UI上の見出しテキストを「アカウントを作成する」から「アクションボードに登録」に更新しました。
  - 同意や年齢検証に基づく「次へ進む」ボタンの有効・無効の挙動確認テストを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->