### PR TITLE
fix: カテゴリとミッションのタイトルにおける「Tiktok」を「TikTok」に修正

### DIFF
--- a/mission_data/categories.yaml
+++ b/mission_data/categories.yaml
@@ -36,7 +36,7 @@ categories:
     sort_no: 900
     category_kbn: DEFAULT
   - slug: support-on-tiktok
-    title: Tiktokで応援しよう
+    title: TikTokで応援しよう
     sort_no: 1000
     category_kbn: DEFAULT
   - slug: support-on-x

--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -64,15 +64,15 @@ missions:
     artifact_label: あなたのXアカウント名
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//11_follow_teammirai_x.png
   - slug: follow-teammirai-tiktok
-    title: 公式Tiktokをフォローしよう
+    title: 公式TikTokをフォローしよう
     icon_url: /img/mission_fallback.svg
-    content: '<a href="https://www.tiktok.com/@annotakahiro2024" target="_blank" rel="noopener noreferrer">チームみらいの公式Tiktokアカウント</a>をフォローして、ショート動画をチェックしよう！安野たかひろの解説動画をはじめ、候補者の街頭演説や舞台裏トークなど、お忙しい方でも気軽にご覧いただけるコンテンツを揃えています。'
+    content: '<a href="https://www.tiktok.com/@annotakahiro2024" target="_blank" rel="noopener noreferrer">チームみらいの公式TikTokアカウント</a>をフォローして、ショート動画をチェックしよう！安野たかひろの解説動画をはじめ、候補者の街頭演説や舞台裏トークなど、お忙しい方でも気軽にご覧いただけるコンテンツを揃えています。'
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1
     is_featured: false
     is_hidden: false
-    artifact_label: あなたのTiktokアカウント名
+    artifact_label: あなたのTikTokアカウント名
     ogp_image_url: null
     event_date: null
   - slug: share-manifest-sns

--- a/supabase/migrations/20250623115600_update_mission_category.sql
+++ b/supabase/migrations/20250623115600_update_mission_category.sql
@@ -13,7 +13,7 @@ values
 ('720b511c-8be3-8e0c-e2ae-d95be1613281', 'クイズで学ぼう', 700, 'DEFAULT'),
 ('19bb0960-86af-4162-2351-530f664ac5b5', '政策を改善しよう', 800, 'DEFAULT'),
 ('373fe78b-9e63-96f7-40af-650120a599f1', 'YouTubeで応援しよう', 900, 'DEFAULT'),
-('91a10bef-fab0-1a99-c8d5-4353cd39c402', 'Tiktokで応援しよう', 1000, 'DEFAULT'),
+('91a10bef-fab0-1a99-c8d5-4353cd39c402', 'TikTokで応援しよう', 1000, 'DEFAULT'),
 ('089ed58c-9bbc-fb5d-8b51-e608906a965c', 'Xで応援しよう', 1100, 'DEFAULT'),
 ('6d4a5924-5411-277c-9c7d-911df2b717a1', 'noteで応援しよう', 1200, 'DEFAULT'),
 ('cb1da45e-740d-5ad9-55e8-40cb5c8446e1', '作って応援しよう', 1300, 'DEFAULT');
@@ -33,7 +33,7 @@ values
 --   (coalesce((select id from missions where title = '公式LINEアカウントと友達になろう'), '00000000-0000-0000-0000-000000000000'), '8b36a669-3457-0b67-308b-b4b8b0a3356d', 100),
 --   (coalesce((select id from missions where title = '公式YouTubeチャンネルを登録しよう'), '00000000-0000-0000-0000-000000000000'), '8b36a669-3457-0b67-308b-b4b8b0a3356d', 200),
 --   (coalesce((select id from missions where title = 'チームみらいの公式Xをフォローしよう'), '00000000-0000-0000-0000-000000000000'), '8b36a669-3457-0b67-308b-b4b8b0a3356d', 300),
--- --   (coalesce((select id from missions where title = '公式Tiktokをフォローしよう'), '00000000-0000-0000-0000-000000000000'), '8b36a669-3457-0b67-308b-b4b8b0a3356d', 400),
+-- --   (coalesce((select id from missions where title = '公式TikTokをフォローしよう'), '00000000-0000-0000-0000-000000000000'), '8b36a669-3457-0b67-308b-b4b8b0a3356d', 400),
 --   (coalesce((select id from missions where title = '公式noteをフォローしよう'), '00000000-0000-0000-0000-000000000000'), '8b36a669-3457-0b67-308b-b4b8b0a3356d', 500),
 
 -- -- 3. コミュニティに参加しよう
@@ -44,7 +44,7 @@ values
 
 -- -- 4. いいねで応援しよう
 -- --   (coalesce((select id from missions where title = 'YouTubeでチームみらい動画に高評価をつけよう'), '00000000-0000-0000-0000-000000000000'), '504a2520-23e3-e49b-e3f8-9e97981a1d03', 100),
--- --   (coalesce((select id from missions where title = 'Tiktokでチームみらい動画に♡をつけよう'), '00000000-0000-0000-0000-000000000000'), '504a2520-23e3-e49b-e3f8-9e97981a1d03', 200),
+-- --   (coalesce((select id from missions where title = 'TikTokでチームみらい動画に♡をつけよう'), '00000000-0000-0000-0000-000000000000'), '504a2520-23e3-e49b-e3f8-9e97981a1d03', 200),
 -- --   (coalesce((select id from missions where title = 'Xでチームみらい投稿に♡をつけよう'), '00000000-0000-0000-0000-000000000000'), '504a2520-23e3-e49b-e3f8-9e97981a1d03', 300),
 -- --   (coalesce((select id from missions where title = 'noteでチームみらい記事にスキ♡をつけよう'), '00000000-0000-0000-0000-000000000000'), '504a2520-23e3-e49b-e3f8-9e97981a1d03', 400),
 -- --   (coalesce((select id from missions where title = 'Instagramでチームみらい投稿に♡をつけよう'), '00000000-0000-0000-0000-000000000000'), '504a2520-23e3-e49b-e3f8-9e97981a1d03', 500),
@@ -82,9 +82,9 @@ values
 -- --   (coalesce((select id from missions where title = 'YouTubeでチームみらい動画に高評価をつけよう'), '00000000-0000-0000-0000-000000000000'), '373fe78b-9e63-96f7-40af-650120a599f1', 300),
 --   (coalesce((select id from missions where title = 'YouTube動画を切り抜こう'), '00000000-0000-0000-0000-000000000000'), '373fe78b-9e63-96f7-40af-650120a599f1', 400),
 
--- -- 10. Tiktokで応援しよう
--- --   (coalesce((select id from missions where title = '公式Tiktokをフォローしよう'), '00000000-0000-0000-0000-000000000000'), '91a10bef-fab0-1a99-c8d5-4353cd39c402', 100),
--- --   (coalesce((select id from missions where title = 'Tiktokでチームみらい動画に♡をつけよう'), '00000000-0000-0000-0000-000000000000'), '91a10bef-fab0-1a99-c8d5-4353cd39c402', 200),
+-- -- 10. TikTokで応援しよう
+-- --   (coalesce((select id from missions where title = '公式TikTokをフォローしよう'), '00000000-0000-0000-0000-000000000000'), '91a10bef-fab0-1a99-c8d5-4353cd39c402', 100),
+-- --   (coalesce((select id from missions where title = 'TikTokでチームみらい動画に♡をつけよう'), '00000000-0000-0000-0000-000000000000'), '91a10bef-fab0-1a99-c8d5-4353cd39c402', 200),
 
 -- -- 11. Xで応援しよう
 --   (coalesce((select id from missions where title = 'チームみらいの公式Xをフォローしよう'), '00000000-0000-0000-0000-000000000000'), '089ed58c-9bbc-fb5d-8b51-e608906a965c', 100),


### PR DESCRIPTION
# 変更の概要
TikTok表記揺れが発生していたので対応

（#692 の対応で気付かずすみません... :pray:
これ以外の箇所もついでに修正しております）

### 見た目の変化

<img width="286" alt="スクリーンショット 2025-06-29 11 05 53" src="https://github.com/user-attachments/assets/4b5fba56-b16d-4fe9-b53f-d31b2e7ae226" />
<img width="479" alt="スクリーンショット 2025-06-29 11 06 23" src="https://github.com/user-attachments/assets/f5739f7a-e756-4942-a8b2-9fc7ca2e43ef" />


# 変更の背景
アクションボードで遊んでいたらたまたま発見

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カテゴリーおよびミッション内の「Tiktok」の表記を「TikTok」に修正し、ブランド名の正しい大文字表記に統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->