### PR TITLE
#655: /users/{usersId}で横スクロールが発生する

### DIFF
--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function UserDetailPage({ params }: Props) {
     ]);
 
   return (
-    <div className="flex flex-col items-stretch max-w-xl gap-4 py-8">
+    <div className="flex flex-col items-stretch w-full max-w-xl gap-4 py-8">
       <Levels userId={user.id} hideProgress />
       <div className="flex justify-center gap-2">
         {user.x_username && (


### PR DESCRIPTION
# 変更の概要
- w-full をつけることで、コンテンツが画面幅に収まるようにしました

# 変更の背景
- /users/{usersId}で横スクロールが発生していたため
- closes #655

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクショ

![スクリーンショット 2025-06-27 21 08 47](https://github.com/user-attachments/assets/623d3c0e-6475-4e70-a0bb-e3005d484be8)
![スクリーンショット 2025-06-27 21 09 00](https://github.com/user-attachments/assets/9d26c923-cd2b-464f-a0b8-34315902870d)

（念の為 PC 表示）
![スクリーンショット 2025-06-27 21 09 55](https://github.com/user-attachments/assets/beaeafc9-cb55-4c18-9e46-20ce194b9c6c)
