### PR TITLE
feat: ポスターマップをログインなしで閲覧可能にする

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -248,15 +248,15 @@ export default function PrefecturePosterMapClient({
           <DialogHeader>
             <DialogTitle>ステータスを更新</DialogTitle>
             <DialogDescription>
-              <div>{selectedBoard?.name}のステータスを更新します</div>
-              {selectedBoard && (
-                <>
-                  <div className="mt-1 text-sm">{selectedBoard.address}</div>
-                  <div className="text-sm">{selectedBoard.city}</div>
-                </>
-              )}
+              {selectedBoard?.name}のステータスを更新します
             </DialogDescription>
           </DialogHeader>
+          {selectedBoard && (
+            <div className="mb-4 text-sm text-muted-foreground">
+              <div>{selectedBoard.address}</div>
+              <div>{selectedBoard.city}</div>
+            </div>
+          )}
           <div className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="status">新しいステータス</Label>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -51,7 +51,7 @@ type StatusHistory =
   };
 
 interface PrefecturePosterMapClientProps {
-  userId: string;
+  userId?: string;
   prefecture: string;
   prefectureName: string;
   center: [number, number];
@@ -91,6 +91,10 @@ export default function PrefecturePosterMapClient({
   };
 
   const handleBoardSelect = (board: PosterBoard) => {
+    if (!userId) {
+      toast.info("ステータスを更新するにはログインが必要です");
+      return;
+    }
     setSelectedBoard(board);
     setUpdateStatus(board.status);
     setUpdateNote("");
@@ -100,7 +104,7 @@ export default function PrefecturePosterMapClient({
   };
 
   const loadHistory = async () => {
-    if (!selectedBoard) return;
+    if (!selectedBoard || !userId) return;
 
     setLoadingHistory(true);
     try {
@@ -169,7 +173,9 @@ export default function PrefecturePosterMapClient({
             {prefectureName}のポスター掲示板
           </h1>
           <p className="text-muted-foreground">
-            掲示板をクリックしてステータスを更新できます
+            {userId
+              ? "掲示板をクリックしてステータスを更新できます"
+              : "ログインするとステータスを更新できます"}
           </p>
         </div>
       </div>
@@ -329,20 +335,23 @@ export default function PrefecturePosterMapClient({
           )}
 
           <DialogFooter className="flex items-center justify-between">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                if (!showHistory) {
-                  loadHistory();
-                }
-                setShowHistory(!showHistory);
-              }}
-              type="button"
-            >
-              <History className="mr-2 h-4 w-4" />
-              履歴
-            </Button>
+            {userId && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  if (!showHistory) {
+                    loadHistory();
+                  }
+                  setShowHistory(!showHistory);
+                }}
+                type="button"
+              >
+                <History className="mr-2 h-4 w-4" />
+                履歴
+              </Button>
+            )}
+            {!userId && <div />}
             <div className="flex gap-2">
               <Button
                 variant="outline"

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -335,23 +335,20 @@ export default function PrefecturePosterMapClient({
           )}
 
           <DialogFooter className="flex items-center justify-between">
-            {userId && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  if (!showHistory) {
-                    loadHistory();
-                  }
-                  setShowHistory(!showHistory);
-                }}
-                type="button"
-              >
-                <History className="mr-2 h-4 w-4" />
-                履歴
-              </Button>
-            )}
-            {!userId && <div />}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                if (!showHistory) {
+                  loadHistory();
+                }
+                setShowHistory(!showHistory);
+              }}
+              type="button"
+            >
+              <History className="mr-2 h-4 w-4" />
+              履歴
+            </Button>
             <div className="flex gap-2">
               <Button
                 variant="outline"

--- a/app/map/poster/[prefecture]/page.tsx
+++ b/app/map/poster/[prefecture]/page.tsx
@@ -38,10 +38,6 @@ export default async function PrefecturePosterMapPage({
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user) {
-    return redirect("/sign-in");
-  }
-
   // Validate prefecture parameter
   if (!validPrefectures.includes(prefecture as PosterPrefectureKey)) {
     return redirect("/map/poster");
@@ -52,7 +48,7 @@ export default async function PrefecturePosterMapPage({
 
   return (
     <PrefecturePosterMapClient
-      userId={user.id}
+      userId={user?.id}
       prefecture={prefectureNameJp}
       prefectureName={prefectureNameJp}
       center={center}

--- a/app/map/poster/page.tsx
+++ b/app/map/poster/page.tsx
@@ -1,6 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
 import PosterMapPageClient from "./PosterMapPageClient";
 
 export const metadata: Metadata = {
@@ -9,15 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default async function PosterMapPage() {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return redirect("/sign-in");
-  }
-
   return <PosterMapPageClient />;
 }

--- a/supabase/migrations/20250701131916_allow_public_read_poster_boards.sql
+++ b/supabase/migrations/20250701131916_allow_public_read_poster_boards.sql
@@ -1,0 +1,10 @@
+-- Allow anonymous users to read poster boards
+DROP POLICY IF EXISTS "poster_boards_authenticated_select" ON public.poster_boards;
+CREATE POLICY "poster_boards_public_select" ON public.poster_boards
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- Keep poster board status history private (authenticated users only)
+-- Note: We are not modifying the existing RLS policy for poster_board_status_history
+-- to protect user privacy. Only authenticated users can view the history.

--- a/tests/rls/poster-boards.test.ts
+++ b/tests/rls/poster-boards.test.ts
@@ -44,7 +44,7 @@ describe("poster_boards テーブルのRLSテスト", () => {
   });
 
   describe("SELECT操作", () => {
-    it("匿名ユーザーはボードを閲覧できない", async () => {
+    it("匿名ユーザーはボードを閲覧できる", async () => {
       const anonClient = getAnonClient();
       const { data, error } = await anonClient
         .from("poster_boards")
@@ -52,7 +52,8 @@ describe("poster_boards テーブルのRLSテスト", () => {
         .eq("id", testBoardId);
 
       expect(error).toBeNull();
-      expect(data).toEqual([]);
+      expect(data).toHaveLength(1);
+      expect(data![0].id).toBe(testBoardId);
     });
 
     it("認証済みユーザーはボードを閲覧できる", async () => {


### PR DESCRIPTION
# 変更の概要
- ログインしていないユーザーでもポスターボード一覧を閲覧できる
- 更新・履歴の閲覧は不可

# 変更の背景
- closes #791 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

## Test plan
- [x] ログインしていない状態で `/map/poster` にアクセスできることを確認
- [x] ログインしていない状態で都道府県別のポスターマップを閲覧できることを確認
- [x] ログインしていない状態でボードをクリックするとログインを促すメッセージが表示されることを確認
- [x] ログインしていない状態で履歴ボタンが表示されないことを確認
- [x] ログイン状態でボードのステータス更新ができることを確認
- [x] ログイン状態で履歴ボタンが表示され、履歴を閲覧できることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **新機能**
  * ログインしていないユーザーでもポスターボード一覧を閲覧できるようになりました。

* **UIの改善**
  * 未ログイン時、ステータス更新や履歴閲覧はできず、ログインを促すメッセージが表示されます。
  * ステータス更新ダイアログの表示が見やすく改善されました。

* **テスト**
  * 匿名ユーザーがボードを閲覧できることを確認するテストに修正されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->