### PR TITLE
fix: ポスター掲示板のページネーションの安定性を改善

### DIFF
--- a/lib/services/poster-boards.ts
+++ b/lib/services/poster-boards.ts
@@ -19,6 +19,7 @@ export async function getPosterBoards(prefecture?: string) {
       .from("poster_boards")
       .select("*")
       .order("created_at", { ascending: false })
+      .order("id", { ascending: false })
       .range(page * pageSize, (page + 1) * pageSize - 1);
 
     if (prefecture) {
@@ -155,6 +156,7 @@ export async function getPrefecturesWithBoards() {
       .select("prefecture")
       .not("prefecture", "is", null)
       .order("prefecture")
+      .order("id", { ascending: true })
       .range(page * pageSize, (page + 1) * pageSize - 1);
 
     if (error) {


### PR DESCRIPTION
## Summary
- ポスター掲示板のページネーションで同じタイムスタンプや都道府県を持つレコードがある場合の不具合を修正
- `created_at`や`prefecture`だけでなく、`id`でも追加ソートすることで安定したページネーションを実現

## 変更内容
- `getPosterBoards`関数: `created_at`に加えて`id`でもソート（降順）
- `getPrefecturesWithBoards`関数: `prefecture`に加えて`id`でもソート（昇順）

## 解決される問題
同じ`created_at`や`prefecture`を持つレコードが存在する場合に、ページ境界でレコードが重複したり欠落したりする可能性があった問題を解決します。

## Test plan
- [ ] ローカル環境でポスター掲示板マップが正常に表示されることを確認
- [ ] 都道府県選択が正常に動作することを確認
- [ ] ページネーションが安定して動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ポスターボードや都道府県リストの表示順序が一部調整され、より一貫性のある並び順で表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->