### PR TITLE
ポスターマップページの「ミッション一覧に戻る」のリンクを修正

### DIFF
--- a/app/map/poster/PosterMapPageClient.tsx
+++ b/app/map/poster/PosterMapPageClient.tsx
@@ -290,7 +290,7 @@ export default function PosterMapPageClient() {
       {/* Action Button */}
       <div className="flex justify-center pt-4">
         <Button size="lg" asChild>
-          <Link href="/missions">
+          <Link href="/#featured-missions">
             ミッション一覧に戻る
             <ChevronRight className="ml-2 h-4 w-4" />
           </Link>


### PR DESCRIPTION
# 変更の概要
- ミッション一覧に戻る のリンクを修正した
- 以下と同様に `/#featured-missions` （トップページの重要ミッションのセクション）を指定する形に修正した
https://github.com/team-mirai-volunteer/action-board/blob/efe808f6b8eb01c8e8ad517e77be3cd5811f892c/app/missions/%5Bid%5D/_components/MissionFormWrapper.tsx#L318-L322

> ![スクリーンショット 2025-06-28 22 38 49](https://github.com/user-attachments/assets/642ed5eb-1ee5-42b7-bf78-36886b7a1b1f)

# 変更の背景
/missions というページが存在しないため、404 になってしまう
> ![スクリーンショット 2025-06-28 22 39 32](https://github.com/user-attachments/assets/60a4826c-00a2-4d9c-b87f-ec8d8d95ce31)

https://github.com/team-mirai-volunteer/action-board/blob/efe808f6b8eb01c8e8ad517e77be3cd5811f892c/app/map/poster/PosterMapPageClient.tsx#L293-L295
- closes なし

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * アクションボタンのリンク先が「/missions」からホームページの「#featured-missions」セクションに変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->