### PR TITLE
feat: ログイン後に元のページに戻る機能を実装

### DIFF
--- a/app/(auth-pages)/sign-in/SignInForm.tsx
+++ b/app/(auth-pages)/sign-in/SignInForm.tsx
@@ -10,14 +10,18 @@ import { signInWithLine } from "@/lib/auth/line-auth";
 import Link from "next/link";
 import { useActionState, useState } from "react";
 
-export default function SignInForm() {
+interface SignInFormProps {
+  returnUrl?: string;
+}
+
+export default function SignInForm({ returnUrl }: SignInFormProps) {
   const [state, formAction] = useActionState(signInActionWithState, null);
   const [isLineLoading, setIsLineLoading] = useState(false);
 
   const handleLINELogin = async () => {
     try {
       setIsLineLoading(true);
-      await signInWithLine();
+      await signInWithLine(returnUrl);
     } catch (error) {
       setIsLineLoading(false);
     }
@@ -50,6 +54,9 @@ export default function SignInForm() {
       <form action={formAction} className="flex flex-col gap-2 [&>input]:mb-3">
         {state?.error && (
           <FormMessage message={{ error: state.error }} className="mb-4" />
+        )}
+        {returnUrl && (
+          <input type="hidden" name="returnUrl" value={returnUrl} />
         )}
 
         <Label htmlFor="email">メールアドレス</Label>

--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -3,7 +3,9 @@ import Image from "next/image";
 import Link from "next/link";
 import SignInForm from "./SignInForm";
 
-export default async function Login(props: { searchParams: Promise<Message> }) {
+export default async function Login(props: {
+  searchParams: Promise<Message & { returnUrl?: string }>;
+}) {
   const searchParams = await props.searchParams;
   return (
     <div className="flex-1 flex flex-col min-w-72">
@@ -18,7 +20,7 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
         </Link>
       </p>
       <FormMessage className="mt-8" message={searchParams} />
-      <SignInForm />
+      <SignInForm returnUrl={searchParams.returnUrl} />
     </div>
   );
 }

--- a/app/(protected)/settings/profile/ProfileForm.tsx
+++ b/app/(protected)/settings/profile/ProfileForm.tsx
@@ -28,6 +28,7 @@ import { updateProfile } from "./actions";
 interface ProfileFormProps {
   message?: Message;
   isNew: boolean;
+  returnUrl?: string;
   initialProfile: {
     name?: string;
     address_prefecture?: string;
@@ -45,6 +46,7 @@ interface ProfileFormProps {
 export default function ProfileForm({
   message,
   isNew,
+  returnUrl,
   initialProfile,
   initialPrivateUser,
 }: ProfileFormProps) {
@@ -71,12 +73,13 @@ export default function ProfileForm({
   useEffect(() => {
     // フォーム送信成功時の処理
     if (state?.success && isNew) {
-      router.push("/");
+      // 新規ユーザーの場合、returnUrlがあればそこへ、なければホームへ
+      router.push(returnUrl || "/");
     }
     if (state?.success) {
       setQueryMessage(undefined);
     }
-  }, [state?.success, isNew, router]);
+  }, [state?.success, isNew, router, returnUrl]);
 
   // ファイル選択時のプレビュー処理
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/(protected)/settings/profile/page.tsx
+++ b/app/(protected)/settings/profile/page.tsx
@@ -5,6 +5,7 @@ import ProfileForm from "./ProfileForm";
 
 type ProfileSettingsPageSearchParams = {
   new: string;
+  returnUrl?: string;
 } & Message;
 
 export default async function ProfileSettingsPage({
@@ -44,6 +45,7 @@ export default async function ProfileSettingsPage({
       <ProfileForm
         message={params}
         isNew={isNew}
+        returnUrl={params?.returnUrl}
         initialProfile={{
           name: privateUser?.name || user.user_metadata.name || "",
           address_prefecture: privateUser?.address_prefecture || "",

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -204,6 +204,7 @@ export const signInActionWithState = async (
 ) => {
   const email = formData.get("email")?.toString();
   const password = formData.get("password")?.toString();
+  const returnUrl = formData.get("returnUrl")?.toString();
 
   // フォームデータを保存（エラー時の状態復元用、メールアドレスのみ）
   const currentFormData = {
@@ -242,7 +243,7 @@ export const signInActionWithState = async (
     };
   }
 
-  return redirect("/");
+  return redirect(returnUrl || "/");
 };
 
 export const signInAction = async (formData: FormData) => {
@@ -474,6 +475,7 @@ export async function handleLineAuthAction(
   code: string,
   dateOfBirth?: string,
   referralCode?: string | null,
+  returnUrl?: string,
 ): Promise<
   { success: true; redirectTo: string } | { success: false; error: string }
 > {
@@ -705,14 +707,20 @@ export async function handleLineAuthAction(
 
     // 7. リダイレクト先を返す
     if (isNewUser) {
+      // 新規ユーザーの場合、プロフィール設定へ（returnUrlを保持）
+      const profileUrl = returnUrl
+        ? `/settings/profile?new=true&returnUrl=${encodeURIComponent(returnUrl)}`
+        : "/settings/profile?new=true";
       return {
         success: true,
-        redirectTo: "/settings/profile?new=true",
+        redirectTo: profileUrl,
       };
     }
+
+    // 既存ユーザーの場合、returnUrlまたはホームへ
     return {
       success: true,
-      redirectTo: "/?login=success",
+      redirectTo: returnUrl || "/?login=success",
     };
   } catch (error) {
     return {

--- a/app/auth/line-callback/page.tsx
+++ b/app/auth/line-callback/page.tsx
@@ -58,10 +58,21 @@ function LineCallbackContent() {
 
         const code = searchParams.get("code");
         const state = searchParams.get("state");
-        const storedState = localStorage.getItem("lineLoginState");
+        const storedCsrf = localStorage.getItem("lineLoginState");
+
+        // stateをデコードしてCSRFトークンとreturnUrlを取得
+        let stateData: { csrf: string; returnUrl: string | null } | null = null;
+        try {
+          if (state) {
+            stateData = JSON.parse(atob(state));
+          }
+        } catch (e) {
+          // 古い形式のstateの場合はそのまま使用
+          stateData = { csrf: state || "", returnUrl: null };
+        }
 
         // CSRF対策: stateの検証
-        if (!state || state !== storedState) {
+        if (!stateData || stateData.csrf !== storedCsrf) {
           throw new Error("セキュリティエラー: 認証状態が無効です");
         }
 
@@ -78,6 +89,7 @@ function LineCallbackContent() {
           code,
           loginData.dateOfBirth,
           loginData.referralCode,
+          stateData?.returnUrl || undefined,
         );
 
         if (result.success) {

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -92,7 +92,8 @@ export default function PrefecturePosterMapClient({
 
   const handleBoardSelect = (board: PosterBoard) => {
     if (!userId) {
-      toast.info("ステータスを更新するにはログインが必要です");
+      const returnUrl = `/map/poster/${prefecture}`;
+      window.location.href = `/sign-in?returnUrl=${encodeURIComponent(returnUrl)}`;
       return;
     }
     setSelectedBoard(board);

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -51,7 +51,7 @@ type StatusHistory =
   };
 
 interface PrefecturePosterMapClientProps {
-  userId: string;
+  userId?: string;
   prefecture: string;
   prefectureName: string;
   center: [number, number];
@@ -91,6 +91,10 @@ export default function PrefecturePosterMapClient({
   };
 
   const handleBoardSelect = (board: PosterBoard) => {
+    if (!userId) {
+      toast.info("ステータスを更新するにはログインが必要です");
+      return;
+    }
     setSelectedBoard(board);
     setUpdateStatus(board.status);
     setUpdateNote("");
@@ -100,7 +104,7 @@ export default function PrefecturePosterMapClient({
   };
 
   const loadHistory = async () => {
-    if (!selectedBoard) return;
+    if (!selectedBoard || !userId) return;
 
     setLoadingHistory(true);
     try {
@@ -169,7 +173,9 @@ export default function PrefecturePosterMapClient({
             {prefectureName}のポスター掲示板
           </h1>
           <p className="text-muted-foreground">
-            掲示板をクリックしてステータスを更新できます
+            {userId
+              ? "掲示板をクリックしてステータスを更新できます"
+              : "ログインするとステータスを更新できます"}
           </p>
         </div>
       </div>
@@ -329,20 +335,23 @@ export default function PrefecturePosterMapClient({
           )}
 
           <DialogFooter className="flex items-center justify-between">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                if (!showHistory) {
-                  loadHistory();
-                }
-                setShowHistory(!showHistory);
-              }}
-              type="button"
-            >
-              <History className="mr-2 h-4 w-4" />
-              履歴
-            </Button>
+            {userId && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  if (!showHistory) {
+                    loadHistory();
+                  }
+                  setShowHistory(!showHistory);
+                }}
+                type="button"
+              >
+                <History className="mr-2 h-4 w-4" />
+                履歴
+              </Button>
+            )}
+            {!userId && <div />}
             <div className="flex gap-2">
               <Button
                 variant="outline"

--- a/app/map/poster/[prefecture]/page.tsx
+++ b/app/map/poster/[prefecture]/page.tsx
@@ -38,10 +38,6 @@ export default async function PrefecturePosterMapPage({
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user) {
-    return redirect("/sign-in");
-  }
-
   // Validate prefecture parameter
   if (!validPrefectures.includes(prefecture as PosterPrefectureKey)) {
     return redirect("/map/poster");
@@ -52,7 +48,7 @@ export default async function PrefecturePosterMapPage({
 
   return (
     <PrefecturePosterMapClient
-      userId={user.id}
+      userId={user?.id}
       prefecture={prefectureNameJp}
       prefectureName={prefectureNameJp}
       center={center}

--- a/app/map/poster/page.tsx
+++ b/app/map/poster/page.tsx
@@ -1,6 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
 import PosterMapPageClient from "./PosterMapPageClient";
 
 export const metadata: Metadata = {
@@ -9,15 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default async function PosterMapPage() {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return redirect("/sign-in");
-  }
-
   return <PosterMapPageClient />;
 }

--- a/lib/auth/line-auth.ts
+++ b/lib/auth/line-auth.ts
@@ -4,7 +4,7 @@
  * LINEログイン開始関数
  * LINE Web Login API を直接使用してLINE認証ページにリダイレクト
  */
-export async function signInWithLine() {
+export async function signInWithLine(returnUrl?: string) {
   // LINE Web Login API の認証URL作成
   const clientId = process.env.NEXT_PUBLIC_LINE_CLIENT_ID;
   if (!clientId) {
@@ -15,10 +15,14 @@ export async function signInWithLine() {
   }
 
   const redirectUri = `${window.location.origin}/api/auth/callback/line`;
-  const state = crypto.randomUUID();
+  const stateData = {
+    csrf: crypto.randomUUID(),
+    returnUrl: returnUrl || null,
+  };
+  const state = btoa(JSON.stringify(stateData));
 
   // stateをローカルストレージに保存（CSRF対策、モバイル対応）
-  localStorage.setItem("lineLoginState", state);
+  localStorage.setItem("lineLoginState", stateData.csrf);
 
   const authUrl = new URL("https://access.line.me/oauth2/v2.1/authorize");
   authUrl.searchParams.set("response_type", "code");

--- a/supabase/migrations/20250701131916_allow_public_read_poster_boards.sql
+++ b/supabase/migrations/20250701131916_allow_public_read_poster_boards.sql
@@ -1,0 +1,10 @@
+-- Allow anonymous users to read poster boards
+DROP POLICY IF EXISTS "poster_boards_authenticated_select" ON public.poster_boards;
+CREATE POLICY "poster_boards_public_select" ON public.poster_boards
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- Keep poster board status history private (authenticated users only)
+-- Note: We are not modifying the existing RLS policy for poster_board_status_history
+-- to protect user privacy. Only authenticated users can view the history.

--- a/tests/rls/poster-boards.test.ts
+++ b/tests/rls/poster-boards.test.ts
@@ -44,7 +44,7 @@ describe("poster_boards テーブルのRLSテスト", () => {
   });
 
   describe("SELECT操作", () => {
-    it("匿名ユーザーはボードを閲覧できない", async () => {
+    it("匿名ユーザーはボードを閲覧できる", async () => {
       const anonClient = getAnonClient();
       const { data, error } = await anonClient
         .from("poster_boards")
@@ -52,7 +52,8 @@ describe("poster_boards テーブルのRLSテスト", () => {
         .eq("id", testBoardId);
 
       expect(error).toBeNull();
-      expect(data).toEqual([]);
+      expect(data).toHaveLength(1);
+      expect(data![0].id).toBe(testBoardId);
     });
 
     it("認証済みユーザーはボードを閲覧できる", async () => {


### PR DESCRIPTION
# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * サインインやLINE認証後にリダイレクト先URL（returnUrl）を指定できるようになりました。
  * ポスターボードマップのページが未ログインでも閲覧可能になりました。ステータス更新や履歴閲覧はログインが必要です。

* **バグ修正**
  * 匿名ユーザーでもポスターボード一覧を閲覧できるようになりました。

* **テスト**
  * 匿名ユーザーがポスターボードを閲覧できることを確認するテストに変更されました。

* **ドキュメント**
  * 特になし（UIやユーザー向けの説明文の変更はありません）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->