### PR TITLE
feat: アクションボード紹介URLの遷移先をトップページにして、魅力伝わるように対応 #556

### DIFF
--- a/app/(auth-pages)/sign-up-email/EmailSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up-email/EmailSignUpForm.tsx
@@ -13,7 +13,6 @@ import { useFormStatus } from "react-dom";
 
 interface EmailSignUpFormProps {
   searchParams: Message;
-  referralCode: string | null;
 }
 
 function EmailSignUpFormContent({
@@ -81,7 +80,6 @@ function EmailSignUpFormContent({
 
 export default function EmailSignUpForm({
   searchParams,
-  referralCode,
 }: EmailSignUpFormProps) {
   const router = useRouter();
 

--- a/app/(auth-pages)/sign-up-email/EmailSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up-email/EmailSignUpForm.tsx
@@ -147,11 +147,6 @@ export default function EmailSignUpForm({
         name="date_of_birth"
         value={sessionData.dateOfBirth || ""}
       />
-      <input
-        type="hidden"
-        name="ref"
-        value={sessionData.referralCode || referralCode || ""}
-      />
 
       <h1 className="text-2xl font-medium text-center mb-2">
         メールアドレスとパスワードを入力

--- a/app/(auth-pages)/sign-up-email/page.tsx
+++ b/app/(auth-pages)/sign-up-email/page.tsx
@@ -12,7 +12,7 @@ export default async function EmailSignup(props: {
       <div className="flex justify-center items-center m-4">
         <Image src="/img/logo.png" alt="logo" width={114} height={96} />
       </div>
-      <EmailSignUpForm searchParams={searchParams} referralCode={null} />
+      <EmailSignUpForm searchParams={searchParams} />
     </div>
   );
 }

--- a/app/(auth-pages)/sign-up-email/page.tsx
+++ b/app/(auth-pages)/sign-up-email/page.tsx
@@ -3,20 +3,16 @@ import Image from "next/image";
 import EmailSignUpForm from "./EmailSignUpForm";
 
 export default async function EmailSignup(props: {
-  searchParams: Promise<Message & { ref?: string }>;
+  searchParams: Promise<Message>;
 }) {
   const searchParams = await props.searchParams;
-  const referralCode = searchParams.ref ?? null;
 
   return (
     <div className="flex-1 flex flex-col min-w-72">
       <div className="flex justify-center items-center m-4">
         <Image src="/img/logo.png" alt="logo" width={114} height={96} />
       </div>
-      <EmailSignUpForm
-        searchParams={searchParams}
-        referralCode={referralCode}
-      />
+      <EmailSignUpForm searchParams={searchParams} referralCode={null} />
     </div>
   );
 }

--- a/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
@@ -214,7 +214,7 @@ function LoginSelectionPhase({
         "lineLoginData",
         JSON.stringify({
           dateOfBirth: formattedDate,
-          referralCode: referralCode,
+          referralCode: null, // リファラルコードはcookieから取得するためnull
         }),
       );
 
@@ -267,7 +267,7 @@ function LoginSelectionPhase({
             "signupData",
             JSON.stringify({
               dateOfBirth: formattedDate,
-              referralCode: referralCode,
+              referralCode: null, // リファラルコードはcookieから取得するためnull
             }),
           );
           router.push("/sign-up-email");

--- a/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
@@ -20,7 +20,6 @@ import { useCallback, useEffect, useState } from "react";
 
 interface TwoStepSignUpFormProps {
   searchParams: Message;
-  referralCode: string | null;
 }
 
 // フェーズ1: 同意・生年月日入力
@@ -194,11 +193,9 @@ function ConsentPhase({
 // フェーズ2: ログイン方法選択
 function LoginSelectionPhase({
   formattedDate,
-  referralCode,
   onBack,
 }: {
   formattedDate: string;
-  referralCode: string | null;
   onBack: () => void;
 }) {
   const [isLoading, setIsLoading] = useState(false);
@@ -290,7 +287,6 @@ function LoginSelectionPhase({
 
 export default function TwoStepSignUpForm({
   searchParams,
-  referralCode,
 }: TwoStepSignUpFormProps) {
   // フェーズ管理
   const [currentPhase, setCurrentPhase] = useState<
@@ -404,7 +400,6 @@ export default function TwoStepSignUpForm({
       ) : (
         <LoginSelectionPhase
           formattedDate={formattedDate}
-          referralCode={referralCode}
           onBack={handleBack}
         />
       )}

--- a/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/TwoStepSignUpForm.tsx
@@ -211,7 +211,6 @@ function LoginSelectionPhase({
         "lineLoginData",
         JSON.stringify({
           dateOfBirth: formattedDate,
-          referralCode: null, // リファラルコードはcookieから取得するためnull
         }),
       );
 
@@ -264,7 +263,6 @@ function LoginSelectionPhase({
             "signupData",
             JSON.stringify({
               dateOfBirth: formattedDate,
-              referralCode: null, // リファラルコードはcookieから取得するためnull
             }),
           );
           router.push("/sign-up-email");

--- a/app/(auth-pages)/sign-up/page.tsx
+++ b/app/(auth-pages)/sign-up/page.tsx
@@ -3,20 +3,16 @@ import Image from "next/image";
 import TwoStepSignUpForm from "./TwoStepSignUpForm";
 
 export default async function Signup(props: {
-  searchParams: Promise<Message & { ref?: string }>;
+  searchParams: Promise<Message>;
 }) {
   const searchParams = await props.searchParams;
-  const referralCode = searchParams.ref ?? null;
 
   return (
     <div className="flex-1 flex flex-col min-w-72">
       <div className="flex justify-center items-center m-4">
         <Image src="/img/logo.png" alt="logo" width={114} height={96} />
       </div>
-      <TwoStepSignUpForm
-        searchParams={searchParams}
-        referralCode={referralCode}
-      />
+      <TwoStepSignUpForm searchParams={searchParams} referralCode={null} />
     </div>
   );
 }

--- a/app/(auth-pages)/sign-up/page.tsx
+++ b/app/(auth-pages)/sign-up/page.tsx
@@ -12,7 +12,7 @@ export default async function Signup(props: {
       <div className="flex justify-center items-center m-4">
         <Image src="/img/logo.png" alt="logo" width={114} height={96} />
       </div>
-      <TwoStepSignUpForm searchParams={searchParams} referralCode={null} />
+      <TwoStepSignUpForm searchParams={searchParams} />
     </div>
   );
 }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -671,7 +671,7 @@ export async function handleLineAuthAction(
       if (finalReferralCode && email) {
         await handleReferralCode(finalReferralCode, email);
         // 紹介コード処理完了後、cookieを削除
-        deleteCookie("referral_code");
+        await deleteCookie("referral_code");
       }
     }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,9 +3,11 @@ import { notoSansJP } from "@/lib/metadata";
 import { ThemeProvider } from "next-themes";
 import Footer from "./footer";
 import "./globals.css";
+import { ReferralCodeHandlerWrapper } from "@/components/ReferralCodeHandlerWrapper";
 import { Toaster } from "@/components/ui/sonner";
 import { generateRootMetadata } from "@/lib/metadata";
 import Script from "next/script";
+import { Suspense } from "react";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 
@@ -52,6 +54,9 @@ export default function RootLayout({
         >
           <Navbar />
           <main className="md:container md:mx-auto flex flex-col items-center">
+            <Suspense>
+              <ReferralCodeHandlerWrapper />
+            </Suspense>
             {children}
           </main>
           <Footer />

--- a/app/missions/[id]/_components/MissionWithSubmissionHistory.tsx
+++ b/app/missions/[id]/_components/MissionWithSubmissionHistory.tsx
@@ -166,7 +166,7 @@ export function MissionWithSubmissionHistory({
   const origin =
     process.env.NEXT_PUBLIC_APP_ORIGIN ||
     (typeof window !== "undefined" ? window.location.origin : "");
-  const signupUrl = `${origin}/sign-up?ref=${referralCode}`;
+  const signupUrl = `${origin}/?ref=${referralCode}`;
 
   return (
     <>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import { ReferralCodeHandler } from "@/components/ReferralCodeHandler";
 import Activities from "@/components/activities";
 import Hero from "@/components/hero";
 import { LevelUpCheck } from "@/components/level-up-check";
@@ -59,9 +58,6 @@ export default async function Home({
 
   return (
     <div className="flex flex-col min-h-screen py-4">
-      {/* リファラルコード処理 */}
-      {referralCode && <ReferralCodeHandler referralCode={referralCode} />}
-
       {/* レベルアップ通知 */}
       {levelUpNotification && (
         <LevelUpCheck levelUpData={levelUpNotification} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { ReferralCodeHandler } from "@/components/ReferralCodeHandler";
 import Activities from "@/components/activities";
 import Hero from "@/components/hero";
 import { LevelUpCheck } from "@/components/level-up-check";
@@ -19,8 +20,14 @@ import { redirect } from "next/navigation";
 // メタデータ生成を外部関数に委譲
 export const generateMetadata = generateRootMetadata;
 
-export default async function Home() {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>;
+}) {
   const supabase = await createClient();
+  const params = await searchParams;
+  const referralCode = params.ref;
 
   const {
     data: { user },
@@ -52,6 +59,9 @@ export default async function Home() {
 
   return (
     <div className="flex flex-col min-h-screen py-4">
+      {/* リファラルコード処理 */}
+      {referralCode && <ReferralCodeHandler referralCode={referralCode} />}
+
       {/* レベルアップ通知 */}
       {levelUpNotification && (
         <LevelUpCheck levelUpData={levelUpNotification} />

--- a/components/ReferralCodeHandler.tsx
+++ b/components/ReferralCodeHandler.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { setClientCookie } from "@/lib/utils/cookies";
+import { useEffect } from "react";
+
+interface ReferralCodeHandlerProps {
+  referralCode: string;
+}
+
+export function ReferralCodeHandler({
+  referralCode,
+}: ReferralCodeHandlerProps) {
+  useEffect(() => {
+    // リファラルコードをcookieに保存（30日間有効）
+    setClientCookie("referral_code", referralCode, {
+      maxAge: 60 * 60 * 24 * 30, // 30日
+      path: "/",
+      sameSite: "lax",
+    });
+
+    // URLからリファラルコードパラメータを削除（履歴に残さない）
+    const url = new URL(window.location.href);
+    url.searchParams.delete("ref");
+    window.history.replaceState({}, "", url.toString());
+  }, [referralCode]);
+
+  // このコンポーネントは何も表示しない
+  return null;
+}

--- a/components/ReferralCodeHandlerWrapper.tsx
+++ b/components/ReferralCodeHandlerWrapper.tsx
@@ -1,0 +1,10 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+import { ReferralCodeHandler } from "./ReferralCodeHandler";
+
+export function ReferralCodeHandlerWrapper() {
+  const searchParams = useSearchParams();
+  const referralCode = searchParams.get("ref");
+  if (!referralCode) return null;
+  return <ReferralCodeHandler referralCode={referralCode} />;
+}

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -610,28 +610,28 @@ export type Database = {
           address_prefecture: string;
           avatar_url: string | null;
           created_at: string;
+          github_username: string | null;
           id: string;
           name: string;
           x_username: string | null;
-          github_username: string | null;
         };
         Insert: {
           address_prefecture: string;
           avatar_url?: string | null;
           created_at: string;
+          github_username?: string | null;
           id: string;
           name: string;
           x_username?: string | null;
-          github_username?: string | null;
         };
         Update: {
           address_prefecture?: string;
           avatar_url?: string | null;
           created_at?: string;
+          github_username?: string | null;
           id?: string;
           name?: string;
           x_username?: string | null;
-          github_username?: string | null;
         };
         Relationships: [];
       };

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -610,28 +610,28 @@ export type Database = {
           address_prefecture: string;
           avatar_url: string | null;
           created_at: string;
-          github_username: string | null;
           id: string;
           name: string;
           x_username: string | null;
+          github_username: string | null;
         };
         Insert: {
           address_prefecture: string;
           avatar_url?: string | null;
           created_at: string;
-          github_username?: string | null;
           id: string;
           name: string;
           x_username?: string | null;
+          github_username: string | null;
         };
         Update: {
           address_prefecture?: string;
           avatar_url?: string | null;
           created_at?: string;
-          github_username?: string | null;
           id?: string;
           name?: string;
           x_username?: string | null;
+          github_username: string | null;
         };
         Relationships: [];
       };

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -622,7 +622,7 @@ export type Database = {
           id: string;
           name: string;
           x_username?: string | null;
-          github_username: string | null;
+          github_username?: string | null;
         };
         Update: {
           address_prefecture?: string;
@@ -631,7 +631,7 @@ export type Database = {
           id?: string;
           name?: string;
           x_username?: string | null;
-          github_username: string | null;
+          github_username?: string | null;
         };
         Relationships: [];
       };

--- a/lib/utils/cookies.ts
+++ b/lib/utils/cookies.ts
@@ -1,0 +1,62 @@
+"use client";
+
+// クライアントサイドでのCookie操作のみを提供
+export function setClientCookie(
+  name: string,
+  value: string,
+  options?: {
+    maxAge?: number;
+    path?: string;
+    domain?: string;
+    secure?: boolean;
+    sameSite?: "strict" | "lax" | "none";
+  },
+) {
+  if (typeof window === "undefined") return;
+
+  const cookieOptions = [
+    `max-age=${options?.maxAge || 60 * 60 * 24 * 30}`,
+    `path=${options?.path || "/"}`,
+  ];
+
+  if (options?.domain) {
+    cookieOptions.push(`domain=${options.domain}`);
+  }
+  if (options?.secure) {
+    cookieOptions.push("secure");
+  }
+  if (options?.sameSite) {
+    cookieOptions.push(`samesite=${options.sameSite}`);
+  }
+
+  document.cookie = `${name}=${value}; ${cookieOptions.join("; ")}`;
+}
+
+export function getClientCookie(name: string): string | undefined {
+  if (typeof window === "undefined") return undefined;
+
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    return parts.pop()?.split(";").shift();
+  }
+  return undefined;
+}
+
+export function deleteClientCookie(
+  name: string,
+  options?: {
+    path?: string;
+    domain?: string;
+  },
+) {
+  if (typeof window === "undefined") return;
+
+  const cookieOptions = [`path=${options?.path || "/"}`, "max-age=0"];
+
+  if (options?.domain) {
+    cookieOptions.push(`domain=${options.domain}`);
+  }
+
+  document.cookie = `${name}=; ${cookieOptions.join("; ")}`;
+}

--- a/lib/utils/server-cookies.ts
+++ b/lib/utils/server-cookies.ts
@@ -1,0 +1,47 @@
+import { cookies } from "next/headers";
+
+// サーバーサイドでのCookie操作
+export async function setCookie(
+  name: string,
+  value: string,
+  options?: {
+    maxAge?: number;
+    path?: string;
+    domain?: string;
+    secure?: boolean;
+    httpOnly?: boolean;
+    sameSite?: "strict" | "lax" | "none";
+  },
+) {
+  const cookieStore = await cookies();
+  cookieStore.set(name, value, {
+    maxAge: options?.maxAge || 60 * 60 * 24 * 30, // デフォルト30日
+    path: options?.path || "/",
+    domain: options?.domain,
+    secure: options?.secure,
+    httpOnly: options?.httpOnly || false,
+    sameSite: options?.sameSite || "lax",
+  });
+}
+
+// Cookieの取得
+export async function getCookie(name: string): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  return cookieStore.get(name)?.value;
+}
+
+// Cookieの削除
+export async function deleteCookie(
+  name: string,
+  options?: {
+    path?: string;
+    domain?: string;
+  },
+) {
+  const cookieStore = await cookies();
+  cookieStore.delete({
+    name,
+    path: options?.path || "/",
+    domain: options?.domain,
+  });
+}


### PR DESCRIPTION
# 変更の概要

## 主な変更内容

- **紹介URLの遷移先変更**: 紹介URL（`/?ref=xxxxx`）にアクセスした際、直接サインアップ画面ではなくトップページに遷移するように変更

- **リファラルコード処理の統一**: メールサインアップとLINEログインの両方でcookie経由でのリファラルコード処理に統一

- **Cookie操作の分離**: クライアントサイド用（`lib/utils/cookies.ts`）とサーバーサイド用（`lib/utils/server-cookies.ts`）に分離

- **トップページでのリファラルコード処理**: `ReferralCodeHandler`コンポーネントを新規作成し、トップページでリファラルコードをcookieに保存

- **サインアップフォームの簡素化**: リファラルコードのhiddenフィールドを削除し、cookie経由での処理に変更

- **セキュリティ向上**: リファラルコード処理完了後のcookie自動削除機能を追加

## 新規作成ファイル
- `components/ReferralCodeHandler.tsx`
- `lib/utils/cookies.ts`
- `lib/utils/server-cookies.ts`

## 修正ファイル
- `app/page.tsx` - リファラルコードハンドラーの追加
- `app/actions.ts` - cookie経由でのリファラルコード処理に変更
- サインアップ関連ページ - リファラルコード処理の簡素化

## 見た目の変化

https://github.com/user-attachments/assets/441e0eb4-2187-432d-88ba-235a90a39635



# 変更の背景
- 紹介URLにアクセスしたとき、いきなり新規登録画面に入ると唐突感があるため
- closes #556

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * リファラルコードをURLクエリから自動的にクッキーへ保存し、以降のサインアップや認証で自動的に利用されるようになりました。
  * リファラルコードの管理用コンポーネントおよびクッキー操作ユーティリティを追加しました。

* **仕様変更**
  * サインアップフォームからリファラルコード入力欄を削除しました。
  * サインアップURLが `/sign-up` からトップページ（`/`）に変更されました。

* **バグ修正**
  * リファラルコードが確実に一度だけ利用され、利用後はクッキーから削除されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->