### PR TITLE
docs: `NEXT_PUBLIC_SUPABASE_ANON_KEY` をREAEMEに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@
    ```
    NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
 
+   # `supabase start` 実行時に表示される値を指定します。
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
    SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 
    # SentryのDSNを指定します。開発時は空でもかまいません。


### PR DESCRIPTION
# 変更の概要
READMEに、`.env.local`への`NEXT_PUBLIC_SUPABASE_ANON_KEY`の指定を追記しました。
この指定がないと、フロントエンドからのAPI呼び出しでエラーとなる。

# 変更の背景
https://team-mirai-volunteer.slack.com/archives/C08SNQ7D29L/p1750847574622329?thread_ts=1750825139.369749&cid=C08SNQ7D29L

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - READMEに、`.env.local` 設定例として Supabase の匿名公開キーの記載例と説明を追加し、ローカル開発環境の設定手順をより分かりやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->