### PR TITLE
feat: 「チームみらいのマニフェスト(要約版)をみてみよう！」 #568 を追加

### DIFF
--- a/mission_data/category_links.yaml
+++ b/mission_data/category_links.yaml
@@ -25,6 +25,8 @@ category_links:
         sort_no: 300
       - mission_slug: chat-idobata-ai
         sort_no: 400
+      - mission_slug: read-manifest
+        sort_no: 500
   - category_slug: join-community
     missions:
       - mission_slug: join-slack
@@ -83,14 +85,16 @@ category_links:
     missions:
       - mission_slug: chat-idobata-ai
         sort_no: 100
-      - mission_slug: quiz-policy-intermediate
+      - mission_slug: read-manifest
         sort_no: 200
-      - mission_slug: quiz-policy-intermediate-2
+      - mission_slug: quiz-policy-intermediate
         sort_no: 300
-      - mission_slug: propose-manifest-idobata
+      - mission_slug: quiz-policy-intermediate-2
         sort_no: 400
-      - mission_slug: share-manifest-sns
+      - mission_slug: propose-manifest-idobata
         sort_no: 500
+      - mission_slug: share-manifest-sns
+        sort_no: 600
   - category_slug: support-on-x
     missions:
       - mission_slug: follow-teammirai-x

--- a/mission_data/mission_main_links.yaml
+++ b/mission_data/mission_main_links.yaml
@@ -2,3 +2,6 @@ mission_main_links:
   - mission_slug: link-official-site
     label: チームみらい公式サイトを見る
     link: https://team-mir.ai
+  - mission_slug: read-manifest
+    label: チームみらいのマニフェスト(要約版)を読む
+    link: https://speakerdeck.com/teammirai/timumiraimanihuesuto-yao-yue-ban-v0-dot-2

--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -23,13 +23,12 @@ missions:
   - slug: read-manifest
     title: チームみらいのマニフェスト(要約版)をみてみよう！
     icon_url: /img/mission_fallback.svg
-    content: <a href="https://speakerdeck.com/teammirai/timumiraimanihuesuto-yao-yue-ban-v0-dot-2" target="_blank" rel="noopener noreferrer">チームみらいのマニフェスト(要約版)</a>は、スライド形式で手軽に読むことができます。チームみらいの考える政治や政策について知ろう！
+    content: チームみらいのマニフェスト(要約版)は、スライド形式で手軽に読むことができます。チームみらいの考える政治や政策について知ろう！
     difficulty: 2
-    required_artifact_type: NONE
+    required_artifact_type: LINK_ACCESS
     max_achievement_count: 1
     is_featured: false
     is_hidden: false
-    artifact_label: null
     ogp_image_url: null
   - slug: propose-manifest-idobata
     title: いどばた政策サイトからマニフェストを提案しよう

--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -20,6 +20,17 @@ missions:
     is_hidden: false
     artifact_label: リポストした投稿のURL
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//19_x_repost.png
+  - slug: read-manifest
+    title: チームみらいのマニフェスト(要約版)をみてみよう！
+    icon_url: /img/mission_fallback.svg
+    content: <a href="https://speakerdeck.com/teammirai/timumiraimanihuesuto-yao-yue-ban-v0-dot-2" target="_blank" rel="noopener noreferrer">チームみらいのマニフェスト(要約版)</a>は、スライド形式で手軽に読むことができます。チームみらいの考える政治や政策について知ろう！
+    difficulty: 2
+    required_artifact_type: NONE
+    max_achievement_count: 1
+    is_featured: false
+    is_hidden: false
+    artifact_label: null
+    ogp_image_url: null
   - slug: propose-manifest-idobata
     title: いどばた政策サイトからマニフェストを提案しよう
     icon_url: /img/mission_fallback.svg


### PR DESCRIPTION
# 変更の概要
- `missions.yaml` に「チームみらいのマニフェスト(要約版)をみてみよう！」を追加
- あわせて、`category_links.yaml` に `read-manifest` slugを追加
  - sort_noは`20250623115600_update_mission_category.sql` 内コメントアウトの設定値を参考に指定
- mission_main_linkに対象のslugを追加し、要約版のURLを登録

### 見た目の変化

![image](https://github.com/user-attachments/assets/0e7399e4-ab58-4021-98c0-7549a095e58f)
![image](https://github.com/user-attachments/assets/e2d5d328-88f8-4760-b036-20a16ec249c8)
<img width="495" alt="image" src="https://github.com/user-attachments/assets/61c0adda-52b5-4c88-9a71-4a001d661d56" />




# 変更の背景
- [しょーこ](https://team-mirai-volunteer.slack.com/team/U0908DY1HJP)さん提案の[アイディア](https://team-mirai-volunteer.slack.com/archives/C08SY7B0XAN/p1750395462696309?thread_ts=1750390372.882149&cid=C08SY7B0XAN)を反映
- closes #568

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **新機能**
  * 「チームみらいのマニフェスト(要約版)をみてみよう！」という新しいミッションが追加されました。スライド形式でマニフェストの要約版を閲覧できます。
* **その他**
  * 「learn-about-teammirai」および「improve-policies」カテゴリ内のミッション表示順が調整されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->