### PR TITLE
#588: 「チームみらいの機関誌をポスティングしよう」を達成した後の獲得のポイントの文言が100ptで固定されている

### DIFF
--- a/app/missions/[id]/actions.ts
+++ b/app/missions/[id]/actions.ts
@@ -177,6 +177,9 @@ export const achieveMissionAction = async (formData: FormData) => {
     locationText,
   });
 
+  // ポスティングボーナスXP + ミッション達成XP 用の変数
+  let totalXpGranted = 0;
+
   if (!validatedFields.success) {
     return {
       success: false,
@@ -487,6 +490,7 @@ export const achieveMissionAction = async (formData: FormData) => {
       // ポスティング用のポイント計算とXP付与
       const pointsPerUnit = POSTING_POINTS_PER_UNIT; // 固定値（フェーズ1では固定、フェーズ2で設定テーブルから取得予定）
       const totalPoints = validatedData.postingCount * pointsPerUnit;
+      totalXpGranted += totalPoints;
 
       // 通常のXP（ミッション難易度ベース）に加えて、ポスティングボーナスXPを付与
       const bonusXpResult = await grantXp(
@@ -518,11 +522,11 @@ export const achieveMissionAction = async (formData: FormData) => {
     console.error("XP付与に失敗しました:", xpResult.error);
     // XP付与の失敗はミッション達成の成功を妨げない
   }
-
+  totalXpGranted += xpResult?.xpGranted ?? 0;
   return {
     success: true,
     message: "ミッションを達成しました！",
-    xpGranted: xpResult.xpGranted,
+    xpGranted: totalXpGranted,
     userLevel: xpResult.userLevel,
   };
 };

--- a/app/missions/[id]/actions.ts
+++ b/app/missions/[id]/actions.ts
@@ -490,7 +490,6 @@ export const achieveMissionAction = async (formData: FormData) => {
       // ポスティング用のポイント計算とXP付与
       const pointsPerUnit = POSTING_POINTS_PER_UNIT; // 固定値（フェーズ1では固定、フェーズ2で設定テーブルから取得予定）
       const totalPoints = validatedData.postingCount * pointsPerUnit;
-      totalXpGranted += totalPoints;
 
       // 通常のXP（ミッション難易度ベース）に加えて、ポスティングボーナスXPを付与
       const bonusXpResult = await grantXp(
@@ -507,6 +506,8 @@ export const achieveMissionAction = async (formData: FormData) => {
           bonusXpResult.error,
         );
         // ボーナスXP付与の失敗はミッション達成の成功を妨げない
+      } else {
+        totalXpGranted += totalPoints;
       }
     }
   }


### PR DESCRIPTION
# 変更の概要
- ミッション達成時に表示される経験値が基礎経験値になっていた
- ポスティング枚数によるボーナスポイントも含めた経験値を表示するようにした

### 現状、50 枚で登録しても「100ポイント獲得しました！ 」という表示になっている図
![スクリーンショット 2025-06-28 12 48 49](https://github.com/user-attachments/assets/12e3b035-d208-44bc-90f7-77091c12be7d)
![スクリーンショット 2025-06-28 12 49 33](https://github.com/user-attachments/assets/e8258a85-89e9-4bae-a3a6-e2ef2f70f318)

# 変更の背景
- 実際に加算されているポイントは枚数に応じて計算されたものですが、表示が難易度に応じた100ptで固定されており、ユーザーにとってわかりづらい
- closes #588 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

#  スクショ

50 枚で記録した場合
![スクリーンショット 2025-06-28 12 42 25](https://github.com/user-attachments/assets/e9582488-71c8-4d1f-806a-c998832f6260)

600ポイント獲得しました！ と表示される（100 + 500 = 600）
![スクリーンショット 2025-06-28 12 42 53](https://github.com/user-attachments/assets/90d66d31-76df-4b33-b415-27094eec0353)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ミッション達成時に付与されるXPが、投稿ボーナスXPとミッション完了XPの合計値として正しく表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->