### PR TITLE
#716: ポスティングミッション取り消し時のxp減算ができていない

### DIFF
--- a/app/missions/[id]/actions.ts
+++ b/app/missions/[id]/actions.ts
@@ -1,7 +1,11 @@
 "use server";
 
 import { ARTIFACT_TYPES } from "@/lib/artifactTypes"; // パス変更
-import { grantMissionCompletionXp, grantXp } from "@/lib/services/userLevel";
+import {
+  getUserXpBonus,
+  grantMissionCompletionXp,
+  grantXp,
+} from "@/lib/services/userLevel";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { calculateMissionXp } from "@/lib/utils/utils";
 
@@ -616,9 +620,15 @@ export const cancelSubmissionAction = async (formData: FormData) => {
 
   // XPを減算する（ミッション達成時に付与されたXPを取り消し）
   const xpToRevoke = calculateMissionXp(missionData.difficulty);
+  const bonusXp =
+    missionData.title === "チームみらいの機関誌をポスティングしよう"
+      ? await getUserXpBonus(authUser.id, validatedAchievementId)
+      : 0;
+  const totalXpToRevoke = xpToRevoke + bonusXp;
+
   const xpResult = await grantXp(
     authUser.id,
-    -xpToRevoke, // 負の値でXPを減算
+    -totalXpToRevoke, // 負の値でXPを減算
     "MISSION_CANCELLATION",
     validatedAchievementId,
     `ミッション「${missionData.title}」の提出取り消しによる経験値減算`,

--- a/app/missions/[id]/actions.ts
+++ b/app/missions/[id]/actions.ts
@@ -592,7 +592,7 @@ export const cancelSubmissionAction = async (formData: FormData) => {
   // ミッション情報を取得してXP計算のための難易度を確認
   const { data: missionData, error: missionFetchError } = await supabase
     .from("missions")
-    .select("difficulty, title")
+    .select("difficulty, title, slug")
     .eq("id", achievement.mission_id)
     .single();
 
@@ -621,7 +621,7 @@ export const cancelSubmissionAction = async (formData: FormData) => {
   // XPを減算する（ミッション達成時に付与されたXPを取り消し）
   const xpToRevoke = calculateMissionXp(missionData.difficulty);
   const bonusXp =
-    missionData.title === "チームみらいの機関誌をポスティングしよう"
+    missionData.slug === "posting-magazine"
       ? await getUserXpBonus(authUser.id, validatedAchievementId)
       : 0;
   const totalXpToRevoke = xpToRevoke + bonusXp;

--- a/lib/services/userLevel.ts
+++ b/lib/services/userLevel.ts
@@ -208,6 +208,31 @@ export async function getUserXpHistory(
 }
 
 /**
+ * ユーザーのBONUSXPを取得する
+ */
+export async function getUserXpBonus(
+  userId: string,
+  achievementId: string,
+): Promise<number> {
+  const supabase = await createServiceClient();
+
+  const { data, error } = await supabase
+    .from("xp_transactions")
+    .select("xp_amount")
+    .eq("user_id", userId)
+    .eq("source_id", achievementId)
+    .eq("source_type", "BONUS")
+    .single();
+
+  if (error) {
+    console.error("Failed to fetch BONUS XP:", error);
+    return 0;
+  }
+
+  return data.xp_amount || 0;
+}
+
+/**
  * 特定ユーザーのランクを取得する
  */
 export async function getUserRank(userId: string): Promise<number | null> {


### PR DESCRIPTION
# 変更の概要
- ポスティングミッション取り消し時に、基本xp のみ取り消されていて、BONUS の xp は取り消されない状態だった
- ポスティングミッション取り消し時に、BONUS の xp も取り消すように修正した

# 変更の背景
- ポスティングミッション取り消し時に、経験値が減算されない
- closes #716 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクショ

**user_levels（最初の状態）**
![スクリーンショット 2025-06-27 23 30 32](https://github.com/user-attachments/assets/46662b85-7d96-4d61-bfca-c2551d00a973)

**ポスティングミッションで 1000 枚記録**
![スクリーンショット 2025-06-27 23 31 58](https://github.com/user-attachments/assets/d853a649-6cb0-4bcb-8529-99a20392c89a)

**user_levels の xp に 10100 追加**
![スクリーンショット 2025-06-27 23 32 48](https://github.com/user-attachments/assets/43658b1a-2d77-4f61-a0fb-0919d5e90049)

**取り消し**
![スクリーンショット 2025-06-27 23 33 49](https://github.com/user-attachments/assets/4ac1c3fa-c041-479b-87e4-98b603063e3c)

**user_levels の xp から 10100 減算**
![スクリーンショット 2025-06-27 23 34 20](https://github.com/user-attachments/assets/37c82fa6-0c7a-477a-9a24-dd785ddf234c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **新機能**
  * 特定のミッションタイトルの場合、キャンセル時にボーナスXPも含めてXPが減算されるようになりました。

* **バグ修正**
  * ユーザーのボーナスXP減算時の処理が正しく行われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->