### PR TITLE
fix: ポスターミッション番号バリデーションを緩和して多様な自治体の形式に対応

### DIFF
--- a/components/mission/PosterForm.test.tsx
+++ b/components/mission/PosterForm.test.tsx
@@ -143,10 +143,7 @@ describe("PosterForm", () => {
     expect(boardNumberInput).toHaveAttribute("type", "text");
     expect(boardNumberInput).toHaveAttribute("name", "boardNumber");
     expect(boardNumberInput).toHaveAttribute("maxLength", "20");
-    expect(boardNumberInput).toHaveAttribute(
-      "pattern",
-      "^[A-Za-z0-9]+-[A-Za-z0-9]+$",
-    );
+    expect(boardNumberInput).toHaveAttribute("pattern", "^(\\d+|\\d+-\\d+)$");
     expect(boardNumberInput).toBeRequired();
   });
 
@@ -204,9 +201,7 @@ describe("PosterForm", () => {
     expect(
       screen.getByText(/市町村名と区名を入力してください/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/「番号-番号」の形式で入力してください/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/番号を入力してください/)).toBeInTheDocument();
     expect(
       screen.getByText(/場所の目印があれば入力してください/),
     ).toBeInTheDocument();
@@ -231,7 +226,9 @@ describe("PosterForm", () => {
     expect(
       screen.getByPlaceholderText("例：渋谷区、名古屋市中区"),
     ).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("例：10-1、27-2")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("例：10-1、27-2、00"),
+    ).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("例：東小学校前、駅前商店街"),
     ).toBeInTheDocument();

--- a/components/mission/PosterForm.tsx
+++ b/components/mission/PosterForm.tsx
@@ -122,11 +122,11 @@ export function PosterForm({ disabled }: PosterFormProps) {
           required
           maxLength={20}
           disabled={disabled}
-          placeholder="例：10-1、27-2"
-          pattern="^[A-Za-z0-9]+-[A-Za-z0-9]+$"
+          placeholder="例：10-1、27-2、00"
+          pattern="^(\d+|\d+-\d+)$"
         />
         <p className="text-xs text-gray-500">
-          「番号-番号」の形式で入力してください（例：10-1、27-2）
+          番号を入力してください（例：10-1、27-2、00）
         </p>
       </div>
 


### PR DESCRIPTION
# 変更の概要
- ポスターミッションの番号フィールドのバリデーションを緩和
- 神奈川県相模原市などの「00」形式の番号入力に対応
- 不正な文字列入力を防ぐ適切なバリデーションを実装

# 変更の背景
- 神奈川県相模原市などの自治体では掲示板番号が「00」形式で管理されている
- 従来のバリデーション（`^[A-Za-z0-9]+-[A-Za-z0-9]+$`）はハイフン必須のため、これらの自治体でミッション完了ができない問題があった
- closes #878

# 技術的詳細

## 新しいバリデーション仕様
**正規表現パターン**: `^(\d+|\d+-\d+)$`

### 許可される形式
- `11` : 数字のみ（神奈川県相模原市などの形式）
- `10-1` : 数字-数字の形式（従来の形式）
- `27-2` : 数字-数字の形式（従来の形式）

### 拒否される形式
- `aaa` : 文字列
- `10-a` : 数字と文字の混在
- `10--1` : ハイフン連続
- `abc-123` : 文字と数字の混在

## 変更ファイル
1. **PosterForm.tsx**: 
   - pattern属性を`^(\d+|\d+-\d+)$`に変更
   - プレースホルダーを「例：10-1、27-2、00」に更新
   - ヘルプテキストを「番号を入力してください（例：10-1、27-2、00）」に更新

2. **PosterForm.test.tsx**:
   - 新しいpattern属性のテストケースを更新
   - 更新されたヘルプテキストとプレースホルダーのテスト修正

## 検証結果
- ✅ PosterFormコンポーネントのテストが全て通過
- ✅ Biomeによるコード品質チェック通過
- ✅ 神奈川県相模原市の「00」形式でもミッション完了可能
- ✅ 従来の「10-1」形式も引き続き使用可能

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

🤖 Generated with [Claude Code](https://claude.ai/code)