### PR TITLE
消えてしまった artifact_type 'EMAIL'を復活

### DIFF
--- a/supabase/migrations/20250623150000_add_quiz_system.sql
+++ b/supabase/migrations/20250623150000_add_quiz_system.sql
@@ -107,7 +107,7 @@ DROP CONSTRAINT IF EXISTS check_artifact_type;
 
 ALTER TABLE mission_artifacts 
 ADD CONSTRAINT check_artifact_type 
-CHECK (artifact_type IN ('LINK', 'TEXT', 'IMAGE', 'IMAGE_WITH_GEOLOCATION', 'REFERRAL', 'POSTING', 'QUIZ'));
+CHECK (artifact_type IN ('LINK', 'TEXT', 'EMAIL', 'IMAGE', 'IMAGE_WITH_GEOLOCATION', 'REFERRAL', 'POSTING', 'QUIZ'));
 
 -- ensure_artifact_data制約にQUIZタイプを追加
 ALTER TABLE mission_artifacts
@@ -124,6 +124,12 @@ ADD CONSTRAINT ensure_artifact_data CHECK (
     )
     OR (
       (artifact_type = 'TEXT'::text)
+      AND (text_content IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+    )
+    OR (
+      (artifact_type = 'EMAIL'::text)
       AND (text_content IS NOT NULL)
       AND (link_url IS NULL)
       AND (image_storage_path IS NULL)


### PR DESCRIPTION
# 変更の概要
- https://github.com/team-mirai-volunteer/action-board/blob/develop/supabase/migrations/20250623150000_add_quiz_system.sql に artifact_type 'EMAIL' を追加する

# 変更の背景

- https://github.com/team-mirai-volunteer/action-board/blob/develop/supabase/migrations/20250623150000_add_quiz_system.sql に伴い、https://github.com/team-mirai-volunteer/action-board/blob/develop/supabase/migrations/20250617144928_add_email_artifact_type.sql で追加したartifact_type 'EMAIL' が消えてしまった
- 現在 develop ブランチで、`サポーターSlackに入ろう` のミッションの完了を記録すると次のような表示になる
![スクリーンショット 2025-06-23 20 09 45](https://github.com/user-attachments/assets/bb1447e4-a7d5-4ee1-8cf0-e9d600768d9a)

- closes なし

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました