### PR TITLE
マイグレーションが失敗する問題の修正

### DIFF
--- a/supabase/migrations/20250623115600_update_mission_category.sql
+++ b/supabase/migrations/20250623115600_update_mission_category.sql
@@ -1,7 +1,7 @@
 -- mission-categoryを一度削除。
 TRUNCATE mission_category_link, mission_category;
 
-正のカゴリ定義でINSRT。
+-- 正のカテゴリ定義でINSERT。
 insert into mission_category (id, category_title, sort_no, category_kbn)
 values  
 ('0cc2f4f9-ab0a-480c-c1e2-442513421dfc', 'チームみらいのことを知ろう', 100, 'DEFAULT'),

--- a/supabase/migrations/20250624081700_add_slug_to_missions.sql
+++ b/supabase/migrations/20250624081700_add_slug_to_missions.sql
@@ -56,6 +56,10 @@ UPDATE missions SET slug = CASE
 END
 WHERE slug IS NULL;
 
+UPDATE missions
+SET slug = 'dummy-slug-' || id
+WHERE slug IS NULL;
+
 -- Make slug column NOT NULL after updating all existing records
 ALTER TABLE missions ALTER COLUMN slug SET NOT NULL;
 


### PR DESCRIPTION
# 変更の概要
- マイグレーションファイルの修正

# 変更の背景
- `supabase db reset` に失敗したので

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - SQLマイグレーションスクリプト内のコメントの誤字と書式を修正しました。

- **新機能**
  - ミッションのスラッグがNULLの場合、自動的にダミー値（dummy-slug-＋ID）を設定し、全てのミッションにスラッグが必ず存在するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->