### PR TITLE
ピン選択時にマップの位置が戻るバグを修正

### DIFF
--- a/app/map/poster/PosterMap.tsx
+++ b/app/map/poster/PosterMap.tsx
@@ -65,7 +65,6 @@ export default function PosterMap({
   const mapRef = useRef<L.Map | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: 予期せぬタイミングでの再レンダリングによってマップの位置が変わるのを避けるため、依存配列を空にしています
   useEffect(() => {
     if (!mapRef.current) {
       // Initialize map with center from props
@@ -78,7 +77,14 @@ export default function PosterMap({
         maxZoom: 18,
       }).addTo(mapRef.current);
     }
+    // Update map view when center changes
+    if (mapRef.current) {
+      mapRef.current.setView(center, 12);
+    }
+  }, [center]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 予期せぬタイミングでの再レンダリングによってマップの位置が変わるのを避けるため、依存配列を空にしています
+  useEffect(() => {
     // Clear existing markers
     for (const marker of markersRef.current) {
       marker.remove();
@@ -102,18 +108,13 @@ export default function PosterMap({
       }
     }
 
-    // Update map view when center changes
-    if (mapRef.current) {
-      mapRef.current.setView(center, 12);
-    }
-
     // Cleanup function
     return () => {
       for (const marker of markersRef.current) {
         marker.remove();
       }
     };
-  }, []);
+  }, [boards]);
 
   return <div id="poster-map" className="h-[600px] w-full relative z-0" />;
 }

--- a/app/map/poster/PosterMap.tsx
+++ b/app/map/poster/PosterMap.tsx
@@ -83,7 +83,7 @@ export default function PosterMap({
     }
   }, [center]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: 予期せぬタイミングでの再レンダリングによってマップの位置が変わるのを避けるため、依存配列を空にしています
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 予期せぬタイミングでの再レンダリングによってマップの位置が変わるのを避けるため、依存配列を最低限にしています
   useEffect(() => {
     // Clear existing markers
     for (const marker of markersRef.current) {

--- a/app/map/poster/PosterMap.tsx
+++ b/app/map/poster/PosterMap.tsx
@@ -65,6 +65,7 @@ export default function PosterMap({
   const mapRef = useRef<L.Map | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 予期せぬタイミングでの再レンダリングによってマップの位置が変わるのを避けるため、依存配列を空にしています
   useEffect(() => {
     if (!mapRef.current) {
       // Initialize map with center from props
@@ -112,7 +113,7 @@ export default function PosterMap({
         marker.remove();
       }
     };
-  }, [boards, onBoardClick, center]);
+  }, []);
 
   return <div id="poster-map" className="h-[600px] w-full relative z-0" />;
 }


### PR DESCRIPTION
# 変更の概要
- closes https://github.com/team-mirai-volunteer/action-board/issues/787

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * マップの表示位置が予期せず変更される問題を修正しました。  
  * ボードのマーカー表示が安定し、マップの位置変更が不要なタイミングで発生しなくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->