### PR TITLE
現在地ボタンを押したとき最大ズームに

### DIFF
--- a/app/map/poster/PosterMapWithCluster.tsx
+++ b/app/map/poster/PosterMapWithCluster.tsx
@@ -433,7 +433,10 @@ export default function PosterMapWithCluster({
   // 現在地取得ボタンのハンドラ
   const handleLocate = () => {
     if (currentPos && mapRef.current) {
-      mapRef.current.setView(currentPos, MAX_ZOOM, { animate: true });
+      mapRef.current.flyTo(currentPos, MAX_ZOOM, {
+        animate: true,
+        duration: 0.8,
+      });
     }
   };
 

--- a/app/map/poster/PosterMapWithCluster.tsx
+++ b/app/map/poster/PosterMapWithCluster.tsx
@@ -7,6 +7,7 @@ import "leaflet/dist/leaflet.css";
 import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import "./poster-map.css";
+import { MAX_ZOOM } from "@/lib/constants";
 import {
   type PosterPrefectureKey,
   getPrefectureDefaultZoom,
@@ -269,7 +270,7 @@ export default function PosterMapWithCluster({
       L.tileLayer("https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png", {
         attribution:
           '<a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank">地理院タイル</a>',
-        maxZoom: 18,
+        maxZoom: MAX_ZOOM,
       }).addTo(mapRef.current);
 
       // Initialize marker cluster group
@@ -432,8 +433,7 @@ export default function PosterMapWithCluster({
   // 現在地取得ボタンのハンドラ
   const handleLocate = () => {
     if (currentPos && mapRef.current) {
-      const currentZoom = mapRef.current.getZoom();
-      mapRef.current.setView(currentPos, currentZoom);
+      mapRef.current.setView(currentPos, MAX_ZOOM, { animate: true });
     }
   };
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -17,3 +17,6 @@ export const MAX_POSTING_COUNT = 100000;
 
 // ポスターミッションでの最大枚数
 export const MAX_POSTER_COUNT = 10000;
+
+// ポスターマップの最大ズーム値
+export const MAX_ZOOM = 18;


### PR DESCRIPTION
# 変更の概要
- 「現在地」ボタンを押したとき最大ズームになるようにしました。

# 変更の背景
- https://team-mirai-volunteer.slack.com/archives/C08SNQ7D29L/p1751528127851219

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新機能**
  * 地図の最大ズームレベルが統一され、「現在地に移動」ボタンを押すと常に最大ズームで現在地に移動し、アニメーションで表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->