### PR TITLE
CIのマイグレーションでinclude-all

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - |
         npx supabase link --project-ref ${_SUPABASE_PROJECT_ID} -p $$SUPABASE_DB_PASSWORD
 
-        npx supabase db push
+        npx supabase db push --include-all
         npx supabase config push
     env:
       - 'CI=true'


### PR DESCRIPTION
# 変更の概要
supabase db push コマンドに --include-all を付与。
これによって適用されている最新のマイグレーションよりも古いマイグレーションファイルもマイグレーション実行することになります。

# 変更の背景
- developブランチにマージするタイミングがまちまちなので、しょっちゅう--include-allを自分の手元でstagingのSupabaseにやってるが運用辛い
- マイグレーションは意図した順番で実行されるべき、というのは本来あるが、運用上--include-allを手元でやるデメリットのほうが大きい

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました