### PR TITLE
missionsテーブルにslugを追加

### DIFF
--- a/supabase/migrations/20250624081700_add_slug_to_missions.sql
+++ b/supabase/migrations/20250624081700_add_slug_to_missions.sql
@@ -1,0 +1,71 @@
+-- Add slug column to missions table
+ALTER TABLE missions ADD COLUMN slug TEXT;
+
+-- Add unique constraint to slug
+ALTER TABLE missions ADD CONSTRAINT missions_slug_unique UNIQUE (slug);
+
+-- Update existing missions with slugs based on their titles
+UPDATE missions SET slug = CASE
+  -- YouTube関連
+  WHEN title = 'YouTube動画を切り抜こう' THEN 'youtube-clip'
+  WHEN title = 'YouTube動画を視聴しよう' THEN 'youtube-watch'
+  WHEN title = '公式YouTubeチャンネルを登録しよう' THEN 'youtube-subscribe'
+  
+  -- X (Twitter)関連
+  WHEN title = '安野たかひろの公式Xをフォローしよう' THEN 'follow-anno-x'
+  WHEN title = 'チームみらいの公式Xをフォローしよう' THEN 'follow-teammirai-x'
+  WHEN title = 'Xでチームみらいに関する投稿をしよう' THEN 'x-post'
+  WHEN title = 'Xでチームみらいの投稿をリポストしよう' THEN 'x-repost'
+  WHEN title = 'X でチームみらい投稿に♡をつけよう' THEN 'x-like'
+  
+  -- SNS関連
+  WHEN title = 'Instagram でチームみらい投稿に♡をつけよう' THEN 'instagram-like'
+  WHEN title = 'note でチームみらい記事にスキ♡をつけよう' THEN 'note-like'
+  WHEN title = '公式noteをフォローしよう' THEN 'follow-note'
+  WHEN title = 'マニフェストの感想をSNSでシェアしよう' THEN 'share-manifest-sns'
+  
+  -- コミュニティ参加
+  WHEN title = 'サポーターSlackに入ろう' THEN 'join-slack'
+  WHEN title = '都道府県別LINEオープンチャットに入ろう' THEN 'join-prefecture-openchat'
+  WHEN title = 'サポーター目的別LINEオープンチャットに入ろう' THEN 'join-purpose-openchat'
+  WHEN title = '公式LINEアカウントと友達になろう' THEN 'add-line-friend'
+  
+  -- いどばた政策関連
+  WHEN title = 'いどばた政策サイトからマニフェストを提案しよう' THEN 'propose-manifest-idobata'
+  WHEN title = 'いどばた政策サイトでAIとチャットしよう' THEN 'chat-idobata-ai'
+  
+  -- イベント・活動関連
+  WHEN title = 'イベントに参加しよう' THEN 'join-event'
+  WHEN title = 'イベント運営を手伝おう' THEN 'help-event-operation'
+  WHEN title = '街頭演説に参加しよう' THEN 'join-street-speech'
+  WHEN title = 'チームみらいの機関誌をポスティングしよう' THEN 'posting-magazine'
+  WHEN title = 'チームみらいの政党ポスターを貼ろう' THEN 'put-up-poster'
+  
+  -- 開発・技術関連
+  WHEN title = '開発者向け: Githubでプルリクエストを出そう' THEN 'github-pull-request'
+  
+  -- クイズ関連
+  WHEN title = 'チームみらいクイズ（初級）に挑戦しよう' THEN 'quiz-teammirai-beginner'
+  WHEN title = '政策・マニフェストクイズ（中級）に挑戦しよう' THEN 'quiz-policy-intermediate'
+  WHEN title = '政策・マニフェストクイズ（中級2）に挑戦しよう' THEN 'quiz-policy-intermediate-2'
+  
+  -- その他
+  WHEN title = 'チームみらいの仲間を増やそう' THEN 'referral'
+  
+  -- シードデータ
+  WHEN title = '(seed) 今日のベストショット (画像提出)' THEN 'seed-best-shot'
+  WHEN title = '(seed) 発見！地域の宝 (位置情報付き画像)' THEN 'seed-local-treasure'
+  WHEN title = '(seed) 日付付きミッション１ (成果物不要, 上限1回)' THEN 'seed-date-mission-1'
+  WHEN title = '(seed) ゴミ拾いをしよう (成果物不要)' THEN 'seed-cleanup'
+  WHEN title = '(seed) Xのニックネームを入力しよう(テキスト提出)' THEN 'seed-x-nickname'
+  WHEN title = '(seed) 活動ブログを書こう (リンク提出)' THEN 'seed-activity-blog'
+  
+  ELSE NULL
+END
+WHERE slug IS NULL;
+
+-- Make slug column NOT NULL after updating all existing records
+ALTER TABLE missions ALTER COLUMN slug SET NOT NULL;
+
+-- Create index on slug for better query performance
+CREATE INDEX idx_missions_slug ON missions(slug);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -59,14 +59,14 @@ VALUES
   ('6ba7b818-9dad-11d1-80b4-00c04fd430c8', 0, 1, '2025-06-04T04:30:00Z');
 
 -- ミッション
-INSERT INTO missions (id, title, icon_url, content, difficulty, event_date, required_artifact_type, max_achievement_count)
+INSERT INTO missions (id, title, icon_url, content, difficulty, event_date, required_artifact_type, max_achievement_count, slug)
 VALUES
-  ('e2898d7e-903f-4f9a-8b1b-93f783c9afac', '(seed) ゴミ拾いをしよう (成果物不要)', NULL, '近所のゴミを拾ってみよう！清掃活動の報告は任意です。', 1, NULL, 'NONE', NULL),
-  ('2246205f-933f-4a86-83af-dbf6bb6cde90', '(seed) 活動ブログを書こう (リンク提出)', '/img/mission_fallback.svg', 'あなたの活動についてブログ記事を書き、URLを提出してください。', 2, NULL, 'LINK', 10),
-  ('3346205f-933f-4a86-83af-dbf6bb6cde91', '(seed) 今日のベストショット (画像提出)', '/img/mission_fallback.svg', '今日の活動で見つけた素晴らしい瞬間を写真で共有してください。', 3, '2025-06-01', 'IMAGE', NULL),
-  ('4446205f-933f-4a86-83af-dbf6bb6cde92', '(seed) 発見！地域の宝 (位置情報付き画像)', '/img/mission_fallback.svg', 'あなたの地域で見つけた素敵な場所や物を、位置情報付きの写真で教えてください。', 4, NULL, 'IMAGE_WITH_GEOLOCATION', 5),
-  ('5546205f-933f-4a86-83af-dbf6bb6cde93', '(seed) 日付付きミッション１ (成果物不要, 上限1回)', '/img/mission_fallback.svg', 'テスト用のミッションです。<a href="/">link test</a>', 5, '2025-05-01', 'NONE', 1),
-  ('e5348472-d054-4ef4-81af-772c6323b669', '(seed) Xのニックネームを入力しよう(テキスト提出)', NULL, 'Xのニックネームを入力しよう', 1, NULL, 'TEXT', NULL);  
+  ('e2898d7e-903f-4f9a-8b1b-93f783c9afac', '(seed) ゴミ拾いをしよう (成果物不要)', NULL, '近所のゴミを拾ってみよう！清掃活動の報告は任意です。', 1, NULL, 'NONE', NULL, 'seed-cleanup'),
+  ('2246205f-933f-4a86-83af-dbf6bb6cde90', '(seed) 活動ブログを書こう (リンク提出)', '/img/mission_fallback.svg', 'あなたの活動についてブログ記事を書き、URLを提出してください。', 2, NULL, 'LINK', 10, 'seed-activity-blog'),
+  ('3346205f-933f-4a86-83af-dbf6bb6cde91', '(seed) 今日のベストショット (画像提出)', '/img/mission_fallback.svg', '今日の活動で見つけた素晴らしい瞬間を写真で共有してください。', 3, '2025-06-01', 'IMAGE', NULL, 'seed-best-shot'),
+  ('4446205f-933f-4a86-83af-dbf6bb6cde92', '(seed) 発見！地域の宝 (位置情報付き画像)', '/img/mission_fallback.svg', 'あなたの地域で見つけた素敵な場所や物を、位置情報付きの写真で教えてください。', 4, NULL, 'IMAGE_WITH_GEOLOCATION', 5, 'seed-local-treasure'),
+  ('5546205f-933f-4a86-83af-dbf6bb6cde93', '(seed) 日付付きミッション１ (成果物不要, 上限1回)', '/img/mission_fallback.svg', 'テスト用のミッションです。<a href="/">link test</a>', 5, '2025-05-01', 'NONE', 1, 'seed-date-mission-1'),
+  ('e5348472-d054-4ef4-81af-772c6323b669', '(seed) Xのニックネームを入力しよう(テキスト提出)', NULL, 'Xのニックネームを入力しよう', 1, NULL, 'TEXT', NULL, 'seed-x-nickname');
 
 --★#278対応にて、achievementsとmission_artifactsのuser_idのFKをpublic_user_profileからauth.usersへ変更
 --★seed.sql実行時点でauth.usersデータを作れず、上記2テーブルがFK違反になることから、INSERT処理はコメントアウト


### PR DESCRIPTION
# 変更の概要
- missionsテーブルにslugを追加しました
- 今までidやタイトルで指定していたが、↓の理由から特定のmissionを指し示すのには不適切
  - idは環境ごとに違う場合がある
  - タイトルは文言調整などで変わりやすい

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました