### PR TITLE
feat: 公式Tiktokをフォローしよう #643 を追加

### DIFF
--- a/mission_data/category_links.yaml
+++ b/mission_data/category_links.yaml
@@ -9,6 +9,8 @@ category_links:
         sort_no: 300
       - mission_slug: follow-anno-x
         sort_no: 350
+      - mission_slug: follow-teammirai-tiktok
+        sort_no: 400
       - mission_slug: follow-note
         sort_no: 500
   - category_slug: learn-about-teammirai
@@ -123,3 +125,7 @@ category_links:
         sort_no: 200
       - mission_slug: github-pull-request
         sort_no: 300
+  - category_slug: support-on-tiktok
+    missions:
+      - mission_slug: follow-teammirai-tiktok
+        sort_no: 100

--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -43,6 +43,18 @@ missions:
     is_hidden: false
     artifact_label: あなたのXアカウント名
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//11_follow_teammirai_x.png
+  - slug: follow-teammirai-tiktok
+    title: 公式Tiktokをフォローしよう
+    icon_url: /img/mission_fallback.svg
+    content: '<a href="https://www.tiktok.com/@annotakahiro2024" target="_blank" rel="noopener noreferrer">チームみらいの公式Tiktokアカウント</a>をフォローして、ショート動画をチェックしよう！安野たかひろの解説動画をはじめ、候補者の街頭演説や舞台裏トークなど、お忙しい方でも気軽にご覧いただけるコンテンツがたくさんあります。'
+    difficulty: 1
+    required_artifact_type: TEXT
+    max_achievement_count: 1
+    is_featured: false
+    is_hidden: false
+    artifact_label: あなたのTiktokアカウント名
+    ogp_image_url: null
+    event_date: null
   - slug: share-manifest-sns
     title: マニフェストの感想をSNSでシェアしよう
     icon_url: /img/mission_fallback.svg

--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -46,7 +46,7 @@ missions:
   - slug: follow-teammirai-tiktok
     title: 公式Tiktokをフォローしよう
     icon_url: /img/mission_fallback.svg
-    content: '<a href="https://www.tiktok.com/@annotakahiro2024" target="_blank" rel="noopener noreferrer">チームみらいの公式Tiktokアカウント</a>をフォローして、ショート動画をチェックしよう！安野たかひろの解説動画をはじめ、候補者の街頭演説や舞台裏トークなど、お忙しい方でも気軽にご覧いただけるコンテンツがたくさんあります。'
+    content: '<a href="https://www.tiktok.com/@annotakahiro2024" target="_blank" rel="noopener noreferrer">チームみらいの公式Tiktokアカウント</a>をフォローして、ショート動画をチェックしよう！安野たかひろの解説動画をはじめ、候補者の街頭演説や舞台裏トークなど、お忙しい方でも気軽にご覧いただけるコンテンツを揃えています。'
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1


### PR DESCRIPTION
# 変更の概要
「公式Tiktokをフォローしよう」ミッションを追加
( #679 の作り直しですmm)

# 変更の背景
- チームみらいの公式TikTokアカウント（@annotakahiro2024）を伸ばしたい
- closes #643

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 「チームみらい」の公式TikTokアカウントをフォローする新ミッションを追加しました。
  - TikTokサポート専用の新しいカテゴリを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->