### PR TITLE
#687 復習表示はクイズのみにする。最大数に達していないミッションで報告ができない問題の修正

### DIFF
--- a/app/missions/[id]/_components/MissionFormWrapper.tsx
+++ b/app/missions/[id]/_components/MissionFormWrapper.tsx
@@ -151,7 +151,8 @@ export function MissionFormWrapper({
 
   return (
     <>
-      {!hasReachedUserMaxAchievements &&
+      {mission.required_artifact_type === ARTIFACT_TYPES.QUIZ.key &&
+        !hasReachedUserMaxAchievements &&
         userAchievementCount > 0 &&
         mission?.max_achievement_count !== null && (
           <div className="rounded-lg border bg-muted/50 p-4 text-center mb-4">
@@ -171,7 +172,7 @@ export function MissionFormWrapper({
           </div>
         )}
 
-      {!completed &&
+      {!hasReachedUserMaxAchievements &&
         (mission.required_artifact_type === ARTIFACT_TYPES.QUIZ.key ? (
           // クイズミッションの場合
           <div className="space-y-4">

--- a/supabase/migrations/20250623115600_update_mission_category.sql
+++ b/supabase/migrations/20250623115600_update_mission_category.sql
@@ -1,7 +1,6 @@
 -- mission-categoryを一度削除。
 TRUNCATE mission_category_link, mission_category;
 
-正のカゴリ定義でINSRT。
 insert into mission_category (id, category_title, sort_no, category_kbn)
 values  
 ('0cc2f4f9-ab0a-480c-c1e2-442513421dfc', 'チームみらいのことを知ろう', 100, 'DEFAULT'),


### PR DESCRIPTION
# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - クイズタイプのミッションに対してのみ、レビュー挑戦メッセージとミッションフォームが表示される条件を厳格化しました。

- **スタイル**
  - SQLマイグレーションファイルから誤記を含む日本語コメントを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->