### PR TITLE
feat: 都道府県別にポスターマップのズームレベルを最適化

### DIFF
--- a/app/map/poster/PosterMap.tsx
+++ b/app/map/poster/PosterMap.tsx
@@ -4,6 +4,10 @@ import L from "leaflet";
 import { useEffect, useRef } from "react";
 import "leaflet/dist/leaflet.css";
 import "./poster-map.css";
+import {
+  type PosterPrefectureKey,
+  getPrefectureDefaultZoom,
+} from "@/lib/constants/poster-prefectures";
 import type { Database } from "@/lib/types/supabase";
 
 // Fix Leaflet default marker icon issue with Next.js
@@ -23,6 +27,7 @@ interface PosterMapProps {
   boards: PosterBoard[];
   onBoardClick: (board: PosterBoard) => void;
   center: [number, number];
+  prefectureKey?: PosterPrefectureKey;
 }
 
 // Status colors for markers
@@ -61,14 +66,20 @@ export default function PosterMap({
   boards,
   onBoardClick,
   center,
+  prefectureKey,
 }: PosterMapProps) {
   const mapRef = useRef<L.Map | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
 
   useEffect(() => {
+    // Get zoom level for the prefecture
+    const zoomLevel = prefectureKey
+      ? getPrefectureDefaultZoom(prefectureKey)
+      : 12;
+
     if (!mapRef.current) {
-      // Initialize map with center from props
-      mapRef.current = L.map("poster-map").setView(center, 12);
+      // Initialize map with calculated zoom
+      mapRef.current = L.map("poster-map").setView(center, zoomLevel);
 
       // Add tile layer (using GSI tiles)
       L.tileLayer("https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png", {
@@ -103,7 +114,7 @@ export default function PosterMap({
 
     // Update map view when center changes
     if (mapRef.current) {
-      mapRef.current.setView(center, 12);
+      mapRef.current.setView(center, zoomLevel);
     }
 
     // Cleanup function
@@ -112,7 +123,7 @@ export default function PosterMap({
         marker.remove();
       }
     };
-  }, [boards, onBoardClick, center]);
+  }, [boards, onBoardClick, center, prefectureKey]);
 
   return <div id="poster-map" className="h-[600px] w-full relative z-0" />;
 }

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -20,6 +20,10 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  JP_TO_EN_PREFECTURE,
+  type PosterPrefectureKey,
+} from "@/lib/constants/poster-prefectures";
+import {
   getBoardStatusHistory,
   getPosterBoards,
   updateBoardStatus,
@@ -216,6 +220,9 @@ export default function PrefecturePosterMapClient({
           boards={boards}
           onBoardClick={handleBoardSelect}
           center={center}
+          prefectureKey={
+            JP_TO_EN_PREFECTURE[prefectureName] as PosterPrefectureKey
+          }
         />
       </div>
 

--- a/lib/constants/poster-prefectures.ts
+++ b/lib/constants/poster-prefectures.ts
@@ -1,16 +1,64 @@
 export const POSTER_PREFECTURE_MAP = {
-  hokkaido: { jp: "北海道", center: [43.0642, 141.3469] as [number, number] },
-  miyagi: { jp: "宮城県", center: [38.2688, 140.8721] as [number, number] },
-  saitama: { jp: "埼玉県", center: [35.857, 139.649] as [number, number] },
-  chiba: { jp: "千葉県", center: [35.605, 140.1233] as [number, number] },
-  tokyo: { jp: "東京都", center: [35.6762, 139.6503] as [number, number] },
-  kanagawa: { jp: "神奈川県", center: [35.4478, 139.6425] as [number, number] },
-  nagano: { jp: "長野県", center: [36.6513, 138.181] as [number, number] },
-  aichi: { jp: "愛知県", center: [35.1802, 136.9066] as [number, number] },
-  osaka: { jp: "大阪府", center: [34.6937, 135.5023] as [number, number] },
-  hyogo: { jp: "兵庫県", center: [34.6913, 135.1831] as [number, number] },
-  ehime: { jp: "愛媛県", center: [33.8416, 132.7658] as [number, number] },
-  fukuoka: { jp: "福岡県", center: [33.5904, 130.4017] as [number, number] },
+  hokkaido: {
+    jp: "北海道",
+    center: [43.0642, 141.3469] as [number, number],
+    defaultZoom: 8,
+  },
+  miyagi: {
+    jp: "宮城県",
+    center: [38.2688, 140.8721] as [number, number],
+    defaultZoom: 10,
+  },
+  saitama: {
+    jp: "埼玉県",
+    center: [35.857, 139.649] as [number, number],
+    defaultZoom: 11,
+  },
+  chiba: {
+    jp: "千葉県",
+    center: [35.605, 140.1233] as [number, number],
+    defaultZoom: 10,
+  },
+  tokyo: {
+    jp: "東京都",
+    center: [35.6762, 139.6503] as [number, number],
+    defaultZoom: 12,
+  },
+  kanagawa: {
+    jp: "神奈川県",
+    center: [35.4478, 139.6425] as [number, number],
+    defaultZoom: 11,
+  },
+  nagano: {
+    jp: "長野県",
+    center: [36.6513, 138.181] as [number, number],
+    defaultZoom: 10,
+  },
+  aichi: {
+    jp: "愛知県",
+    center: [35.1802, 136.9066] as [number, number],
+    defaultZoom: 10,
+  },
+  osaka: {
+    jp: "大阪府",
+    center: [34.6937, 135.5023] as [number, number],
+    defaultZoom: 12,
+  },
+  hyogo: {
+    jp: "兵庫県",
+    center: [34.6913, 135.1831] as [number, number],
+    defaultZoom: 11,
+  },
+  ehime: {
+    jp: "愛媛県",
+    center: [33.8416, 132.7658] as [number, number],
+    defaultZoom: 11,
+  },
+  fukuoka: {
+    jp: "福岡県",
+    center: [33.5904, 130.4017] as [number, number],
+    defaultZoom: 11,
+  },
 } as const;
 
 export type PosterPrefectureKey = keyof typeof POSTER_PREFECTURE_MAP;
@@ -34,3 +82,10 @@ export const VALID_JP_PREFECTURES = Object.values(POSTER_PREFECTURE_MAP).map(
 export const VALID_EN_PREFECTURES = Object.keys(
   POSTER_PREFECTURE_MAP,
 ) as PosterPrefectureKey[];
+
+// Helper function to get default zoom for a prefecture
+export function getPrefectureDefaultZoom(
+  prefectureKey: PosterPrefectureKey,
+): number {
+  return POSTER_PREFECTURE_MAP[prefectureKey].defaultZoom;
+}


### PR DESCRIPTION
 # 変更の概要
  - ポスターマップのズームレベルを都道府県別に最適化
  - 各都道府県に適したdefaultZoomレベルを設定（北海道: 8, 東京都: 12など）
  - minZoom/maxZoom設定を削除し、defaultZoomのみに簡素化

  # 変更の背景
  - 現在のポスターマップは一律でズーム12が設定されているが、都道府県によって最適な表示レベ
  ルが異なる
  - 特に北海道のような広域な地域では現状のズームレベルが近すぎて使いにくい
  - closes #788

  # CLAへの同意
  - 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https:
  //github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
  内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]"
  に書き換える）ことで同意したものとみなします。

  - [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 地図表示時に都道府県ごとのデフォルトズームレベルが反映されるようになりました。

* **改善**
  * 都道府県名に応じたズームレベル設定が自動的に適用されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->