### PR TITLE
mission_artifacts の link_url を重複チェック

### DIFF
--- a/app/missions/[id]/actions.ts
+++ b/app/missions/[id]/actions.ts
@@ -407,6 +407,52 @@ export const achieveMissionAction = async (formData: FormData) => {
       };
     }
 
+    // LINK重複バリデーション（mission_idベースで正確に判定）
+    if (
+      validatedRequiredArtifactType === ARTIFACT_TYPES.LINK.key &&
+      validatedData.requiredArtifactType === ARTIFACT_TYPES.LINK.key
+    ) {
+      // まず同じユーザー・LINKタイプ・同じURLの成果物を全て取得
+      const { data: candidateArtifacts, error: candidateError } = await supabase
+        .from("mission_artifacts")
+        .select("id, achievement_id")
+        .eq("user_id", authUser.id)
+        .eq("artifact_type", ARTIFACT_TYPES.LINK.key)
+        .eq("link_url", validatedData.artifactLink);
+      if (candidateError) {
+        return {
+          success: false,
+          error: "重複チェック中にエラーが発生しました。",
+        };
+      }
+      if (candidateArtifacts && candidateArtifacts.length > 0) {
+        // 各成果物のachievement_idからmission_idを取得し、今回のmissionIdと一致するものがあれば重複
+        const achievementIds = candidateArtifacts.map((a) => a.achievement_id);
+        if (achievementIds.length > 0) {
+          const { data: achievements, error: achievementsError } =
+            await supabase
+              .from("achievements")
+              .select("id, mission_id")
+              .in("id", achievementIds);
+          if (achievementsError) {
+            return {
+              success: false,
+              error: "重複チェック中にエラーが発生しました。",
+            };
+          }
+          const isDuplicate = achievements.some(
+            (ach) => ach.mission_id === validatedMissionId,
+          );
+          if (isDuplicate) {
+            return {
+              success: false,
+              error: "同じリンクはすでに登録されています。",
+            };
+          }
+        }
+      }
+    }
+
     const { data: newArtifact, error: artifactError } = await supabase
       .from("mission_artifacts")
       .insert(artifactPayload)


### PR DESCRIPTION
# 変更の概要
- link_url を重複チェックを追加し、すでに登録済みの URL を登録しようとすると失敗するようにしました

> ![スクリーンショット 2025-06-30 0 02 54](https://github.com/user-attachments/assets/0ebbd052-eeb1-41ed-bd3e-08fcbcde53cf)

# 変更の背景
- すでに登録している URL も登録できてしまう
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました