### PR TITLE
mod: jest configを修正し、テスト対象外のファイルがカバレッジレポートに出力されないようにしました

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,17 @@ const config = {
   },
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   collectCoverage: true,
-  collectCoverageFrom: ["(app|components|lib|stories)/**/*.(ts|tsx)"],
+  collectCoverageFrom: ["(app|components|lib)/**/*.(ts|tsx)", "!**/*.d.ts"],
   coverageReporters: ["html", "text", "lcov"],
   coverageDirectory: "<rootDir>/coverage",
-  coveragePathIgnorePatterns: [],
+  coveragePathIgnorePatterns: [
+    "<rootDir>/app/privacy/",
+    "<rootDir>/app/terms/",
+    "<rootDir>/lib/types/",
+    "<rootDir>/lib/supabase/",
+    "<rootDir>/lib/address.ts",
+    "<rootDir>/lib/constants.ts",
+  ],
   coverageProvider: "v8",
 };
 


### PR DESCRIPTION
# 変更の概要
- jest configを修正し、テスト対象外のファイルがカバレッジレポートに出力されないようにしました

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました