### PR TITLE
fix: ミッションクリアボタンのスタイルと文言を修正

### DIFF
--- a/components/mission/FeaturedMissions.test.tsx
+++ b/components/mission/FeaturedMissions.test.tsx
@@ -32,7 +32,7 @@ describe("FeaturedMissions", () => {
     const { getByTestId } = render(<FeaturedMissions {...props} />);
 
     expect(getByTestId("filter-featured")).toHaveTextContent("true");
-    expect(getByTestId("title")).toHaveTextContent("📈 重要ミッション");
+    expect(getByTestId("title")).toHaveTextContent("🎯 重要ミッション");
     expect(getByTestId("id")).toHaveTextContent("featured-missions");
     expect(getByTestId("user-id")).toHaveTextContent("test-user-id");
     expect(getByTestId("max-size")).toHaveTextContent("5");
@@ -56,7 +56,7 @@ describe("FeaturedMissions", () => {
 
     const { getByTestId } = render(<FeaturedMissions {...props} />);
 
-    expect(getByTestId("title")).toHaveTextContent("📈 重要ミッション");
+    expect(getByTestId("title")).toHaveTextContent("🎯 重要ミッション");
     expect(getByTestId("id")).toHaveTextContent("featured-missions");
   });
 

--- a/components/mission/FeaturedMissions.tsx
+++ b/components/mission/FeaturedMissions.tsx
@@ -8,7 +8,7 @@ export default function FeaturedMissions(
     <Missions
       {...props}
       filterFeatured={true}
-      title="📈 重要ミッション"
+      title="🎯 重要ミッション"
       id="featured-missions"
     />
   );

--- a/components/mission/mission.test.tsx
+++ b/components/mission/mission.test.tsx
@@ -152,7 +152,7 @@ describe("Mission", () => {
 
     expect(screen.getByText("テストミッション")).toBeInTheDocument();
     expect(screen.getByText("みんなで10回達成")).toBeInTheDocument();
-    expect(screen.getByText("詳細を見る →")).toBeInTheDocument();
+    expect(screen.getByText("今すぐチャレンジ🔥")).toBeInTheDocument();
   });
 
   it("イベント日付が正しく表示される", () => {
@@ -178,7 +178,7 @@ describe("Mission", () => {
       />,
     );
 
-    expect(screen.getByText("ミッションクリア🎉")).toBeInTheDocument();
+    expect(screen.getByText("ミッション完了🎉")).toBeInTheDocument();
   });
 
   it("最大達成回数が設定されていない場合は制限なし", () => {
@@ -193,7 +193,7 @@ describe("Mission", () => {
       />,
     );
 
-    expect(screen.getByText("詳細を見る →")).toBeInTheDocument();
+    expect(screen.getByText("今すぐチャレンジ🔥")).toBeInTheDocument();
   });
 
   it("アイコンURLがnullの場合はフォールバック画像を使用", () => {

--- a/components/mission/mission.test.tsx
+++ b/components/mission/mission.test.tsx
@@ -178,7 +178,7 @@ describe("Mission", () => {
       />,
     );
 
-    expect(screen.getByText("ミッション完了🎉")).toBeInTheDocument();
+    expect(screen.getByText("ミッションクリア🎉")).toBeInTheDocument();
   });
 
   it("最大達成回数が設定されていない場合は制限なし", () => {

--- a/components/mission/mission.test.tsx
+++ b/components/mission/mission.test.tsx
@@ -123,6 +123,7 @@ jest.mock("lucide-react", () => ({
 
 const mockMission: Tables<"missions"> = {
   id: "test-mission-1",
+  slug: "test-mission-1",
   title: "テストミッション",
   content: "テストミッションの内容",
   difficulty: 1,
@@ -177,7 +178,7 @@ describe("Mission", () => {
       />,
     );
 
-    expect(screen.getByText("達成内容を見る →")).toBeInTheDocument();
+    expect(screen.getByText("ミッションクリア🎉")).toBeInTheDocument();
   });
 
   it("最大達成回数が設定されていない場合は制限なし", () => {

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -1,9 +1,12 @@
+"use client";
+
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { DifficultyBadge } from "@/components/ui/difficulty-badge";
 import type { Tables } from "@/lib/types/supabase";
 import { calculateMissionXp } from "@/lib/utils/utils";
 import clsx from "clsx";
+import { motion } from "framer-motion";
 import { UsersRound } from "lucide-react";
 import Link from "next/link";
 import { Button } from "../ui/button";
@@ -118,17 +121,21 @@ export default function Mission({
           </div>
         </div>
         <Link href={`/missions/${mission.id}`} className="block">
-          <Button
-            variant="default"
-            className={clsx(
-              "w-full rounded-full py-6 text-base font-bold text-white",
-              hasReachedMaxAchievements
-                ? "bg-yellow-500 hover:bg-yellow-600"
-                : "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 shadow-md hover:shadow-lg",
-            )}
-          >
-            {hasReachedMaxAchievements ? "ミッションクリア🎉" : "詳細を見る →"}
-          </Button>
+          <motion.div whileTap={{ scale: 0.95 }}>
+            <Button
+              variant="default"
+              className={clsx(
+                "w-full rounded-full py-6 text-base font-bold text-white",
+                hasReachedMaxAchievements
+                  ? "bg-yellow-500 hover:bg-yellow-600"
+                  : "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 shadow-md hover:shadow-lg",
+              )}
+            >
+              {hasReachedMaxAchievements
+                ? "ミッションクリア🎉"
+                : "詳細を見る →"}
+            </Button>
+          </motion.div>
         </Link>
       </CardFooter>
     </Card>

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -132,8 +132,8 @@ export default function Mission({
               )}
             >
               {hasReachedMaxAchievements
-                ? "ミッションクリア🎉"
-                : "詳細を見る →"}
+                ? "ミッション完了🎉"
+                : "今すぐチャレンジ🔥"}
             </Button>
           </motion.div>
         </Link>

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -128,7 +128,7 @@ export default function Mission({
                 "w-full rounded-full py-6 text-base font-bold text-white",
                 hasReachedMaxAchievements
                   ? "bg-yellow-500 hover:bg-yellow-600"
-                  : "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 shadow-md hover:shadow-lg",
+                  : "bg-[#31BCA7] hover:bg-[#2aa896] shadow-md hover:shadow-lg",
               )}
             >
               {hasReachedMaxAchievements

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -128,7 +128,7 @@ export default function Mission({
                 "w-full rounded-full py-6 text-base font-bold text-white",
                 hasReachedMaxAchievements
                   ? "bg-yellow-500 hover:bg-yellow-600"
-                  : "bg-[#31BCA7] hover:bg-[#2aa896] shadow-md hover:shadow-lg",
+                  : "bg-primary hover:bg-primary/90 shadow-md hover:shadow-lg",
               )}
             >
               {hasReachedMaxAchievements

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -128,7 +128,7 @@ export default function Mission({
                 "w-full rounded-full py-6 text-base font-bold text-white",
                 hasReachedMaxAchievements
                   ? "bg-yellow-500 hover:bg-yellow-600"
-                  : "bg-primary hover:bg-primary/90 shadow-md hover:shadow-lg",
+                  : "bg-primary hover:bg-primary/90",
               )}
             >
               {hasReachedMaxAchievements

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -124,7 +124,12 @@ export default function Mission({
           <motion.div whileTap={{ scale: 0.95 }}>
             <Button
               variant="default"
-              className="w-full rounded-full py-6 text-base font-bold text-white bg-yellow-500 hover:bg-yellow-600"
+              className={clsx(
+                "w-full rounded-full py-6 text-base font-bold text-white",
+                hasReachedMaxAchievements
+                  ? "bg-yellow-500 hover:bg-yellow-600"
+                  : "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 shadow-md hover:shadow-lg",
+              )}
             >
               {hasReachedMaxAchievements
                 ? "ミッションクリア🎉"

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -124,12 +124,7 @@ export default function Mission({
           <motion.div whileTap={{ scale: 0.95 }}>
             <Button
               variant="default"
-              className={clsx(
-                "w-full rounded-full py-6 text-base font-bold text-white",
-                hasReachedMaxAchievements
-                  ? "bg-yellow-500 hover:bg-yellow-600"
-                  : "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 shadow-md hover:shadow-lg",
-              )}
+              className="w-full rounded-full py-6 text-base font-bold text-white bg-yellow-500 hover:bg-yellow-600"
             >
               {hasReachedMaxAchievements
                 ? "ミッションクリア🎉"

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { DifficultyBadge } from "@/components/ui/difficulty-badge";
 import type { Tables } from "@/lib/types/supabase";
 import { calculateMissionXp } from "@/lib/utils/utils";
 import clsx from "clsx";
@@ -15,14 +13,12 @@ import MissionAchievementStatus from "./mission-achievement-status";
 
 interface MissionProps {
   mission: Omit<Tables<"missions">, "slug">;
-  achieved: boolean;
   achievementsCount?: number;
   userAchievementCount?: number;
 }
 
 export default function Mission({
   mission,
-  achieved,
   achievementsCount,
   userAchievementCount = 0,
 }: MissionProps) {
@@ -127,12 +123,12 @@ export default function Mission({
               className={clsx(
                 "w-full rounded-full py-6 text-base font-bold text-white",
                 hasReachedMaxAchievements
-                  ? "bg-yellow-500 hover:bg-yellow-600"
+                  ? "bg-yellow-300 hover:bg-yellow/90 text-primary"
                   : "bg-primary hover:bg-primary/90",
               )}
             >
               {hasReachedMaxAchievements
-                ? "ミッション完了🎉"
+                ? "ミッションクリア🎉"
                 : "今すぐチャレンジ🔥"}
             </Button>
           </motion.div>

--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -2,6 +2,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { DifficultyBadge } from "@/components/ui/difficulty-badge";
 import type { Tables } from "@/lib/types/supabase";
+import { calculateMissionXp } from "@/lib/utils/utils";
 import clsx from "clsx";
 import { UsersRound } from "lucide-react";
 import Link from "next/link";
@@ -82,8 +83,8 @@ export default function Mission({
       </CardHeader>
 
       <CardFooter className="flex flex-col items-stretch gap-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center justify-between">
+        <div className="flex flex-col items-start gap-1.5">
+          <div className="flex items-center">
             <UsersRound className="size-4 mr-2" />
             <span
               className={clsx(
@@ -96,24 +97,37 @@ export default function Mission({
                 : "みんなで0回達成"}
             </span>
           </div>
-          <div className="flex items-center gap-2">
-            <DifficultyBadge
-              difficulty={mission.difficulty}
-              className={clsx(hasReachedMaxAchievements && "opacity-60")}
-            />
+          <div className="flex items-center">
+            <span
+              className={clsx(
+                "text-sm font-medium",
+                hasReachedMaxAchievements ? "text-gray-500" : "text-gray-700",
+              )}
+            >
+              難易度：
+            </span>
+            <span className="mx-1">{"⭐".repeat(mission.difficulty)}</span>
+            <span
+              className={clsx(
+                "text-sm font-medium ml-1.5",
+                hasReachedMaxAchievements ? "text-gray-500" : "text-gray-700",
+              )}
+            >
+              獲得ポイント：{calculateMissionXp(mission.difficulty)}
+            </span>
           </div>
         </div>
         <Link href={`/missions/${mission.id}`} className="block">
           <Button
             variant="default"
             className={clsx(
-              "w-full rounded-full py-6 text-base font-bold text-white shadow-md hover:shadow-lg",
+              "w-full rounded-full py-6 text-base font-bold text-white",
               hasReachedMaxAchievements
-                ? "bg-gradient-to-r from-gray-400 to-gray-500 hover:from-gray-500 hover:to-gray-600"
-                : "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700",
+                ? "bg-yellow-500 hover:bg-yellow-600"
+                : "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 shadow-md hover:shadow-lg",
             )}
           >
-            {hasReachedMaxAchievements ? "達成内容を見る →" : "詳細を見る →"}
+            {hasReachedMaxAchievements ? "ミッションクリア🎉" : "詳細を見る →"}
           </Button>
         </Link>
       </CardFooter>

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "form-data": "^4.0.3",
+        "framer-motion": "^12.22.0",
         "js-yaml": "^4.1.0",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.511.0",
@@ -10309,6 +10310,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.22.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.22.0.tgz",
+      "integrity": "sha512-qG07rR8/mboCNU34nORbrIbBXbJzP4aDqBdr67TAIVlMryDEOwh7LXjylWovlnPCMg78ExoY0Gn2F1fV+3DNIw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.22.0",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -13306,6 +13334,21 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.22.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.22.0.tgz",
+      "integrity": "sha512-ooH7+/BPw9gOsL9VtPhEJHE2m4ltnhMlcGMhEqA0YGNhKof7jdaszvsyThXI6LVIKshJUZ9/CP6HNqQhJfV7kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
       "license": "MIT"
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "form-data": "^4.0.3",
+    "framer-motion": "^12.22.0",
     "js-yaml": "^4.1.0",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.511.0",


### PR DESCRIPTION
# 変更の概要
- PR #829 のdevinの実装を元に、ミッションクリアボタンのスタイルと文言を修正
- ボタンの色を黄色（`bg-yellow-300`）に変更
- 文言を「ミッション完了🎉」から「ミッションクリア🎉」に変更
- 使用されていないインポートを削除してコードをクリーンアップ

# 変更の背景
- PR #829でdevinが実装したミッションクリアボタンの色と文言がデザイン仕様と異なっていた
- 提供されたスクリーンショット通りの見た目（黄色背景、「ミッションクリア🎉」文言）になるよう修正が必要だった
- また、使用されていないインポートがあったため、コードの整理も実施
- closes #859

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました