### PR TITLE
feat: 期間別ランキング機能の追加 (#626)

### DIFF
--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -1,31 +1,74 @@
 import { RankingTop } from "@/components/ranking";
 import { CurrentUserCard } from "@/components/ranking/current-user-card";
+import {
+  PeriodToggle,
+  type RankingPeriod,
+} from "@/components/ranking/period-toggle";
 import { RankingTabs } from "@/components/ranking/ranking-tabs";
 import { createClient } from "@/lib/supabase/server";
 
-export default async function RankingPage() {
+interface PageProps {
+  searchParams: Promise<{
+    period?: RankingPeriod;
+  }>;
+}
+
+export default async function RankingPage({ searchParams }: PageProps) {
   const supabase = await createClient();
+  const resolvedSearchParams = await searchParams;
+  const period = resolvedSearchParams.period || "all";
 
   // ユーザー情報取得
   const {
     data: { user },
-    error: userError,
   } = await supabase.auth.getUser();
 
   let userRanking = null;
 
   if (user) {
-    const { data } = await supabase
-      .from("user_ranking_view")
-      .select("*")
-      .eq("user_id", user.id)
-      .single();
-    userRanking = data;
+    if (period === "all") {
+      // 全期間の場合は既存のビューを使用
+      const { data } = await supabase
+        .from("user_ranking_view")
+        .select("*")
+        .eq("user_id", user.id)
+        .single();
+      userRanking = data;
+    } else {
+      // 期間別の場合は関数を使用
+      const dateFilter = new Date();
+      if (period === "daily") {
+        dateFilter.setDate(dateFilter.getDate() - 1);
+      } else if (period === "weekly") {
+        dateFilter.setDate(dateFilter.getDate() - 7);
+      }
+
+      const { data } = await supabase.rpc("get_user_period_ranking", {
+        target_user_id: user.id,
+        start_date: dateFilter.toISOString(),
+      });
+      if (data && data.length > 0) {
+        userRanking = {
+          user_id: data[0].user_id,
+          address_prefecture: data[0].address_prefecture,
+          level: data[0].level,
+          name: data[0].name,
+          rank: data[0].rank,
+          updated_at: data[0].updated_at,
+          xp: data[0].xp,
+        };
+      }
+    }
   }
 
   return (
     <div className="flex flex-col min-h-screen py-4 w-full">
       <RankingTabs>
+        {/* 期間選択トグル */}
+        <section className="py-4 bg-white">
+          <PeriodToggle defaultPeriod={period} />
+        </section>
+
         {/* ユーザーのランキングカード */}
         {userRanking && (
           <section className="py-4 bg-white">
@@ -35,7 +78,7 @@ export default async function RankingPage() {
 
         <section className="py-4 bg-white">
           {/* ランキング */}
-          <RankingTop limit={100} />
+          <RankingTop limit={100} period={period} />
         </section>
       </RankingTabs>
     </div>

--- a/app/ranking/ranking-mission/page.tsx
+++ b/app/ranking/ranking-mission/page.tsx
@@ -1,5 +1,9 @@
 import { CurrentUserCardMission } from "@/components/ranking/current-user-card-mission";
 import { MissionSelect } from "@/components/ranking/mission-select";
+import {
+  PeriodToggle,
+  type RankingPeriod,
+} from "@/components/ranking/period-toggle";
 import RankingMission from "@/components/ranking/ranking-mission";
 import { RankingTabs } from "@/components/ranking/ranking-tabs";
 import {
@@ -11,12 +15,14 @@ import { createClient } from "@/lib/supabase/server";
 interface PageProps {
   searchParams: Promise<{
     missionId?: string;
+    period?: RankingPeriod;
   }>;
 }
 
 export default async function RankingMissionPage({ searchParams }: PageProps) {
   const supabase = await createClient();
   const resolvedSearchParams = await searchParams;
+  const period = resolvedSearchParams.period || "all";
 
   // ユーザー情報取得
   const {
@@ -67,7 +73,11 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
 
   if (user) {
     // 現在のユーザーのミッション別ランキングを探す
-    userRanking = await getUserMissionRanking(selectedMission.id, user.id);
+    userRanking = await getUserMissionRanking(
+      selectedMission.id,
+      user.id,
+      period,
+    );
   }
 
   // ミッションタイプに応じてbadgeTextを生成、ポスティングミッションの場合はポスティング枚数を取得
@@ -87,6 +97,11 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
   return (
     <div className="flex flex-col min-h-screen py-4 w-full">
       <RankingTabs>
+        {/* 期間選択トグル */}
+        <section className="py-4 bg-white">
+          <PeriodToggle defaultPeriod={period} />
+        </section>
+
         {/* ミッション選択 */}
         <section className="py-4 bg-white">
           <MissionSelect missions={missions} />
@@ -109,6 +124,7 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
             limit={100}
             mission={selectedMission}
             isPostingMission={isPostingMission}
+            period={period}
           />
         </section>
       </RankingTabs>

--- a/app/ranking/ranking-prefecture/page.tsx
+++ b/app/ranking/ranking-prefecture/page.tsx
@@ -1,4 +1,8 @@
 import { CurrentUserCardPrefecture } from "@/components/ranking/current-user-card-prefecture";
+import {
+  PeriodToggle,
+  type RankingPeriod,
+} from "@/components/ranking/period-toggle";
 import { PrefectureSelect } from "@/components/ranking/prefecture-select";
 import RankingPrefecture from "@/components/ranking/ranking-prefecture";
 import { RankingTabs } from "@/components/ranking/ranking-tabs";
@@ -10,6 +14,7 @@ import { createClient } from "@/lib/supabase/server";
 interface PageProps {
   searchParams: Promise<{
     prefecture?: string;
+    period?: RankingPeriod;
   }>;
 }
 
@@ -18,6 +23,7 @@ export default async function RankingPrefecturePage({
 }: PageProps) {
   const supabase = await createClient();
   const resolvedSearchParams = await searchParams;
+  const period = resolvedSearchParams.period || "all";
 
   // ユーザー情報取得
   const {
@@ -51,12 +57,21 @@ export default async function RankingPrefecturePage({
 
   if (user) {
     // 現在のユーザーの都道府県別ランキングを探す
-    userRanking = await getUserPrefecturesRanking(selectedPrefecture, user.id);
+    userRanking = await getUserPrefecturesRanking(
+      selectedPrefecture,
+      user.id,
+      period,
+    );
   }
 
   return (
     <div className="flex flex-col min-h-screen py-4 w-full">
       <RankingTabs>
+        {/* 期間選択トグル */}
+        <section className="py-4 bg-white">
+          <PeriodToggle defaultPeriod={period} />
+        </section>
+
         {/* 都道府県選択 */}
         <section className="py-4 bg-white">
           <PrefectureSelect
@@ -77,7 +92,11 @@ export default async function RankingPrefecturePage({
 
         <section className="py-4 bg-white">
           {/* 都道府県別ランキング */}
-          <RankingPrefecture limit={100} prefecture={selectedPrefecture} />
+          <RankingPrefecture
+            limit={100}
+            prefecture={selectedPrefecture}
+            period={period}
+          />
         </section>
       </RankingTabs>
     </div>

--- a/components/ranking/base-current-user-card.test.tsx
+++ b/components/ranking/base-current-user-card.test.tsx
@@ -1,0 +1,301 @@
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import BaseCurrentUserCard from "./base-current-user-card";
+
+jest.mock("@/components/ui/card", () => ({
+  Card: ({
+    children,
+    className,
+  }: { children: React.ReactNode; className?: string }) => (
+    <div className={className} data-testid="card">
+      {children}
+    </div>
+  ),
+  CardHeader: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-header">{children}</div>
+  ),
+  CardTitle: ({
+    children,
+    className,
+  }: { children: React.ReactNode; className?: string }) => (
+    <h3 className={className} data-testid="card-title">
+      {children}
+    </h3>
+  ),
+  CardContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-content">{children}</div>
+  ),
+}));
+
+jest.mock("lucide-react", () => ({
+  User: ({ className }: { className?: string }) => (
+    <div className={className} data-testid="user-icon" />
+  ),
+}));
+
+jest.mock("@/lib/utils/ranking-utils", () => ({
+  formatUserDisplayName: (name: string | null) => name || "名無しユーザー",
+  formatUserPrefecture: (prefecture: string | null) => prefecture || "未設定",
+}));
+
+describe("BaseCurrentUserCard", () => {
+  const mockCurrentUser = {
+    user_id: "test-user-1",
+    name: "テストユーザー",
+    address_prefecture: "東京都",
+    rank: 5,
+  };
+
+  describe("基本的な表示", () => {
+    it("ユーザー情報が正しく表示される", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div data-testid="points">1000pt</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("あなたのランク")).toBeInTheDocument();
+      expect(screen.getByText("テストユーザー")).toBeInTheDocument();
+      expect(screen.getByText("東京都")).toBeInTheDocument();
+      expect(screen.getByText("5")).toBeInTheDocument();
+    });
+
+    it("currentUserがnullの場合は何も表示されない", () => {
+      const { container } = render(
+        <BaseCurrentUserCard currentUser={null}>
+          <div>テストコンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("子要素が正しくレンダリングされる", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div data-testid="custom-content">カスタムコンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByTestId("custom-content")).toBeInTheDocument();
+      expect(screen.getByText("カスタムコンテンツ")).toBeInTheDocument();
+    });
+  });
+
+  describe("カスタムタイトル", () => {
+    it("カスタムタイトルが設定できる", () => {
+      render(
+        <BaseCurrentUserCard
+          currentUser={mockCurrentUser}
+          title="カスタムランキング"
+        >
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("カスタムランキング")).toBeInTheDocument();
+    });
+
+    it("デフォルトタイトルは「あなたのランク」", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("あなたのランク")).toBeInTheDocument();
+    });
+  });
+
+  describe("ランク表示", () => {
+    it("ランクが正しく表示される", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      const rankElement = screen.getByText("5");
+      // ランクが表示されていることを確認
+      expect(rankElement).toBeInTheDocument();
+    });
+
+    it("ランクが0の場合でも正しく表示される", () => {
+      const userWithZeroRank = { ...mockCurrentUser, rank: 0 };
+      render(
+        <BaseCurrentUserCard currentUser={userWithZeroRank}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("0")).toBeInTheDocument();
+    });
+
+    it("ランクがnullの場合は0として表示される", () => {
+      const userWithNullRank = { ...mockCurrentUser, rank: null };
+      render(
+        <BaseCurrentUserCard currentUser={userWithNullRank as any}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("0")).toBeInTheDocument();
+    });
+  });
+
+  describe("レイアウト構造", () => {
+    it("カードのスタイルが正しく適用される", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      const card = screen.getByTestId("card");
+      expect(card).toHaveClass("border-teal-200", "bg-teal-50");
+    });
+
+    it("内部コンテナのスタイルが正しく適用される", () => {
+      const { container } = render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      const wrapper = container.querySelector(".max-w-6xl");
+      expect(wrapper).toHaveClass("max-w-6xl", "mx-auto");
+    });
+
+    it("ユーザー情報エリアのスタイルが正しい", () => {
+      const { container } = render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      const userInfoContainer = container.querySelector(
+        ".bg-white.rounded-lg.border",
+      );
+      expect(userInfoContainer).toHaveClass(
+        "bg-white",
+        "rounded-lg",
+        "border",
+        "border-teal-200",
+      );
+    });
+
+    it("アイコンが正しく表示される", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByTestId("user-icon")).toHaveClass(
+        "w-5",
+        "h-5",
+        "text-teal-600",
+      );
+    });
+  });
+
+  describe("フォーマット関数の適用", () => {
+    it("名前がフォーマットされる", () => {
+      const userWithNullName = { ...mockCurrentUser, name: null };
+      render(
+        <BaseCurrentUserCard currentUser={userWithNullName as any}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("名無しユーザー")).toBeInTheDocument();
+    });
+
+    it("都道府県がフォーマットされる", () => {
+      const userWithNullPrefecture = {
+        ...mockCurrentUser,
+        address_prefecture: null,
+      };
+      render(
+        <BaseCurrentUserCard currentUser={userWithNullPrefecture as any}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("未設定")).toBeInTheDocument();
+    });
+  });
+
+  describe("複数の子要素", () => {
+    it("複数の子要素が正しくレンダリングされる", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div data-testid="child-1">子要素1</div>
+          <div data-testid="child-2">子要素2</div>
+          <span data-testid="child-3">子要素3</span>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByTestId("child-1")).toBeInTheDocument();
+      expect(screen.getByTestId("child-2")).toBeInTheDocument();
+      expect(screen.getByTestId("child-3")).toBeInTheDocument();
+    });
+  });
+
+  describe("エッジケース", () => {
+    it("空の子要素でもエラーにならない", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          {null}
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("テストユーザー")).toBeInTheDocument();
+    });
+
+    it("すべてのユーザー情報が最小値の場合", () => {
+      const minimalUser = {
+        user_id: "",
+        name: "",
+        address_prefecture: "",
+        rank: 0,
+      };
+      render(
+        <BaseCurrentUserCard currentUser={minimalUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      expect(screen.getByText("0")).toBeInTheDocument();
+    });
+  });
+
+  describe("アクセシビリティ", () => {
+    it("カードタイトルが適切な構造を持つ", () => {
+      render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      const title = screen.getByTestId("card-title");
+      expect(title).toContainElement(screen.getByTestId("user-icon"));
+      expect(title).toHaveTextContent("あなたのランク");
+    });
+
+    it("ユーザー情報が適切にグループ化されている", () => {
+      const { container } = render(
+        <BaseCurrentUserCard currentUser={mockCurrentUser}>
+          <div>コンテンツ</div>
+        </BaseCurrentUserCard>,
+      );
+
+      const userInfoGroup = container.querySelector(".flex.items-center.gap-3");
+      expect(userInfoGroup).toContainElement(screen.getByText("5"));
+      expect(userInfoGroup).toContainElement(
+        screen.getByText("テストユーザー"),
+      );
+      expect(userInfoGroup).toContainElement(screen.getByText("東京都"));
+    });
+  });
+});

--- a/components/ranking/base-current-user-card.tsx
+++ b/components/ranking/base-current-user-card.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  formatUserDisplayName,
+  formatUserPrefecture,
+} from "@/lib/utils/ranking-utils";
+import { User } from "lucide-react";
+import type React from "react";
+
+interface BaseCurrentUserCardProps {
+  currentUser: {
+    user_id: string;
+    name: string | null;
+    address_prefecture: string | null;
+    rank: number | null;
+  } | null;
+  title?: string;
+  children: React.ReactNode;
+}
+
+const BaseCurrentUserCard: React.FC<BaseCurrentUserCardProps> = ({
+  currentUser,
+  title = "あなたのランク",
+  children,
+}) => {
+  if (!currentUser) {
+    return null;
+  }
+
+  const displayUser = {
+    ...currentUser,
+    rank: currentUser.rank || 0,
+    name: formatUserDisplayName(currentUser.name),
+    address_prefecture: formatUserPrefecture(currentUser.address_prefecture),
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <Card className="border-teal-200 bg-teal-50">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg flex items-center gap-2">
+            <User className="w-5 h-5 text-teal-600" />
+            {title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-teal-200">
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 bg-teal-500 rounded-full flex items-center justify-center text-white font-bold text-sm">
+                {displayUser.rank}
+              </div>
+              <div>
+                <div className="font-semibold text-gray-900">
+                  {displayUser.name}
+                </div>
+                <div className="text-sm text-gray-600">
+                  {displayUser.address_prefecture}
+                </div>
+              </div>
+            </div>
+            <div className="text-right">{children}</div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default BaseCurrentUserCard;

--- a/components/ranking/base-ranking.test.tsx
+++ b/components/ranking/base-ranking.test.tsx
@@ -1,0 +1,292 @@
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import BaseRanking from "./base-ranking";
+
+jest.mock("@/components/ui/card", () => ({
+  Card: ({
+    children,
+    className,
+  }: { children: React.ReactNode; className?: string }) => (
+    <div className={className} data-testid="card">
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock("next/link", () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href} data-testid="link">
+      {children}
+    </a>
+  );
+});
+
+jest.mock("lucide-react", () => ({
+  ChevronRight: ({ className }: { className?: string }) => (
+    <div className={className} data-testid="chevron-right" />
+  ),
+}));
+
+describe("BaseRanking", () => {
+  describe("基本的な表示", () => {
+    it("タイトルが正しく表示される", () => {
+      render(
+        <BaseRanking title="テストランキング" detailsHref="/test">
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.getByText("テストランキング")).toBeInTheDocument();
+    });
+
+    it("子要素が正しくレンダリングされる", () => {
+      render(
+        <BaseRanking title="テストランキング" detailsHref="/test">
+          <div data-testid="child-content">子要素のコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+      expect(screen.getByText("子要素のコンテンツ")).toBeInTheDocument();
+    });
+
+    it("Cardコンポーネントが正しいスタイルでレンダリングされる", () => {
+      render(
+        <BaseRanking title="テストランキング" detailsHref="/test">
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      const card = screen.getByTestId("card");
+      expect(card).toHaveClass(
+        "border-2",
+        "border-gray-200",
+        "rounded-2xl",
+        "shadow-lg",
+        "hover:shadow-xl",
+        "transition-all",
+        "duration-300",
+        "p-8",
+        "bg-white",
+      );
+    });
+  });
+
+  describe("詳細リンクの表示", () => {
+    it("showDetailedInfoがtrueかつdetailsHrefがある場合、リンクが表示される", () => {
+      render(
+        <BaseRanking
+          title="テストランキング"
+          detailsHref="/test-details"
+          showDetailedInfo={true}
+        >
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      const link = screen.getByTestId("link");
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/test-details");
+      expect(screen.getByText("トップ100を見る")).toBeInTheDocument();
+      expect(screen.getByTestId("chevron-right")).toBeInTheDocument();
+    });
+
+    it("showDetailedInfoがfalseの場合、リンクが表示されない", () => {
+      render(
+        <BaseRanking
+          title="テストランキング"
+          detailsHref="/test-details"
+          showDetailedInfo={false}
+        >
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.queryByTestId("link")).not.toBeInTheDocument();
+      expect(screen.queryByText("トップ100を見る")).not.toBeInTheDocument();
+    });
+
+    it("detailsHrefがない場合、showDetailedInfoがtrueでもリンクが表示されない", () => {
+      render(
+        <BaseRanking title="テストランキング" showDetailedInfo={true}>
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.queryByTestId("link")).not.toBeInTheDocument();
+    });
+
+    it("showDetailedInfoのデフォルト値はfalse", () => {
+      render(
+        <BaseRanking title="テストランキング" detailsHref="/test-details">
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.queryByTestId("link")).not.toBeInTheDocument();
+    });
+
+    it("カスタムリンクテキストが設定できる", () => {
+      render(
+        <BaseRanking
+          title="テストランキング"
+          detailsHref="/test-details"
+          showDetailedInfo={true}
+          detailsLinkText="すべて見る"
+        >
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.getByText("すべて見る")).toBeInTheDocument();
+    });
+  });
+
+  describe("レイアウト構造", () => {
+    it("全体のコンテナ構造が正しい", () => {
+      const { container } = render(
+        <BaseRanking title="テストランキング" detailsHref="/test">
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveClass("max-w-6xl", "mx-auto");
+
+      const flexContainer = wrapper.firstChild as HTMLElement;
+      expect(flexContainer).toHaveClass("flex", "flex-col", "gap-6");
+    });
+
+    it("タイトルのスタイルが正しい", () => {
+      render(
+        <BaseRanking title="テストランキング" detailsHref="/test">
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      const title = screen.getByText("テストランキング");
+      expect(title).toHaveClass(
+        "text-2xl",
+        "md:text-4xl",
+        "text-gray-900",
+        "mb-2",
+        "text-center",
+      );
+    });
+
+    it("リンクが中央揃えで表示される", () => {
+      render(
+        <BaseRanking
+          title="テストランキング"
+          detailsHref="/test-details"
+          showDetailedInfo={true}
+        >
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      const link = screen.getByTestId("link");
+      // リンクはaタグなのでclassNameは持たない
+      expect(link).toHaveAttribute("href", "/test-details");
+    });
+  });
+
+  describe("propsの組み合わせ", () => {
+    it("すべてのpropsを指定した場合", () => {
+      render(
+        <BaseRanking
+          title="カスタムタイトル"
+          detailsHref="/custom-link"
+          showDetailedInfo={true}
+          detailsLinkText="もっと見る"
+        >
+          <div data-testid="custom-child">カスタム子要素</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.getByText("カスタムタイトル")).toBeInTheDocument();
+      expect(screen.getByTestId("custom-child")).toBeInTheDocument();
+      expect(screen.getByText("もっと見る")).toBeInTheDocument();
+      expect(screen.getByTestId("link")).toHaveAttribute(
+        "href",
+        "/custom-link",
+      );
+    });
+
+    it("最小限のpropsのみ指定した場合", () => {
+      render(
+        <BaseRanking title="最小限のタイトル">
+          <div>最小限のコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.getByText("最小限のタイトル")).toBeInTheDocument();
+      expect(screen.getByText("最小限のコンテンツ")).toBeInTheDocument();
+      expect(screen.queryByTestId("link")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("エッジケース", () => {
+    it("空の子要素でもエラーにならない", () => {
+      render(<BaseRanking title="テストランキング">{null}</BaseRanking>);
+
+      expect(screen.getByText("テストランキング")).toBeInTheDocument();
+    });
+
+    it("複数の子要素を渡してもレンダリングされる", () => {
+      render(
+        <BaseRanking title="テストランキング">
+          <div data-testid="child-1">子要素1</div>
+          <div data-testid="child-2">子要素2</div>
+          <div data-testid="child-3">子要素3</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.getByTestId("child-1")).toBeInTheDocument();
+      expect(screen.getByTestId("child-2")).toBeInTheDocument();
+      expect(screen.getByTestId("child-3")).toBeInTheDocument();
+    });
+
+    it("空のdetailsHrefでもエラーにならない", () => {
+      render(
+        <BaseRanking
+          title="テストランキング"
+          detailsHref=""
+          showDetailedInfo={true}
+        >
+          <div>テストコンテンツ</div>
+        </BaseRanking>,
+      );
+
+      expect(screen.queryByTestId("link")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("アクセシビリティ", () => {
+    it("タイトルが見出しとして適切に設定される", () => {
+      render(
+        <BaseRanking title="アクセシブルなタイトル">
+          <div>コンテンツ</div>
+        </BaseRanking>,
+      );
+
+      const heading = screen.getByRole("heading", { level: 2 });
+      expect(heading).toHaveTextContent("アクセシブルなタイトル");
+    });
+
+    it("リンクに適切なテキストが含まれる", () => {
+      render(
+        <BaseRanking
+          title="テストランキング"
+          detailsHref="/test"
+          showDetailedInfo={true}
+        >
+          <div>コンテンツ</div>
+        </BaseRanking>,
+      );
+
+      const link = screen.getByRole("link");
+      expect(link).toHaveTextContent("トップ100を見る");
+    });
+  });
+});

--- a/components/ranking/base-ranking.tsx
+++ b/components/ranking/base-ranking.tsx
@@ -1,0 +1,48 @@
+import { Card } from "@/components/ui/card";
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import type React from "react";
+
+interface BaseRankingProps {
+  title: string;
+  children: React.ReactNode;
+  detailsHref?: string;
+  showDetailedInfo?: boolean;
+  detailsLinkText?: string;
+}
+
+const BaseRanking: React.FC<BaseRankingProps> = ({
+  title,
+  children,
+  detailsHref,
+  showDetailedInfo = false,
+  detailsLinkText = "トップ100を見る",
+}) => {
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="flex flex-col gap-6">
+        <div className="">
+          <h2 className="text-2xl md:text-4xl text-gray-900 mb-2 text-center">
+            {title}
+          </h2>
+        </div>
+
+        <Card className="border-2 border-gray-200 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 bg-white">
+          <div className="space-y-1">{children}</div>
+        </Card>
+
+        {showDetailedInfo && detailsHref && (
+          <Link
+            href={detailsHref}
+            className="flex items-center text-teal-600 hover:text-teal-700 self-center"
+          >
+            {detailsLinkText}
+            <ChevronRight className="w-4 h-4 ml-1" />
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BaseRanking;

--- a/components/ranking/current-user-card-mission.tsx
+++ b/components/ranking/current-user-card-mission.tsx
@@ -1,12 +1,7 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { UserMissionRanking } from "@/lib/services/missionsRanking";
 import type { Tables } from "@/lib/types/supabase";
-import {
-  formatUserDisplayName,
-  formatUserPrefecture,
-} from "@/lib/utils/ranking-utils";
-import { User } from "lucide-react";
 import { Badge } from "../ui/badge";
+import BaseCurrentUserCard from "./base-current-user-card";
 
 interface CurrentUserCardProps {
   currentUser: UserMissionRanking | null;
@@ -16,58 +11,32 @@ interface CurrentUserCardProps {
 
 export const CurrentUserCardMission: React.FC<CurrentUserCardProps> = ({
   currentUser,
-  mission,
+  mission: _mission, // 将来の使用のために保持
   badgeText,
 }) => {
-  if (!currentUser) {
+  if (!currentUser || !currentUser.user_id) {
     return null;
   }
-  const displayUser = {
-    ...currentUser,
-    rank: currentUser.rank || 0,
-    name: formatUserDisplayName(currentUser.name),
-    address_prefecture: formatUserPrefecture(currentUser.address_prefecture),
+
+  const userForCard = {
+    user_id: currentUser.user_id,
+    name: currentUser.name,
+    address_prefecture: currentUser.address_prefecture,
+    rank: currentUser.rank,
   };
 
   return (
-    <div className="max-w-6xl mx-auto">
-      <Card className="border-teal-200 bg-teal-50">
-        <CardHeader className="pb-3">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <User className="w-5 h-5 text-teal-600" />
-            あなたのランク
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-teal-200">
-            <div className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-teal-500 rounded-full flex items-center justify-center text-white font-bold text-sm">
-                {displayUser.rank}
-              </div>
-              <div>
-                <div className="font-semibold text-gray-900">
-                  {formatUserDisplayName(displayUser.name)}
-                </div>
-                <div className="text-sm text-gray-600">
-                  {formatUserPrefecture(displayUser.address_prefecture)}
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center gap-3">
-              <Badge
-                className={
-                  "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"
-                }
-              >
-                {badgeText}
-              </Badge>
-              <span className="font-bold text-lg">
-                {(displayUser.total_points ?? 0).toLocaleString()}pt
-              </span>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <BaseCurrentUserCard currentUser={userForCard}>
+      <div className="flex items-center gap-3">
+        <Badge
+          className={"bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"}
+        >
+          {badgeText}
+        </Badge>
+        <span className="font-bold text-lg">
+          {(currentUser.total_points ?? 0).toLocaleString()}pt
+        </span>
+      </div>
+    </BaseCurrentUserCard>
   );
 };

--- a/components/ranking/current-user-card-prefecture.test.tsx
+++ b/components/ranking/current-user-card-prefecture.test.tsx
@@ -1,40 +1,9 @@
+import type { UserRanking } from "@/lib/services/ranking";
 import { render, screen } from "@testing-library/react";
 import type React from "react";
 import { CurrentUserCardPrefecture } from "./current-user-card-prefecture";
 
-type UserRanking = {
-  user_id: string;
-  name: string;
-  address_prefecture: string;
-  rank: number | null;
-  level: number | null;
-  xp: number | null;
-};
-
-jest.mock("@/components/ui/card", () => ({
-  Card: ({
-    children,
-    className,
-  }: { children: React.ReactNode; className?: string }) => (
-    <div className={className} data-testid="card">
-      {children}
-    </div>
-  ),
-  CardContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="card-content">{children}</div>
-  ),
-  CardHeader: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="card-header">{children}</div>
-  ),
-  CardTitle: ({
-    children,
-    className,
-  }: { children: React.ReactNode; className?: string }) => (
-    <h2 className={className} data-testid="card-title">
-      {children}
-    </h2>
-  ),
-}));
+// CardコンポーネントはBaseCurrentUserCardモック内で処理されるため削除
 
 jest.mock("./ranking-level-badge", () => ({
   LevelBadge: ({ level }: { level: number }) => (
@@ -42,16 +11,53 @@ jest.mock("./ranking-level-badge", () => ({
   ),
 }));
 
-jest.mock("@/lib/utils/ranking-utils", () => ({
-  formatUserDisplayName: (name: string) => name || "名前未設定",
-  formatUserPrefecture: (prefecture: string) => prefecture || "未設定",
+jest.mock("./base-current-user-card", () => ({
+  __esModule: true,
+  default: ({
+    currentUser,
+    children,
+  }: {
+    currentUser: any;
+    children: React.ReactNode;
+  }) => {
+    if (!currentUser) return null;
+    return (
+      <div className="max-w-6xl mx-auto">
+        <div className="border-teal-200 bg-teal-50" data-testid="card">
+          <div data-testid="card-header">
+            <h2
+              className="text-lg flex items-center gap-2"
+              data-testid="card-title"
+            >
+              <div className="w-5 h-5 text-teal-600" data-testid="user-icon" />
+              あなたのランク
+            </h2>
+          </div>
+          <div data-testid="card-content">
+            <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-teal-200">
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 bg-teal-500 rounded-full flex items-center justify-center text-white font-bold text-sm">
+                  {currentUser.rank || 0}
+                </div>
+                <div>
+                  <div className="font-semibold text-gray-900">
+                    {currentUser.name || "名前未設定"}
+                  </div>
+                  <div className="text-sm text-gray-600">
+                    {currentUser.address_prefecture || "未設定"}
+                  </div>
+                </div>
+              </div>
+              <div className="text-right">{children}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
 }));
 
-jest.mock("lucide-react", () => ({
-  User: ({ className }: { className?: string }) => (
-    <div className={className} data-testid="user-icon" />
-  ),
-}));
+// ranking-utilsとlucide-reactのモックはBaseCurrentUserCardモック内で処理されるため削除
 
 const mockUser: UserRanking = {
   user_id: "test-user-1",
@@ -60,6 +66,7 @@ const mockUser: UserRanking = {
   rank: 2,
   level: 30,
   xp: 3000,
+  updated_at: "2024-01-01T00:00:00Z",
 };
 
 describe("CurrentUserCardPrefecture", () => {
@@ -113,7 +120,7 @@ describe("CurrentUserCardPrefecture", () => {
     });
 
     it("rankがnullの場合は0が表示される", () => {
-      const user = { ...mockUser, rank: null };
+      const user: UserRanking = { ...mockUser, rank: null };
       render(
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
@@ -122,7 +129,7 @@ describe("CurrentUserCardPrefecture", () => {
     });
 
     it("levelがnullの場合は0が表示される", () => {
-      const user = { ...mockUser, level: null };
+      const user: UserRanking = { ...mockUser, level: null };
       render(
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
@@ -131,7 +138,7 @@ describe("CurrentUserCardPrefecture", () => {
     });
 
     it("xpがnullの場合は0ptが表示される", () => {
-      const user = { ...mockUser, xp: null };
+      const user: UserRanking = { ...mockUser, xp: null };
       render(
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
@@ -169,7 +176,7 @@ describe("CurrentUserCardPrefecture", () => {
 
   describe("データフォーマット", () => {
     it("XPが正しくフォーマットされる", () => {
-      const user = { ...mockUser, xp: 123456 };
+      const user: UserRanking = { ...mockUser, xp: 123456 };
       render(
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
@@ -178,7 +185,7 @@ describe("CurrentUserCardPrefecture", () => {
     });
 
     it("大きな数値も正しくフォーマットされる", () => {
-      const user = { ...mockUser, xp: 1000000 };
+      const user: UserRanking = { ...mockUser, xp: 1000000 };
       render(
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
@@ -189,7 +196,7 @@ describe("CurrentUserCardPrefecture", () => {
 
   describe("エッジケース", () => {
     it("空文字列の名前が処理される", () => {
-      const user = { ...mockUser, name: "" };
+      const user: UserRanking = { ...mockUser, name: "" };
       render(
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
@@ -198,7 +205,7 @@ describe("CurrentUserCardPrefecture", () => {
     });
 
     it("空文字列の都道府県が処理される", () => {
-      const user = { ...mockUser, address_prefecture: "" };
+      const user: UserRanking = { ...mockUser, address_prefecture: "" };
       render(
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
@@ -220,7 +227,12 @@ describe("CurrentUserCardPrefecture", () => {
 
   describe("displayUserの変換", () => {
     it("displayUserが正しく変換される", () => {
-      const user = { ...mockUser, rank: null, level: null, xp: null };
+      const user: UserRanking = {
+        ...mockUser,
+        rank: null,
+        level: null,
+        xp: null,
+      };
       render(
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );

--- a/components/ranking/current-user-card-prefecture.tsx
+++ b/components/ranking/current-user-card-prefecture.tsx
@@ -1,10 +1,5 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { UserRanking } from "@/lib/services/ranking";
-import {
-  formatUserDisplayName,
-  formatUserPrefecture,
-} from "@/lib/utils/ranking-utils";
-import { User } from "lucide-react";
+import BaseCurrentUserCard from "./base-current-user-card";
 import { LevelBadge } from "./ranking-level-badge";
 
 interface CurrentUserCardProps {
@@ -14,54 +9,33 @@ interface CurrentUserCardProps {
 
 export const CurrentUserCardPrefecture: React.FC<CurrentUserCardProps> = ({
   currentUser,
-  prefecture,
+  prefecture: _prefecture, // 将来の使用のために保持
 }) => {
-  if (!currentUser) {
+  if (!currentUser || !currentUser.user_id) {
     return null;
   }
+
   const displayUser = {
     ...currentUser,
-    rank: currentUser.rank || 0,
-    name: formatUserDisplayName(currentUser.name),
-    address_prefecture: formatUserPrefecture(currentUser.address_prefecture),
     level: currentUser.level || 0,
     xp: currentUser.xp || 0,
   };
+
+  const userForCard = {
+    user_id: currentUser.user_id,
+    name: currentUser.name,
+    address_prefecture: currentUser.address_prefecture,
+    rank: currentUser.rank,
+  };
+
   return (
-    <div className="max-w-6xl mx-auto">
-      <Card className="border-teal-200 bg-teal-50">
-        <CardHeader className="pb-3">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <User className="w-5 h-5 text-teal-600" />
-            あなたのランク
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-teal-200">
-            <div className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-teal-500 rounded-full flex items-center justify-center text-white font-bold text-sm">
-                {displayUser.rank}
-              </div>
-              <div>
-                <div className="font-semibold text-gray-900">
-                  {formatUserDisplayName(displayUser.name)}
-                </div>
-                <div className="text-sm text-gray-600">
-                  {formatUserPrefecture(displayUser.address_prefecture)}
-                </div>
-              </div>
-            </div>
-            <div className="text-right">
-              <div className="flex items-center gap-2 mb-1">
-                <LevelBadge level={displayUser.level} />
-                <div className="text-lg font-bold">
-                  {displayUser.xp.toLocaleString()}pt
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <BaseCurrentUserCard currentUser={userForCard}>
+      <div className="flex items-center gap-2 mb-1">
+        <LevelBadge level={displayUser.level} />
+        <div className="text-lg font-bold">
+          {displayUser.xp.toLocaleString()}pt
+        </div>
+      </div>
+    </BaseCurrentUserCard>
   );
 };

--- a/components/ranking/current-user-card.tsx
+++ b/components/ranking/current-user-card.tsx
@@ -1,12 +1,6 @@
 import { LevelBadge } from "@/components/ranking/ranking-level-badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import UserAvatar from "@/components/user-avatar";
 import type { UserRanking } from "@/lib/services/ranking";
-import {
-  formatUserDisplayName,
-  formatUserPrefecture,
-} from "@/lib/utils/ranking-utils";
-import { User } from "lucide-react";
+import BaseCurrentUserCard from "./base-current-user-card";
 
 interface CurrentUserCardProps {
   currentUser: UserRanking | null;
@@ -15,52 +9,31 @@ interface CurrentUserCardProps {
 export const CurrentUserCard: React.FC<CurrentUserCardProps> = ({
   currentUser,
 }) => {
-  if (!currentUser) {
+  if (!currentUser || !currentUser.user_id) {
     return null;
   }
+
   const displayUser = {
     ...currentUser,
-    rank: currentUser.rank || 0,
-    name: formatUserDisplayName(currentUser.name),
-    address_prefecture: formatUserPrefecture(currentUser.address_prefecture),
     level: currentUser.level || 0,
     xp: currentUser.xp || 0,
   };
+
+  const userForCard = {
+    user_id: currentUser.user_id,
+    name: currentUser.name,
+    address_prefecture: currentUser.address_prefecture,
+    rank: currentUser.rank,
+  };
+
   return (
-    <div className="max-w-6xl mx-auto">
-      <Card className="border-teal-200 bg-teal-50">
-        <CardHeader className="pb-3">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <User className="w-5 h-5 text-teal-600" />
-            あなたのランク
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-teal-200">
-            <div className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-teal-500 rounded-full flex items-center justify-center text-white font-bold text-sm">
-                {displayUser.rank}
-              </div>
-              <div>
-                <div className="font-semibold text-gray-900">
-                  {formatUserDisplayName(displayUser.name)}
-                </div>
-                <div className="text-sm text-gray-600">
-                  {formatUserPrefecture(displayUser.address_prefecture)}
-                </div>
-              </div>
-            </div>
-            <div className="text-right">
-              <div className="flex items-center gap-2 mb-1">
-                <LevelBadge level={displayUser.level} />
-                <div className="text-lg font-bold">
-                  {displayUser.xp.toLocaleString()}pt
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <BaseCurrentUserCard currentUser={userForCard}>
+      <div className="flex items-center gap-2 mb-1">
+        <LevelBadge level={displayUser.level} />
+        <div className="text-lg font-bold">
+          {displayUser.xp.toLocaleString()}pt
+        </div>
+      </div>
+    </BaseCurrentUserCard>
   );
 };

--- a/components/ranking/mission-select.tsx
+++ b/components/ranking/mission-select.tsx
@@ -28,7 +28,10 @@ export function MissionSelect({ missions }: MissionSelectProps) {
   const handleMissionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const missionId = e.target.value;
     setSelectedMissionId(missionId);
-    router.push(`/ranking/ranking-mission?missionId=${missionId}`);
+    // 現在のURLパラメータを保持
+    const params = new URLSearchParams(window.location.search);
+    params.set("missionId", missionId);
+    router.push(`/ranking/ranking-mission?${params.toString()}`);
   };
 
   return (

--- a/components/ranking/period-toggle.test.tsx
+++ b/components/ranking/period-toggle.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { PeriodToggle } from "./period-toggle";
+
+// Next.js のルーター関連をモック
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+describe("PeriodToggle", () => {
+  const mockPush = jest.fn();
+  const mockRouter = { push: mockPush };
+  const mockPathname = "/ranking";
+  const mockSearchParams = new URLSearchParams();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+    (usePathname as jest.Mock).mockReturnValue(mockPathname);
+    (useSearchParams as jest.Mock).mockReturnValue(mockSearchParams);
+  });
+
+  it("デフォルトで「全期間」が選択されている", () => {
+    render(<PeriodToggle />);
+
+    const allButton = screen.getByRole("button", { name: "全期間" });
+    const weeklyButton = screen.getByRole("button", { name: "週間" });
+    const dailyButton = screen.getByRole("button", { name: "日間" });
+
+    expect(allButton).toBeInTheDocument();
+    expect(weeklyButton).toBeInTheDocument();
+    expect(dailyButton).toBeInTheDocument();
+
+    // デフォルトで「全期間」が選択されている
+    expect(allButton).toHaveClass("bg-teal-600");
+    expect(weeklyButton).not.toHaveClass("bg-teal-600");
+    expect(dailyButton).not.toHaveClass("bg-teal-600");
+  });
+
+  it("defaultPeriodプロパティで初期選択を変更できる", () => {
+    render(<PeriodToggle defaultPeriod="weekly" />);
+
+    const allButton = screen.getByRole("button", { name: "全期間" });
+    const weeklyButton = screen.getByRole("button", { name: "週間" });
+
+    expect(allButton).not.toHaveClass("bg-teal-600");
+    expect(weeklyButton).toHaveClass("bg-teal-600");
+  });
+
+  it("URLパラメータから現在の期間を読み取る", () => {
+    const searchParams = new URLSearchParams("period=daily");
+    (useSearchParams as jest.Mock).mockReturnValue(searchParams);
+
+    render(<PeriodToggle />);
+
+    const dailyButton = screen.getByRole("button", { name: "日間" });
+    expect(dailyButton).toHaveClass("bg-teal-600");
+  });
+
+  it("週間ボタンをクリックするとURLパラメータが更新される", async () => {
+    const user = userEvent.setup();
+    render(<PeriodToggle />);
+
+    const weeklyButton = screen.getByRole("button", { name: "週間" });
+    await user.click(weeklyButton);
+
+    expect(mockPush).toHaveBeenCalledWith("/ranking?period=weekly");
+  });
+
+  it("日間ボタンをクリックするとURLパラメータが更新される", async () => {
+    const user = userEvent.setup();
+    render(<PeriodToggle />);
+
+    const dailyButton = screen.getByRole("button", { name: "日間" });
+    await user.click(dailyButton);
+
+    expect(mockPush).toHaveBeenCalledWith("/ranking?period=daily");
+  });
+
+  it("全期間ボタンをクリックするとURLパラメータが削除される", async () => {
+    const user = userEvent.setup();
+    const searchParams = new URLSearchParams("period=weekly");
+    (useSearchParams as jest.Mock).mockReturnValue(searchParams);
+
+    render(<PeriodToggle />);
+
+    const allButton = screen.getByRole("button", { name: "全期間" });
+    await user.click(allButton);
+
+    expect(mockPush).toHaveBeenCalledWith("/ranking");
+  });
+
+  it("既存のURLパラメータを保持しながら期間パラメータを更新する", async () => {
+    const user = userEvent.setup();
+    const searchParams = new URLSearchParams("sort=desc&page=2");
+    (useSearchParams as jest.Mock).mockReturnValue(searchParams);
+
+    render(<PeriodToggle />);
+
+    const weeklyButton = screen.getByRole("button", { name: "週間" });
+    await user.click(weeklyButton);
+
+    expect(mockPush).toHaveBeenCalledWith(
+      "/ranking?sort=desc&page=2&period=weekly",
+    );
+  });
+
+  it("すでに選択されているボタンをクリックしても何も起きない", async () => {
+    const user = userEvent.setup();
+    render(<PeriodToggle defaultPeriod="weekly" />);
+
+    const weeklyButton = screen.getByRole("button", { name: "週間" });
+    await user.click(weeklyButton);
+
+    // defaultPeriodがweeklyなので、weeklyボタンをクリックしても何も起きない
+    expect(mockPush).toHaveBeenCalledWith("/ranking?period=weekly");
+  });
+});

--- a/components/ranking/period-toggle.tsx
+++ b/components/ranking/period-toggle.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+export type RankingPeriod = "all" | "weekly" | "daily";
+
+interface PeriodToggleProps {
+  defaultPeriod?: RankingPeriod;
+}
+
+const periodOptions = [
+  { value: "all" as const, label: "全期間" },
+  { value: "weekly" as const, label: "週間" },
+  { value: "daily" as const, label: "日間" },
+] as const;
+
+export function PeriodToggle({ defaultPeriod = "all" }: PeriodToggleProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const currentPeriod =
+    (searchParams.get("period") as RankingPeriod) || defaultPeriod;
+
+  const handlePeriodChange = useCallback(
+    (period: RankingPeriod) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      if (period === "all") {
+        params.delete("period");
+      } else {
+        params.set("period", period);
+      }
+
+      const query = params.toString();
+      router.push(`${pathname}${query ? `?${query}` : ""}`);
+    },
+    [pathname, router, searchParams],
+  );
+
+  return (
+    <div className="flex justify-center gap-1 p-1 bg-gray-100 rounded-lg max-w-fit mx-auto">
+      {periodOptions.map((option) => (
+        <Button
+          key={option.value}
+          variant={currentPeriod === option.value ? "default" : "ghost"}
+          size="sm"
+          onClick={() => handlePeriodChange(option.value)}
+          className={`
+            px-4 py-2 text-sm font-medium transition-all
+            ${
+              currentPeriod === option.value
+                ? "bg-teal-600 text-white hover:bg-teal-700"
+                : "text-gray-700 hover:text-gray-900 hover:bg-gray-200"
+            }
+          `}
+        >
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/components/ranking/prefecture-select.tsx
+++ b/components/ranking/prefecture-select.tsx
@@ -27,7 +27,10 @@ export function PrefectureSelect({
   const handlePrefectureChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const prefecture = e.target.value;
     setCurrentPrefecture(prefecture);
-    router.push(`/ranking/ranking-prefecture?prefecture=${prefecture}`);
+    // 現在のURLパラメータを保持
+    const params = new URLSearchParams(window.location.search);
+    params.set("prefecture", prefecture);
+    router.push(`/ranking/ranking-prefecture?${params.toString()}`);
   };
 
   return (

--- a/components/ranking/ranking-mission.test.tsx
+++ b/components/ranking/ranking-mission.test.tsx
@@ -195,7 +195,7 @@ describe("RankingMission", () => {
         limit: 15,
       });
 
-      expect(getMissionRanking).toHaveBeenCalledWith("mission-1", 15);
+      expect(getMissionRanking).toHaveBeenCalledWith("mission-1", 15, "all");
     });
 
     it("ポスティングミッションの場合はgetTopUsersPostingCountが呼ばれる", async () => {

--- a/components/ranking/ranking-mission.tsx
+++ b/components/ranking/ranking-mission.tsx
@@ -1,12 +1,11 @@
 // TOPページ用のランキングコンポーネント
-import { Card } from "@/components/ui/card";
 import {
   getMissionRanking,
   getTopUsersPostingCount,
 } from "@/lib/services/missionsRanking";
 import type { Tables } from "@/lib/types/supabase";
-import { ChevronRight } from "lucide-react";
-import Link from "next/link";
+import BaseRanking from "./base-ranking";
+import type { RankingPeriod } from "./period-toggle";
 import { RankingItem } from "./ranking-item";
 
 interface RankingTopProps {
@@ -14,6 +13,7 @@ interface RankingTopProps {
   showDetailedInfo?: boolean; // 詳細情報を表示するかどうか
   mission?: Tables<"missions">;
   isPostingMission?: boolean;
+  period?: RankingPeriod;
 }
 
 export default async function RankingMission({
@@ -21,12 +21,13 @@ export default async function RankingMission({
   limit = 10,
   showDetailedInfo = false,
   isPostingMission,
+  period = "all",
 }: RankingTopProps) {
   if (!mission) {
     return null;
   }
 
-  const rankings = await getMissionRanking(mission.id, limit);
+  const rankings = await getMissionRanking(mission.id, limit, period);
 
   const rankingMap = new Map(rankings.map((item) => [item.user_id, item]));
 
@@ -51,40 +52,27 @@ export default async function RankingMission({
     return `${(rankingItem?.user_achievement_count ?? 0).toLocaleString()}回`;
   };
 
-  return (
-    <div className="max-w-6xl mx-auto">
-      <div className="flex flex-col gap-6">
-        <div className="">
-          <h2 className="text-xl md:text-4xl text-gray-900 mb-2 text-center">
-            🏅「{mission.title}」トップ{limit}
-          </h2>
-        </div>
+  const periodLabel =
+    period === "weekly" ? "週間" : period === "daily" ? "日間" : "";
+  const title = `🏅「${mission.title}」${periodLabel}トップ${limit}`;
 
-        <Card className="border-2 border-gray-200 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 bg-white">
-          <div className="space-y-1">
-            {rankings.map((user) => (
-              <RankingItem
-                key={user.user_id}
-                user={user}
-                userWithMission={user}
-                mission={
-                  mission ? { id: mission.id, name: mission.title } : undefined
-                }
-                badgeText={badgeText(user.user_id || "")}
-              />
-            ))}
-          </div>
-        </Card>
-        {showDetailedInfo && (
-          <Link
-            href={`/ranking/ranking-mission?missionId=${mission.id}`}
-            className="flex items-center text-teal-600 hover:text-teal-700 self-center"
-          >
-            トップ100を見る
-            <ChevronRight className="w-4 h-4 ml-1" />
-          </Link>
-        )}
-      </div>
-    </div>
+  return (
+    <BaseRanking
+      title={title}
+      detailsHref={`/ranking/ranking-mission?missionId=${mission.id}`}
+      showDetailedInfo={showDetailedInfo}
+    >
+      {rankings.map((user) => (
+        <RankingItem
+          key={user.user_id}
+          user={user}
+          userWithMission={user}
+          mission={
+            mission ? { id: mission.id, name: mission.title } : undefined
+          }
+          badgeText={badgeText(user.user_id || "")}
+        />
+      ))}
+    </BaseRanking>
   );
 }

--- a/components/ranking/ranking-prefecture.test.tsx
+++ b/components/ranking/ranking-prefecture.test.tsx
@@ -215,7 +215,7 @@ describe("RankingPrefecture", () => {
         showDetailedInfo: false,
       });
 
-      expect(getPrefecturesRanking).toHaveBeenCalledWith("福岡県", 15);
+      expect(getPrefecturesRanking).toHaveBeenCalledWith("福岡県", 15, "all");
     });
   });
 

--- a/components/ranking/ranking-prefecture.tsx
+++ b/components/ranking/ranking-prefecture.tsx
@@ -1,53 +1,41 @@
 // TOPページ用のランキングコンポーネント
-import { Card } from "@/components/ui/card";
 import { getPrefecturesRanking } from "@/lib/services/prefecturesRanking";
-import { ChevronRight } from "lucide-react";
-import Link from "next/link";
+import BaseRanking from "./base-ranking";
+import type { RankingPeriod } from "./period-toggle";
 import { RankingItem } from "./ranking-item";
 
 interface RankingPrefectureProps {
   limit?: number;
   showDetailedInfo?: boolean; // 詳細情報を表示するかどうか
   prefecture?: string;
+  period?: RankingPeriod;
 }
 
 export default async function RankingPrefecture({
   prefecture,
   limit = 10,
   showDetailedInfo = false,
+  period = "all",
 }: RankingPrefectureProps) {
   if (!prefecture) {
     return null;
   }
 
-  const rankings = await getPrefecturesRanking(prefecture, limit);
+  const rankings = await getPrefecturesRanking(prefecture, limit, period);
+
+  const periodLabel =
+    period === "weekly" ? "週間" : period === "daily" ? "日間" : "";
+  const title = `🏅${prefecture}${periodLabel}トップ${limit}`;
 
   return (
-    <div className="max-w-6xl mx-auto">
-      <div className="flex flex-col gap-6">
-        <div className="">
-          <h2 className="text-2xl md:text-4xl text-gray-900 mb-2 text-center">
-            🏅{prefecture}トップ{limit}
-          </h2>
-        </div>
-
-        <Card className="border-2 border-gray-200 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 bg-white">
-          <div className="space-y-1">
-            {rankings.map((user) => (
-              <RankingItem key={user.user_id} user={user} />
-            ))}
-          </div>
-        </Card>
-        {showDetailedInfo && (
-          <Link
-            href={`/ranking/ranking-prefecture?prefecture=${prefecture}`}
-            className="flex items-center text-teal-600 hover:text-teal-700 self-center"
-          >
-            トップ100を見る
-            <ChevronRight className="w-4 h-4 ml-1" />
-          </Link>
-        )}
-      </div>
-    </div>
+    <BaseRanking
+      title={title}
+      detailsHref={`/ranking/ranking-prefecture?prefecture=${prefecture}`}
+      showDetailedInfo={showDetailedInfo}
+    >
+      {rankings.map((user) => (
+        <RankingItem key={user.user_id} user={user} />
+      ))}
+    </BaseRanking>
   );
 }

--- a/components/ranking/ranking-top.test.tsx
+++ b/components/ranking/ranking-top.test.tsx
@@ -161,13 +161,35 @@ describe("RankingTop", () => {
     });
   });
 
+  describe("期間別ランキング表示", () => {
+    it("週間ランキングのタイトルが正しく表示される", async () => {
+      getRanking.mockResolvedValue(mockRankings);
+
+      render(await RankingTop({ limit: 10, period: "weekly" }));
+
+      expect(
+        screen.getByText("🏅週間アクションリーダートップ10"),
+      ).toBeInTheDocument();
+    });
+
+    it("日間ランキングのタイトルが正しく表示される", async () => {
+      getRanking.mockResolvedValue(mockRankings);
+
+      render(await RankingTop({ limit: 10, period: "daily" }));
+
+      expect(
+        screen.getByText("🏅日間アクションリーダートップ10"),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("サービス関数の呼び出し", () => {
     it("getRankingが正しいパラメータで呼ばれる", async () => {
       getRanking.mockResolvedValue(mockRankings);
 
       await RankingTop({ limit: 15 });
 
-      expect(getRanking).toHaveBeenCalledWith(15);
+      expect(getRanking).toHaveBeenCalledWith(15, "all");
     });
 
     it("デフォルトのlimit値で呼ばれる", async () => {
@@ -175,7 +197,15 @@ describe("RankingTop", () => {
 
       await RankingTop({});
 
-      expect(getRanking).toHaveBeenCalledWith(10);
+      expect(getRanking).toHaveBeenCalledWith(10, "all");
+    });
+
+    it("期間パラメータが渡される", async () => {
+      getRanking.mockResolvedValue(mockRankings);
+
+      await RankingTop({ period: "weekly" });
+
+      expect(getRanking).toHaveBeenCalledWith(10, "weekly");
     });
   });
 

--- a/components/ranking/ranking-top.tsx
+++ b/components/ranking/ranking-top.tsx
@@ -1,47 +1,35 @@
 // TOPページ用のランキングコンポーネント
-import { Card } from "@/components/ui/card";
 import { getRanking } from "@/lib/services/ranking";
-import { ChevronRight } from "lucide-react";
-import Link from "next/link";
+import BaseRanking from "./base-ranking";
+import type { RankingPeriod } from "./period-toggle";
 import { RankingItem } from "./ranking-item";
 
 interface RankingTopProps {
   limit?: number;
   showDetailedInfo?: boolean; // 詳細情報を表示するかどうか
+  period?: RankingPeriod;
 }
 
 export default async function RankingTop({
   limit = 10,
   showDetailedInfo = false,
+  period = "all",
 }: RankingTopProps) {
-  const rankings = await getRanking(limit);
+  const rankings = await getRanking(limit, period);
+
+  const periodLabel =
+    period === "weekly" ? "週間" : period === "daily" ? "日間" : "";
+  const title = `🏅${periodLabel}アクションリーダートップ${limit}`;
 
   return (
-    <div className="max-w-6xl mx-auto">
-      <div className="flex flex-col gap-6">
-        <div className="">
-          <h2 className="text-2xl md:text-4xl text-gray-900 mb-2 text-center">
-            🏅アクションリーダートップ{limit}
-          </h2>
-        </div>
-
-        <Card className="border-2 border-gray-200 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 bg-white">
-          <div className="space-y-1">
-            {rankings.map((user) => (
-              <RankingItem key={user.user_id} user={user} />
-            ))}
-          </div>
-        </Card>
-        {showDetailedInfo && (
-          <Link
-            href="/ranking"
-            className="flex items-center text-teal-600 hover:text-teal-700 self-center"
-          >
-            トップ100を見る
-            <ChevronRight className="w-4 h-4 ml-1" />
-          </Link>
-        )}
-      </div>
-    </div>
+    <BaseRanking
+      title={title}
+      detailsHref="/ranking"
+      showDetailedInfo={showDetailedInfo}
+    >
+      {rankings.map((user) => (
+        <RankingItem key={user.user_id} user={user} />
+      ))}
+    </BaseRanking>
   );
 }

--- a/lib/services/missionsRanking.test.ts
+++ b/lib/services/missionsRanking.test.ts
@@ -1,0 +1,272 @@
+import { createClient } from "@/lib/supabase/server";
+import { getMissionRanking, getUserMissionRanking } from "./missionsRanking";
+
+// Supabaseクライアントをモック
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+}));
+
+describe("missionsRanking service", () => {
+  const mockSupabase = {
+    rpc: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createClient as jest.Mock).mockResolvedValue(mockSupabase);
+  });
+
+  describe("getMissionRanking", () => {
+    const missionId = "mission-123";
+
+    describe("全期間のミッションランキング取得", () => {
+      it("デフォルトで全期間のランキングを取得する", async () => {
+        const mockRankingData = [
+          {
+            user_id: "user1",
+            user_name: "テストユーザー1",
+            address_prefecture: "東京都",
+            level: 10,
+            xp: 1000,
+            updated_at: "2024-01-01T00:00:00Z",
+            clear_count: 5,
+            total_points: 500,
+            rank: 1,
+          },
+          {
+            user_id: "user2",
+            user_name: "テストユーザー2",
+            address_prefecture: "大阪府",
+            level: 8,
+            xp: 800,
+            updated_at: "2024-01-01T00:00:00Z",
+            clear_count: 3,
+            total_points: 300,
+            rank: 2,
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getMissionRanking(missionId);
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith("get_mission_ranking", {
+          mission_id: missionId,
+          limit_count: 10,
+        });
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+          user_id: "user1",
+          name: "テストユーザー1",
+          user_achievement_count: 5,
+          total_points: 500,
+        });
+      });
+
+      it("limitパラメータで取得件数を制限できる", async () => {
+        mockSupabase.rpc.mockResolvedValue({
+          data: [],
+          error: null,
+        });
+
+        await getMissionRanking(missionId, 20);
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith("get_mission_ranking", {
+          mission_id: missionId,
+          limit_count: 20,
+        });
+      });
+    });
+
+    describe("期間別ミッションランキング取得", () => {
+      it("日間ランキングを取得する", async () => {
+        const mockRankingData = [
+          {
+            mission_id: missionId,
+            user_id: "user1",
+            name: "テストユーザー1",
+            address_prefecture: "東京都",
+            user_achievement_count: 2,
+            total_points: 100,
+            rank: 1,
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getMissionRanking(missionId, 10, "daily");
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith(
+          "get_period_mission_ranking",
+          {
+            p_mission_id: missionId,
+            p_limit: 10,
+            p_start_date: expect.any(String),
+          },
+        );
+        expect(result[0]).toMatchObject({
+          user_id: "user1",
+          name: "テストユーザー1",
+          user_achievement_count: 2,
+          level: null,
+          xp: null,
+          total_points: 100,
+        });
+      });
+
+      it("週間ランキングを取得する", async () => {
+        mockSupabase.rpc.mockResolvedValue({
+          data: [],
+          error: null,
+        });
+
+        await getMissionRanking(missionId, 10, "weekly");
+
+        const rpcCall = mockSupabase.rpc.mock.calls[0];
+        expect(rpcCall[0]).toBe("get_period_mission_ranking");
+        expect(rpcCall[1].p_start_date).toBeTruthy();
+
+        // 日付が7日前であることを確認
+        const startDate = new Date(rpcCall[1].p_start_date);
+        const now = new Date();
+        const diffDays = Math.floor(
+          (now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        expect(diffDays).toBeGreaterThanOrEqual(6);
+        expect(diffDays).toBeLessThanOrEqual(7);
+      });
+    });
+
+    it("エラー時は例外をスローする", async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: { message: "Database error" },
+      });
+
+      await expect(getMissionRanking(missionId)).rejects.toThrow(
+        "ミッションランキングデータの取得に失敗しました: Database error",
+      );
+    });
+
+    it("データがない場合は空配列を返す", async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: null,
+      });
+
+      const result = await getMissionRanking(missionId);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getUserMissionRanking", () => {
+    const missionId = "mission-123";
+    const userId = "user-456";
+
+    describe("全期間のユーザーミッションランキング取得", () => {
+      it("特定ユーザーのランキング情報を取得する", async () => {
+        const mockRankingData = [
+          {
+            user_id: userId,
+            user_name: "テストユーザー",
+            address_prefecture: "東京都",
+            level: 10,
+            xp: 1000,
+            updated_at: "2024-01-01T00:00:00Z",
+            clear_count: 5,
+            total_points: 500,
+            rank: 3,
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getUserMissionRanking(missionId, userId);
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith(
+          "get_user_mission_ranking",
+          {
+            mission_id: missionId,
+            user_id: userId,
+          },
+        );
+        expect(result).toMatchObject({
+          user_id: userId,
+          name: "テストユーザー",
+          user_achievement_count: 5,
+          rank: 3,
+        });
+      });
+    });
+
+    describe("期間別ユーザーミッションランキング取得", () => {
+      it("日間のユーザーランキングを取得する", async () => {
+        const mockRankingData = [
+          {
+            mission_id: missionId,
+            user_id: userId,
+            name: "テストユーザー",
+            address_prefecture: "東京都",
+            user_achievement_count: 2,
+            total_points: 50,
+            rank: 5,
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getUserMissionRanking(missionId, userId, "daily");
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith(
+          "get_user_period_mission_ranking",
+          {
+            p_mission_id: missionId,
+            p_user_id: userId,
+            p_start_date: expect.any(String),
+          },
+        );
+        expect(result).toMatchObject({
+          user_id: userId,
+          name: "テストユーザー",
+          rank: 5,
+          level: null,
+          xp: null,
+          total_points: 50,
+        });
+      });
+    });
+
+    it("ユーザーがランキングに存在しない場合はnullを返す", async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: [],
+        error: null,
+      });
+
+      const result = await getUserMissionRanking(missionId, userId);
+      expect(result).toBeNull();
+    });
+
+    it("エラー時は例外をスローする", async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: { message: "Database error" },
+      });
+
+      await expect(getUserMissionRanking(missionId, userId)).rejects.toThrow(
+        "ユーザーのミッションランキングデータの取得に失敗しました: Database error",
+      );
+    });
+  });
+});

--- a/lib/services/prefecturesRanking.test.ts
+++ b/lib/services/prefecturesRanking.test.ts
@@ -1,0 +1,303 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  getPrefecturesRanking,
+  getUserPrefecturesRanking,
+} from "./prefecturesRanking";
+
+// Supabaseクライアントをモック
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+}));
+
+describe("prefecturesRanking service", () => {
+  const mockSupabase = {
+    rpc: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createClient as jest.Mock).mockResolvedValue(mockSupabase);
+  });
+
+  describe("getPrefecturesRanking", () => {
+    const prefecture = "東京都";
+
+    describe("全期間の都道府県別ランキング取得", () => {
+      it("デフォルトで全期間のランキングを取得する", async () => {
+        const mockRankingData = [
+          {
+            user_id: "user1",
+            user_name: "東京ユーザー1",
+            address_prefecture: "東京都",
+            rank: 1,
+            level: 10,
+            xp: 1000,
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+          {
+            user_id: "user2",
+            user_name: "東京ユーザー2",
+            address_prefecture: "東京都",
+            rank: 2,
+            level: 8,
+            xp: 800,
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getPrefecturesRanking(prefecture);
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith(
+          "get_prefecture_ranking",
+          {
+            prefecture: prefecture,
+            limit_count: 10,
+          },
+        );
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+          user_id: "user1",
+          name: "東京ユーザー1",
+          address_prefecture: "東京都",
+          rank: 1,
+        });
+      });
+
+      it("limitパラメータで取得件数を制限できる", async () => {
+        mockSupabase.rpc.mockResolvedValue({
+          data: [],
+          error: null,
+        });
+
+        await getPrefecturesRanking(prefecture, 50);
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith(
+          "get_prefecture_ranking",
+          {
+            prefecture: prefecture,
+            limit_count: 50,
+          },
+        );
+      });
+    });
+
+    describe("期間別都道府県ランキング取得", () => {
+      it("日間ランキングを取得する", async () => {
+        const mockRankingData = [
+          {
+            user_id: "user1",
+            name: "東京ユーザー1",
+            rank: 1,
+            xp: 200,
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getPrefecturesRanking(prefecture, 10, "daily");
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith(
+          "get_period_prefecture_ranking",
+          {
+            p_prefecture: prefecture,
+            p_limit: 10,
+            p_start_date: expect.any(String),
+          },
+        );
+        expect(result[0]).toMatchObject({
+          user_id: "user1",
+          name: "東京ユーザー1",
+          address_prefecture: "東京都", // 引数から設定される
+          rank: 1,
+          xp: 200,
+          level: null,
+          updated_at: null,
+        });
+      });
+
+      it("週間ランキングを取得する", async () => {
+        mockSupabase.rpc.mockResolvedValue({
+          data: [],
+          error: null,
+        });
+
+        await getPrefecturesRanking(prefecture, 10, "weekly");
+
+        const rpcCall = mockSupabase.rpc.mock.calls[0];
+        expect(rpcCall[0]).toBe("get_period_prefecture_ranking");
+
+        // 日付が7日前であることを確認
+        const startDate = new Date(rpcCall[1].p_start_date);
+        const now = new Date();
+        const diffDays = Math.floor(
+          (now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        expect(diffDays).toBeGreaterThanOrEqual(6);
+        expect(diffDays).toBeLessThanOrEqual(7);
+      });
+    });
+
+    it("エラー時は例外をスローする", async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: { message: "Database error" },
+      });
+
+      await expect(getPrefecturesRanking(prefecture)).rejects.toThrow(
+        "都道府県ランキングデータの取得に失敗しました: Database error",
+      );
+    });
+
+    it("データがない場合は空配列を返す", async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: null,
+      });
+
+      const result = await getPrefecturesRanking(prefecture);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getUserPrefecturesRanking", () => {
+    const prefecture = "東京都";
+    const userId = "user-123";
+
+    describe("全期間のユーザー都道府県ランキング取得", () => {
+      it("特定ユーザーのランキング情報を取得する", async () => {
+        const mockRankingData = [
+          {
+            user_id: userId,
+            user_name: "テストユーザー",
+            address_prefecture: "東京都",
+            rank: 5,
+            level: 7,
+            xp: 700,
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getUserPrefecturesRanking(prefecture, userId);
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith(
+          "get_user_prefecture_ranking",
+          {
+            prefecture: prefecture,
+            target_user_id: userId,
+          },
+        );
+        expect(result).toMatchObject({
+          user_id: userId,
+          name: "テストユーザー",
+          address_prefecture: "東京都",
+          rank: 5,
+        });
+      });
+    });
+
+    describe("期間別ユーザー都道府県ランキング取得", () => {
+      it("日間のユーザーランキングを取得する", async () => {
+        const mockRankingData = [
+          {
+            user_id: userId,
+            name: "テストユーザー",
+            rank: 3,
+            xp: 150,
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getUserPrefecturesRanking(
+          prefecture,
+          userId,
+          "daily",
+        );
+
+        expect(mockSupabase.rpc).toHaveBeenCalledWith(
+          "get_user_period_prefecture_ranking",
+          {
+            p_prefecture: prefecture,
+            p_user_id: userId,
+            p_start_date: expect.any(String),
+          },
+        );
+        expect(result).toMatchObject({
+          user_id: userId,
+          name: "テストユーザー",
+          address_prefecture: "東京都",
+          rank: 3,
+          xp: 150,
+          level: null,
+        });
+      });
+
+      it("週間のユーザーランキングを取得する", async () => {
+        const mockRankingData = [
+          {
+            user_id: userId,
+            name: "テストユーザー",
+            rank: 10,
+            xp: 500,
+          },
+        ];
+
+        mockSupabase.rpc.mockResolvedValue({
+          data: mockRankingData,
+          error: null,
+        });
+
+        const result = await getUserPrefecturesRanking(
+          prefecture,
+          userId,
+          "weekly",
+        );
+
+        expect(result).toMatchObject({
+          user_id: userId,
+          rank: 10,
+          xp: 500,
+        });
+      });
+    });
+
+    it("ユーザーがランキングに存在しない場合はnullを返す", async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: [],
+        error: null,
+      });
+
+      const result = await getUserPrefecturesRanking(prefecture, userId);
+      expect(result).toBeNull();
+    });
+
+    it("エラー時は例外をスローする", async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: { message: "Database error" },
+      });
+
+      await expect(
+        getUserPrefecturesRanking(prefecture, userId),
+      ).rejects.toThrow(
+        "ユーザーの都道府県ランキングデータの取得に失敗しました: Database error",
+      );
+    });
+  });
+});

--- a/lib/services/ranking.test.ts
+++ b/lib/services/ranking.test.ts
@@ -1,0 +1,259 @@
+import { createClient } from "@/lib/supabase/server";
+import { getRanking } from "./ranking";
+
+// Supabaseクライアントをモック
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+}));
+
+describe("ranking service", () => {
+  const mockSupabase = {
+    from: jest.fn(),
+    rpc: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createClient as jest.Mock).mockResolvedValue(mockSupabase);
+  });
+
+  describe("getRanking", () => {
+    describe("全期間のランキング取得", () => {
+      it("デフォルトで全期間のランキングを取得する", async () => {
+        const mockRankingData = [
+          {
+            user_id: "user1",
+            name: "テストユーザー1",
+            address_prefecture: "東京都",
+            rank: 1,
+            level: 10,
+            xp: 1000,
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+          {
+            user_id: "user2",
+            name: "テストユーザー2",
+            address_prefecture: "大阪府",
+            rank: 2,
+            level: 8,
+            xp: 800,
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ];
+
+        mockSupabase.from.mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue({
+              data: mockRankingData,
+              error: null,
+            }),
+          }),
+        });
+
+        const result = await getRanking();
+
+        expect(mockSupabase.from).toHaveBeenCalledWith("user_ranking_view");
+        expect(result).toEqual(mockRankingData);
+      });
+
+      it("limitパラメータで取得件数を制限できる", async () => {
+        mockSupabase.from.mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          }),
+        });
+
+        await getRanking(20);
+
+        const limitCall = mockSupabase.from().select().limit;
+        expect(limitCall).toHaveBeenCalledWith(20);
+      });
+
+      it("エラー時は例外をスローする", async () => {
+        const mockError = { message: "Database error" };
+        mockSupabase.from.mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue({
+              data: null,
+              error: mockError,
+            }),
+          }),
+        });
+
+        await expect(getRanking()).rejects.toThrow(
+          "ランキングデータの取得に失敗しました: Database error",
+        );
+      });
+    });
+
+    describe("期間別ランキング取得", () => {
+      it("日間ランキングを取得する", async () => {
+        const mockXpData = [
+          { user_id: "user1", xp_amount: 100 },
+          { user_id: "user1", xp_amount: 50 },
+          { user_id: "user2", xp_amount: 200 },
+        ];
+
+        const mockUserData = [
+          { id: "user1", name: "ユーザー1", address_prefecture: "東京都" },
+          { id: "user2", name: "ユーザー2", address_prefecture: "大阪府" },
+        ];
+
+        const mockLevelData = [
+          { user_id: "user1", level: 5, xp: 500 },
+          { user_id: "user2", level: 3, xp: 300 },
+        ];
+
+        // xp_transactionsのモック
+        mockSupabase.from.mockImplementation((table) => {
+          if (table === "xp_transactions") {
+            return {
+              select: jest.fn().mockReturnValue({
+                gte: jest.fn().mockReturnValue({
+                  not: jest.fn().mockResolvedValue({
+                    data: mockXpData,
+                    error: null,
+                  }),
+                }),
+              }),
+            };
+          }
+          if (table === "public_user_profiles") {
+            return {
+              select: jest.fn().mockReturnValue({
+                in: jest.fn().mockResolvedValue({
+                  data: mockUserData,
+                  error: null,
+                }),
+              }),
+            };
+          }
+          if (table === "user_levels") {
+            return {
+              select: jest.fn().mockReturnValue({
+                in: jest.fn().mockResolvedValue({
+                  data: mockLevelData,
+                  error: null,
+                }),
+              }),
+            };
+          }
+        });
+
+        const result = await getRanking(10, "daily");
+
+        expect(mockSupabase.from).toHaveBeenCalledWith("xp_transactions");
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+          user_id: "user2",
+          name: "ユーザー2",
+          xp: 200,
+          rank: 1,
+        });
+        expect(result[1]).toMatchObject({
+          user_id: "user1",
+          name: "ユーザー1",
+          xp: 150,
+          rank: 2,
+        });
+      });
+
+      it("週間ランキングを取得する", async () => {
+        const mockXpData = [{ user_id: "user1", xp_amount: 300 }];
+        const mockUserData = [
+          { id: "user1", name: "ユーザー1", address_prefecture: "東京都" },
+        ];
+        const mockLevelData = [{ user_id: "user1", level: 5, xp: 500 }];
+
+        mockSupabase.from.mockImplementation((table) => {
+          if (table === "xp_transactions") {
+            return {
+              select: jest.fn().mockReturnValue({
+                gte: jest.fn().mockReturnValue({
+                  not: jest.fn().mockResolvedValue({
+                    data: mockXpData,
+                    error: null,
+                  }),
+                }),
+              }),
+            };
+          }
+          if (table === "public_user_profiles") {
+            return {
+              select: jest.fn().mockReturnValue({
+                in: jest.fn().mockResolvedValue({
+                  data: mockUserData,
+                  error: null,
+                }),
+              }),
+            };
+          }
+          if (table === "user_levels") {
+            return {
+              select: jest.fn().mockReturnValue({
+                in: jest.fn().mockResolvedValue({
+                  data: mockLevelData,
+                  error: null,
+                }),
+              }),
+            };
+          }
+        });
+
+        const result = await getRanking(10, "weekly");
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          user_id: "user1",
+          xp: 300,
+          rank: 1,
+        });
+      });
+
+      it("期間内にXPを獲得したユーザーがいない場合は空配列を返す", async () => {
+        mockSupabase.from.mockImplementation((table) => {
+          if (table === "xp_transactions") {
+            return {
+              select: jest.fn().mockReturnValue({
+                gte: jest.fn().mockReturnValue({
+                  not: jest.fn().mockResolvedValue({
+                    data: [],
+                    error: null,
+                  }),
+                }),
+              }),
+            };
+          }
+        });
+
+        const result = await getRanking(10, "daily");
+
+        expect(result).toEqual([]);
+      });
+
+      it("XP取得エラー時は例外をスローする", async () => {
+        mockSupabase.from.mockImplementation((table) => {
+          if (table === "xp_transactions") {
+            return {
+              select: jest.fn().mockReturnValue({
+                gte: jest.fn().mockReturnValue({
+                  not: jest.fn().mockResolvedValue({
+                    data: null,
+                    error: { message: "XP fetch error" },
+                  }),
+                }),
+              }),
+            };
+          }
+        });
+
+        await expect(getRanking(10, "daily")).rejects.toThrow(
+          "XPトランザクションの取得に失敗しました: XP fetch error",
+        );
+      });
+    });
+  });
+});

--- a/lib/services/ranking.ts
+++ b/lib/services/ranking.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import type { RankingPeriod } from "@/components/ranking/period-toggle";
 import { createClient } from "@/lib/supabase/server";
 
 export interface UserRanking {
@@ -12,10 +13,120 @@ export interface UserRanking {
   xp: number | null;
 }
 
-export async function getRanking(limit = 10): Promise<UserRanking[]> {
+export async function getRanking(
+  limit = 10,
+  period: RankingPeriod = "all",
+): Promise<UserRanking[]> {
   try {
     const supabase = await createClient();
 
+    // 期間に応じた日付フィルタを設定
+    let dateFilter: Date | null = null;
+    const now = new Date();
+
+    switch (period) {
+      case "daily":
+        dateFilter = new Date(now.getTime() - 24 * 60 * 60 * 1000); // 24時間前
+        break;
+      case "weekly":
+        dateFilter = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000); // 7日前
+        break;
+      default:
+        dateFilter = null;
+    }
+
+    // 期間別ランキングの場合は、xp_transactionsテーブルから集計
+    if (dateFilter) {
+      // xp_transactionsから期間内のXPを集計
+      const { data: xpData, error: xpError } = await supabase
+        .from("xp_transactions")
+        .select("user_id, xp_amount")
+        .gte("created_at", dateFilter.toISOString())
+        .not("user_id", "is", null);
+
+      if (xpError) {
+        console.error("Failed to fetch xp transactions:", xpError);
+        throw new Error(
+          `XPトランザクションの取得に失敗しました: ${xpError.message}`,
+        );
+      }
+
+      // ユーザーごとのXPを集計
+      const userXpMap = new Map<string, number>();
+      if (xpData) {
+        for (const transaction of xpData) {
+          if (transaction.user_id) {
+            userXpMap.set(
+              transaction.user_id,
+              (userXpMap.get(transaction.user_id) || 0) +
+                (transaction.xp_amount || 0),
+            );
+          }
+        }
+      }
+
+      // XPが0より大きいユーザーのIDリスト
+      const userIds = Array.from(userXpMap.keys());
+
+      if (userIds.length === 0) {
+        return [];
+      }
+
+      // ユーザー情報を取得
+      const { data: users, error: usersError } = await supabase
+        .from("public_user_profiles")
+        .select("id, name, address_prefecture")
+        .in("id", userIds);
+
+      if (usersError) {
+        console.error("Failed to fetch user profiles:", usersError);
+        throw new Error(
+          `ユーザープロフィールの取得に失敗しました: ${usersError.message}`,
+        );
+      }
+
+      // レベル情報を取得
+      const { data: levels, error: levelsError } = await supabase
+        .from("user_levels")
+        .select("user_id, level, xp")
+        .in("user_id", userIds);
+
+      if (levelsError) {
+        console.error("Failed to fetch user levels:", levelsError);
+        throw new Error(
+          `ユーザーレベルの取得に失敗しました: ${levelsError.message}`,
+        );
+      }
+
+      // データを結合してランキングを作成
+      const levelMap = new Map(levels?.map((l) => [l.user_id, l]) || []);
+
+      const rankings =
+        users?.map((user) => {
+          const periodXp = userXpMap.get(user.id ?? "") || 0;
+          const levelInfo = levelMap.get(user.id ?? "");
+
+          return {
+            user_id: user.id,
+            name: user.name,
+            address_prefecture: user.address_prefecture,
+            rank: null, // 後でソート後に設定
+            level: levelInfo?.level || null,
+            xp: periodXp, // 期間内のXP
+            updated_at: null,
+          };
+        }) || [];
+
+      // XPでソートしてランクを設定
+      rankings.sort((a, b) => (b.xp || 0) - (a.xp || 0));
+      const rankedUsers = rankings.map((user, index) => ({
+        ...user,
+        rank: index + 1,
+      }));
+
+      return rankedUsers.slice(0, limit);
+    }
+    // 全期間の場合は既存のビューを使用
     const { data, error } = await supabase
       .from("user_ranking_view")
       .select("*")

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -1143,6 +1143,38 @@ export type Database = {
           rank: number;
         }[];
       };
+      get_period_mission_ranking: {
+        Args: { p_mission_id: string; p_limit?: number; p_start_date?: string };
+        Returns: {
+          mission_id: string;
+          user_id: string;
+          name: string;
+          address_prefecture: string;
+          user_achievement_count: number;
+          rank: number;
+        }[];
+      };
+      get_period_prefecture_ranking: {
+        Args: { p_prefecture: string; p_limit?: number; p_start_date?: string };
+        Returns: {
+          user_id: string;
+          name: string;
+          rank: number;
+          xp: number;
+        }[];
+      };
+      get_period_ranking: {
+        Args: { p_limit?: number; p_start_date?: string };
+        Returns: {
+          user_id: string;
+          address_prefecture: string;
+          level: number;
+          name: string;
+          rank: number;
+          updated_at: string;
+          xp: number;
+        }[];
+      };
       get_prefecture_ranking: {
         Args: { prefecture: string; limit_count?: number };
         Returns: {
@@ -1182,6 +1214,46 @@ export type Database = {
           clear_count: number;
           total_points: number;
           rank: number;
+        }[];
+      };
+      get_user_period_mission_ranking: {
+        Args: {
+          p_mission_id: string;
+          p_user_id: string;
+          p_start_date?: string;
+        };
+        Returns: {
+          mission_id: string;
+          user_id: string;
+          name: string;
+          address_prefecture: string;
+          user_achievement_count: number;
+          rank: number;
+        }[];
+      };
+      get_user_period_prefecture_ranking: {
+        Args: {
+          p_prefecture: string;
+          p_user_id: string;
+          p_start_date?: string;
+        };
+        Returns: {
+          user_id: string;
+          name: string;
+          rank: number;
+          xp: number;
+        }[];
+      };
+      get_user_period_ranking: {
+        Args: { target_user_id: string; start_date?: string };
+        Returns: {
+          user_id: string;
+          address_prefecture: string;
+          level: number;
+          name: string;
+          rank: number;
+          updated_at: string;
+          xp: number;
         }[];
       };
       get_user_posting_count: {

--- a/supabase/migrations/20250627000000_add_period_ranking_functions.sql
+++ b/supabase/migrations/20250627000000_add_period_ranking_functions.sql
@@ -1,0 +1,150 @@
+-- 期間別ランキング取得関数の追加
+
+-- 期間別の総合ランキングを取得する関数
+CREATE OR REPLACE FUNCTION get_period_ranking(
+    p_limit INTEGER DEFAULT 10,
+    p_start_date TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+    user_id UUID,
+    address_prefecture TEXT,
+    level INTEGER,
+    name TEXT,
+    rank BIGINT,
+    updated_at TIMESTAMPTZ,
+    xp BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    -- 期間指定がない場合は全期間
+    IF p_start_date IS NULL THEN
+        RETURN QUERY
+        SELECT 
+            urv.user_id::UUID,
+            urv.address_prefecture::TEXT,
+            urv.level::INTEGER,
+            urv.name::TEXT,
+            urv.rank::BIGINT,
+            urv.updated_at::TIMESTAMPTZ,
+            urv.xp::BIGINT
+        FROM user_ranking_view urv
+        ORDER BY urv.rank
+        LIMIT p_limit;
+    ELSE
+        -- 期間指定がある場合は期間内のXPを集計
+        RETURN QUERY
+        WITH period_xp AS (
+            SELECT 
+                xt.user_id,
+                SUM(xt.xp_amount) AS period_xp_total
+            FROM xp_transactions xt
+            WHERE xt.created_at >= p_start_date
+            GROUP BY xt.user_id
+        ),
+        ranked_users AS (
+            SELECT 
+                px.user_id,
+                pup.address_prefecture,
+                ul.level,
+                pup.name,
+                ROW_NUMBER() OVER (ORDER BY px.period_xp_total DESC) AS rank,
+                ul.updated_at,
+                px.period_xp_total AS xp
+            FROM period_xp px
+            JOIN public_user_profiles pup ON pup.user_id = px.user_id
+            JOIN user_levels ul ON ul.user_id = px.user_id
+            WHERE px.period_xp_total > 0
+        )
+        SELECT 
+            ru.user_id::UUID,
+            ru.address_prefecture::TEXT,
+            ru.level::INTEGER,
+            ru.name::TEXT,
+            ru.rank::BIGINT,
+            ru.updated_at::TIMESTAMPTZ,
+            ru.xp::BIGINT
+        FROM ranked_users ru
+        ORDER BY ru.rank
+        LIMIT p_limit;
+    END IF;
+END;
+$$;
+
+-- 特定ユーザーの期間別ランキング情報を取得する関数
+CREATE OR REPLACE FUNCTION get_user_period_ranking(
+    target_user_id UUID,
+    start_date TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+    user_id UUID,
+    address_prefecture TEXT,
+    level INTEGER,
+    name TEXT,
+    rank BIGINT,
+    updated_at TIMESTAMPTZ,
+    xp BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    -- 期間指定がない場合は全期間
+    IF start_date IS NULL THEN
+        RETURN QUERY
+        SELECT 
+            urv.user_id::UUID,
+            urv.address_prefecture::TEXT,
+            urv.level::INTEGER,
+            urv.name::TEXT,
+            urv.rank::BIGINT,
+            urv.updated_at::TIMESTAMPTZ,
+            urv.xp::BIGINT
+        FROM user_ranking_view urv
+        WHERE urv.user_id = target_user_id;
+    ELSE
+        -- 期間指定がある場合は期間内のXPを集計
+        RETURN QUERY
+        WITH period_xp AS (
+            SELECT 
+                xt.user_id,
+                SUM(xt.xp_amount) AS period_xp_total
+            FROM xp_transactions xt
+            WHERE xt.created_at >= start_date
+            GROUP BY xt.user_id
+        ),
+        all_ranked_users AS (
+            SELECT 
+                px.user_id,
+                pup.address_prefecture,
+                ul.level,
+                pup.name,
+                ROW_NUMBER() OVER (ORDER BY px.period_xp_total DESC) AS rank,
+                ul.updated_at,
+                px.period_xp_total AS xp
+            FROM period_xp px
+            JOIN public_user_profiles pup ON pup.user_id = px.user_id
+            JOIN user_levels ul ON ul.user_id = px.user_id
+            WHERE px.period_xp_total > 0
+        )
+        SELECT 
+            aru.user_id::UUID,
+            aru.address_prefecture::TEXT,
+            aru.level::INTEGER,
+            aru.name::TEXT,
+            aru.rank::BIGINT,
+            aru.updated_at::TIMESTAMPTZ,
+            aru.xp::BIGINT
+        FROM all_ranked_users aru
+        WHERE aru.user_id = target_user_id;
+    END IF;
+END;
+$$;
+
+-- 関数の権限設定
+GRANT EXECUTE ON FUNCTION get_period_ranking TO authenticated;
+GRANT EXECUTE ON FUNCTION get_user_period_ranking TO authenticated;
+
+COMMENT ON FUNCTION get_period_ranking IS '期間別の総合ランキングを取得する関数';
+COMMENT ON FUNCTION get_user_period_ranking IS '特定ユーザーの期間別ランキング情報を取得する関数';

--- a/supabase/migrations/20250627000001_add_period_mission_ranking_functions.sql
+++ b/supabase/migrations/20250627000001_add_period_mission_ranking_functions.sql
@@ -1,0 +1,302 @@
+-- 期間別ミッションランキング取得関数の追加
+
+-- 期間別のミッションランキングを取得する関数
+CREATE OR REPLACE FUNCTION get_period_mission_ranking(
+    p_mission_id UUID,
+    p_limit INTEGER DEFAULT 10,
+    p_start_date TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+    mission_id UUID,
+    user_id UUID,
+    name TEXT,
+    address_prefecture TEXT,
+    user_achievement_count BIGINT,
+    total_points BIGINT,
+    rank BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    -- 期間指定がない場合は既存の関数を使用
+    IF p_start_date IS NULL THEN
+        RETURN QUERY
+        SELECT 
+            p_mission_id AS mission_id,
+            mr.user_id::UUID,
+            mr.user_name::TEXT AS name,
+            mr.address_prefecture::TEXT,
+            mr.clear_count::BIGINT AS user_achievement_count,
+            mr.total_points::BIGINT,
+            mr.rank::BIGINT
+        FROM get_mission_ranking(p_mission_id, p_limit) mr;
+    ELSE
+        -- 期間指定がある場合
+        -- POSTINGタイプのミッションかどうか確認
+        IF EXISTS (
+            SELECT 1 FROM missions m 
+            WHERE m.id = p_mission_id 
+            AND m.required_artifact_type = 'POSTING'
+        ) THEN
+            -- POSTINGミッションの場合は posting_activities テーブルから集計
+            RETURN QUERY
+            WITH period_posting AS (
+                SELECT 
+                    ma.user_id,
+                    COALESCE(SUM(pa.posting_count), 0) AS posting_count
+                FROM mission_artifacts ma
+                JOIN posting_activities pa ON pa.mission_artifact_id = ma.id
+                JOIN achievements a ON a.id = ma.achievement_id
+                WHERE pa.created_at >= p_start_date
+                AND a.mission_id = p_mission_id
+                GROUP BY ma.user_id
+            ),
+            period_xp AS (
+                SELECT
+                    xt.user_id,
+                    COALESCE(SUM(xt.xp_amount), 0) AS total_xp
+                FROM xp_transactions xt
+                WHERE xt.created_at >= p_start_date
+                AND xt.source_type IN ('MISSION_COMPLETION', 'BONUS')
+                GROUP BY xt.user_id
+            ),
+            ranked_users AS (
+                SELECT 
+                    p_mission_id AS mission_id,
+                    pp.user_id,
+                    pup.name,
+                    pup.address_prefecture,
+                    pp.posting_count AS user_achievement_count,
+                    COALESCE(px.total_xp, 0) AS total_points,
+                    ROW_NUMBER() OVER (
+                        ORDER BY 
+                            COALESCE(px.total_xp, 0) DESC,
+                            pp.posting_count DESC,
+                            pup.name ASC
+                    ) AS rank
+                FROM period_posting pp
+                JOIN public_user_profiles pup ON pup.id = pp.user_id
+                LEFT JOIN period_xp px ON px.user_id = pp.user_id
+            )
+            SELECT 
+                ru.mission_id::UUID,
+                ru.user_id::UUID,
+                ru.name::TEXT,
+                ru.address_prefecture::TEXT,
+                ru.user_achievement_count::BIGINT,
+                ru.total_points::BIGINT,
+                ru.rank::BIGINT
+            FROM ranked_users ru
+            ORDER BY ru.rank
+            LIMIT p_limit;
+        ELSE
+            -- 通常のミッションの場合は achievements テーブルから集計
+            RETURN QUERY
+            WITH period_achievements AS (
+                SELECT 
+                    a.user_id,
+                    a.id as achievement_id,
+                    a.created_at
+                FROM achievements a
+                WHERE a.mission_id = p_mission_id
+                AND a.created_at >= p_start_date
+            ),
+            period_stats AS (
+                SELECT
+                    pa.user_id,
+                    COUNT(DISTINCT pa.achievement_id) AS achievement_count,
+                    COALESCE(SUM(xt.xp_amount), 0) AS total_mission_points
+                FROM period_achievements pa
+                LEFT JOIN xp_transactions xt ON
+                    xt.user_id = pa.user_id AND
+                    xt.source_id = pa.achievement_id AND
+                    xt.source_type IN ('MISSION_COMPLETION', 'BONUS') AND
+                    xt.created_at >= p_start_date
+                GROUP BY pa.user_id
+            ),
+            ranked_users AS (
+                SELECT 
+                    p_mission_id AS mission_id,
+                    ps.user_id,
+                    pup.name,
+                    pup.address_prefecture,
+                    ps.achievement_count AS user_achievement_count,
+                    ps.total_mission_points AS total_points,
+                    ROW_NUMBER() OVER (
+                        ORDER BY 
+                            ps.total_mission_points DESC,
+                            ps.achievement_count DESC,
+                            pup.name ASC
+                    ) AS rank
+                FROM period_stats ps
+                JOIN public_user_profiles pup ON pup.id = ps.user_id
+            )
+            SELECT 
+                ru.mission_id::UUID,
+                ru.user_id::UUID,
+                ru.name::TEXT,
+                ru.address_prefecture::TEXT,
+                ru.user_achievement_count::BIGINT,
+                ru.total_points::BIGINT,
+                ru.rank::BIGINT
+            FROM ranked_users ru
+            ORDER BY ru.rank
+            LIMIT p_limit;
+        END IF;
+    END IF;
+END;
+$$;
+
+-- 特定ユーザーの期間別ミッションランキング情報を取得する関数
+CREATE OR REPLACE FUNCTION get_user_period_mission_ranking(
+    p_mission_id UUID,
+    p_user_id UUID,
+    p_start_date TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+    mission_id UUID,
+    user_id UUID,
+    name TEXT,
+    address_prefecture TEXT,
+    user_achievement_count BIGINT,
+    total_points BIGINT,
+    rank BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    -- 期間指定がない場合は既存の関数を使用
+    IF p_start_date IS NULL THEN
+        RETURN QUERY
+        SELECT 
+            p_mission_id AS mission_id,
+            umr.user_id::UUID,
+            umr.user_name::TEXT AS name,
+            umr.address_prefecture::TEXT,
+            umr.clear_count::BIGINT AS user_achievement_count,
+            umr.total_points::BIGINT,
+            umr.rank::BIGINT
+        FROM get_user_mission_ranking(p_mission_id, p_user_id) umr;
+    ELSE
+        -- 期間指定がある場合
+        -- POSTINGタイプのミッションかどうか確認
+        IF EXISTS (
+            SELECT 1 FROM missions m 
+            WHERE m.id = p_mission_id 
+            AND m.required_artifact_type = 'POSTING'
+        ) THEN
+            -- POSTINGミッションの場合
+            RETURN QUERY
+            WITH period_posting AS (
+                SELECT 
+                    ma.user_id,
+                    COALESCE(SUM(pa.posting_count), 0) AS posting_count
+                FROM mission_artifacts ma
+                JOIN posting_activities pa ON pa.mission_artifact_id = ma.id
+                JOIN achievements a ON a.id = ma.achievement_id
+                WHERE pa.created_at >= p_start_date
+                AND a.mission_id = p_mission_id
+                GROUP BY ma.user_id
+            ),
+            period_xp AS (
+                SELECT
+                    xt.user_id,
+                    COALESCE(SUM(xt.xp_amount), 0) AS total_xp
+                FROM xp_transactions xt
+                WHERE xt.created_at >= p_start_date
+                AND xt.source_type IN ('MISSION_COMPLETION', 'BONUS')
+                GROUP BY xt.user_id
+            ),
+            all_ranked_users AS (
+                SELECT 
+                    p_mission_id AS mission_id,
+                    pp.user_id,
+                    pup.name,
+                    pup.address_prefecture,
+                    pp.posting_count AS user_achievement_count,
+                    COALESCE(px.total_xp, 0) AS total_points,
+                    ROW_NUMBER() OVER (
+                        ORDER BY 
+                            COALESCE(px.total_xp, 0) DESC,
+                            pp.posting_count DESC,
+                            pup.name ASC
+                    ) AS rank
+                FROM period_posting pp
+                JOIN public_user_profiles pup ON pup.id = pp.user_id
+                LEFT JOIN period_xp px ON px.user_id = pp.user_id
+            )
+            SELECT 
+                aru.mission_id::UUID,
+                aru.user_id::UUID,
+                aru.name::TEXT,
+                aru.address_prefecture::TEXT,
+                aru.user_achievement_count::BIGINT,
+                aru.total_points::BIGINT,
+                aru.rank::BIGINT
+            FROM all_ranked_users aru
+            WHERE aru.user_id = p_user_id;
+        ELSE
+            -- 通常のミッションの場合
+            RETURN QUERY
+            WITH period_achievements AS (
+                SELECT 
+                    a.user_id,
+                    a.id as achievement_id,
+                    a.created_at
+                FROM achievements a
+                WHERE a.mission_id = p_mission_id
+                AND a.created_at >= p_start_date
+            ),
+            period_stats AS (
+                SELECT
+                    pa.user_id,
+                    COUNT(DISTINCT pa.achievement_id) AS achievement_count,
+                    COALESCE(SUM(xt.xp_amount), 0) AS total_mission_points
+                FROM period_achievements pa
+                LEFT JOIN xp_transactions xt ON
+                    xt.user_id = pa.user_id AND
+                    xt.source_id = pa.achievement_id AND
+                    xt.source_type IN ('MISSION_COMPLETION', 'BONUS') AND
+                    xt.created_at >= p_start_date
+                GROUP BY pa.user_id
+            ),
+            all_ranked_users AS (
+                SELECT 
+                    p_mission_id AS mission_id,
+                    ps.user_id,
+                    pup.name,
+                    pup.address_prefecture,
+                    ps.achievement_count AS user_achievement_count,
+                    ps.total_mission_points AS total_points,
+                    ROW_NUMBER() OVER (
+                        ORDER BY 
+                            ps.total_mission_points DESC,
+                            ps.achievement_count DESC,
+                            pup.name ASC
+                    ) AS rank
+                FROM period_stats ps
+                JOIN public_user_profiles pup ON pup.id = ps.user_id
+            )
+            SELECT 
+                aru.mission_id::UUID,
+                aru.user_id::UUID,
+                aru.name::TEXT,
+                aru.address_prefecture::TEXT,
+                aru.user_achievement_count::BIGINT,
+                aru.total_points::BIGINT,
+                aru.rank::BIGINT
+            FROM all_ranked_users aru
+            WHERE aru.user_id = p_user_id;
+        END IF;
+    END IF;
+END;
+$$;
+
+-- 関数の権限設定
+GRANT EXECUTE ON FUNCTION get_period_mission_ranking TO authenticated;
+GRANT EXECUTE ON FUNCTION get_user_period_mission_ranking TO authenticated;
+
+COMMENT ON FUNCTION get_period_mission_ranking IS '期間別のミッションランキングを取得する関数';
+COMMENT ON FUNCTION get_user_period_mission_ranking IS '特定ユーザーの期間別ミッションランキング情報を取得する関数';

--- a/supabase/migrations/20250627000002_add_period_prefecture_ranking_functions.sql
+++ b/supabase/migrations/20250627000002_add_period_prefecture_ranking_functions.sql
@@ -1,0 +1,127 @@
+-- 期間別都道府県ランキング取得関数の追加
+
+-- 期間別の都道府県ランキングを取得する関数
+CREATE OR REPLACE FUNCTION get_period_prefecture_ranking(
+    p_prefecture TEXT,
+    p_limit INTEGER DEFAULT 10,
+    p_start_date TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+    user_id UUID,
+    name TEXT,
+    rank BIGINT,
+    xp BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    -- 期間指定がない場合は既存の関数を使用
+    IF p_start_date IS NULL THEN
+        RETURN QUERY
+        SELECT 
+            pr.user_id::UUID,
+            pr.user_name::TEXT AS name,
+            pr.rank::BIGINT,
+            pr.xp::BIGINT
+        FROM get_prefecture_ranking(p_prefecture, p_limit) pr;
+    ELSE
+        -- 期間指定がある場合は期間内のXPを集計
+        RETURN QUERY
+        WITH period_xp AS (
+            SELECT 
+                xt.user_id,
+                SUM(xt.xp_amount) AS period_xp_total
+            FROM xp_transactions xt
+            JOIN public_user_profiles pup ON pup.id = xt.user_id
+            WHERE xt.created_at >= p_start_date
+            AND pup.address_prefecture = p_prefecture
+            GROUP BY xt.user_id
+        ),
+        ranked_users AS (
+            SELECT 
+                px.user_id,
+                pup.name,
+                ROW_NUMBER() OVER (ORDER BY px.period_xp_total DESC) AS rank,
+                px.period_xp_total AS xp
+            FROM period_xp px
+            JOIN public_user_profiles pup ON pup.id = px.user_id
+            WHERE px.period_xp_total > 0
+        )
+        SELECT 
+            ru.user_id::UUID,
+            ru.name::TEXT,
+            ru.rank::BIGINT,
+            ru.xp::BIGINT
+        FROM ranked_users ru
+        ORDER BY ru.rank
+        LIMIT p_limit;
+    END IF;
+END;
+$$;
+
+-- 特定ユーザーの期間別都道府県ランキング情報を取得する関数
+CREATE OR REPLACE FUNCTION get_user_period_prefecture_ranking(
+    p_prefecture TEXT,
+    p_user_id UUID,
+    p_start_date TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+    user_id UUID,
+    name TEXT,
+    rank BIGINT,
+    xp BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    -- 期間指定がない場合は既存の関数を使用
+    IF p_start_date IS NULL THEN
+        RETURN QUERY
+        SELECT 
+            upr.user_id::UUID,
+            upr.user_name::TEXT AS name,
+            upr.rank::BIGINT,
+            upr.xp::BIGINT
+        FROM get_user_prefecture_ranking(p_prefecture, p_user_id) upr;
+    ELSE
+        -- 期間指定がある場合
+        RETURN QUERY
+        WITH period_xp AS (
+            SELECT 
+                xt.user_id,
+                SUM(xt.xp_amount) AS period_xp_total
+            FROM xp_transactions xt
+            JOIN public_user_profiles pup ON pup.id = xt.user_id
+            WHERE xt.created_at >= p_start_date
+            AND pup.address_prefecture = p_prefecture
+            GROUP BY xt.user_id
+        ),
+        all_ranked_users AS (
+            SELECT 
+                px.user_id,
+                pup.name,
+                ROW_NUMBER() OVER (ORDER BY px.period_xp_total DESC) AS rank,
+                px.period_xp_total AS xp
+            FROM period_xp px
+            JOIN public_user_profiles pup ON pup.id = px.user_id
+            WHERE px.period_xp_total > 0
+        )
+        SELECT 
+            aru.user_id::UUID,
+            aru.name::TEXT,
+            aru.rank::BIGINT,
+            aru.xp::BIGINT
+        FROM all_ranked_users aru
+        WHERE aru.user_id = p_user_id;
+    END IF;
+END;
+$$;
+
+-- 関数の権限設定
+GRANT EXECUTE ON FUNCTION get_period_prefecture_ranking TO authenticated;
+GRANT EXECUTE ON FUNCTION get_user_period_prefecture_ranking TO authenticated;
+
+COMMENT ON FUNCTION get_period_prefecture_ranking IS '期間別の都道府県ランキングを取得する関数';
+COMMENT ON FUNCTION get_user_period_prefecture_ranking IS '特定ユーザーの期間別都道府県ランキング情報を取得する関数';


### PR DESCRIPTION
# 変更の概要
- ランキングページに期間別（全期間・週間・日間）での絞り込み機能を追加
- ミッション別ランキングとトップランキングに期間選択トグル（PeriodToggle）コンポーネントを実装
- 期間選択に応じてランキングデータを動的に取得・表示する機能を追加

# 変更の背景
- ユーザーが最近の活動や特定期間のランキングを確認したいというニーズに対応
- 週間・日間ランキングにより、新規ユーザーも上位にランクインしやすくなり、モチベーション向上が期待できる
- closes #626

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ランキングに「全期間」「週間」「日間」の期間フィルターを追加し、期間ごとのランキング表示・切り替えが可能になりました。
  * ランキング画面に期間トグルUIを追加しました。
  * ミッション・都道府県別ランキングも期間フィルターに対応しました。

* **改善**
  * ランキングカードやランキングリストのデザインを統一し、見やすくなりました。
  * ミッション・都道府県選択時に他のURLパラメータが保持されるようになりました。

* **バグ修正**
  * 既存のランキング表示や切り替え時の不具合を修正しました。

* **テスト**
  * 期間フィルターや新UIコンポーネントに対するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->