### PR TITLE
feat: ポスターマップページのレイアウトを最適化

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -317,8 +317,9 @@ export default function PrefecturePosterMapClient({
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 w-8 p-0 sm:hidden"
+            className="h-8 w-8 p-0"
             onClick={() => setShowHelpDialog(true)}
+            title="使い方を見る"
           >
             <HelpCircle className="h-4 w-4" />
           </Button>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -589,15 +589,13 @@ export default function PrefecturePosterMapClient({
 
             <div className="space-y-2">
               <h4 className="font-semibold">マーカーの色の意味</h4>
-              <div className="grid grid-cols-2 gap-2 text-sm">
+              <div className="space-y-2 text-sm">
                 {Object.entries(statusConfig).map(([status, config]) => (
-                  <div key={status} className="flex items-center gap-2">
+                  <div key={status} className="flex items-start gap-2">
                     <div
-                      className={`h-3 w-3 rounded-full flex-shrink-0 ${config.color}`}
+                      className={`h-3 w-3 rounded-full flex-shrink-0 mt-0.5 ${config.color}`}
                     />
-                    <span className="text-xs">
-                      {config.shortLabel || config.label}
-                    </span>
+                    <span className="text-xs">{config.label}</span>
                   </div>
                 ))}
               </div>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -414,9 +414,9 @@ export default function PrefecturePosterMapClient({
                     <SelectItem key={status} value={status}>
                       <div className="flex items-center gap-2">
                         <div
-                          className={`h-2 w-2 rounded-full ${config.color}`}
+                          className={`h-2 w-2 rounded-full flex-shrink-0 ${config.color}`}
                         />
-                        {config.label}
+                        <span className="truncate">{config.label}</span>
                       </div>
                     </SelectItem>
                   ))}
@@ -592,8 +592,12 @@ export default function PrefecturePosterMapClient({
               <div className="grid grid-cols-2 gap-2 text-sm">
                 {Object.entries(statusConfig).map(([status, config]) => (
                   <div key={status} className="flex items-center gap-2">
-                    <div className={`h-3 w-3 rounded-full ${config.color}`} />
-                    <span>{config.label}</span>
+                    <div
+                      className={`h-3 w-3 rounded-full flex-shrink-0 ${config.color}`}
+                    />
+                    <span className="text-xs">
+                      {config.shortLabel || config.label}
+                    </span>
                   </div>
                 ))}
               </div>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -2,7 +2,6 @@
 
 import { achieveMissionAction } from "@/app/missions/[id]/actions";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -329,52 +328,42 @@ export default function PrefecturePosterMapClient({
         />
       </div>
 
-      {/* Stats - コンパクト化 */}
-      <div className="grid gap-3 grid-cols-2 md:grid-cols-4">
-        <div className="rounded-lg border bg-card p-3 md:p-4">
-          <div className="flex items-center justify-between md:flex-col md:items-center md:justify-center">
-            <span className="text-xs text-muted-foreground md:order-2">
-              総掲示板数
-            </span>
-            <span className="text-xl font-bold md:order-1 md:text-2xl">
-              {totalCount}
-            </span>
+      {/* 統計情報とステータス - 統合版 */}
+      <div className="rounded-lg border bg-card p-3">
+        <div className="flex flex-wrap items-center gap-3">
+          {/* 主要統計 */}
+          <div className="flex items-baseline gap-3">
+            <div className="flex items-baseline gap-1">
+              <span className="text-lg font-bold">{totalCount}</span>
+              <span className="text-xs text-muted-foreground">総数</span>
+            </div>
+            <div className="flex items-baseline gap-1">
+              <span className="text-lg font-bold text-green-600">
+                {completedCount}
+              </span>
+              <span className="text-xs text-muted-foreground">完了</span>
+            </div>
+            <div className="flex items-baseline gap-1">
+              <span className="text-lg font-bold text-blue-600">
+                {completionRate}%
+              </span>
+              <span className="text-xs text-muted-foreground">達成率</span>
+            </div>
           </div>
-        </div>
-        <div className="rounded-lg border bg-card p-3 md:p-4">
-          <div className="flex items-center justify-between md:flex-col md:items-center md:justify-center">
-            <span className="text-xs text-muted-foreground md:order-2">
-              貼付完了
-            </span>
-            <span className="text-xl font-bold text-green-600 md:order-1 md:text-2xl">
-              {completedCount}
-            </span>
-          </div>
-        </div>
-        <div className="rounded-lg border bg-card p-3 md:p-4">
-          <div className="flex items-center justify-between md:flex-col md:items-center md:justify-center">
-            <span className="text-xs text-muted-foreground md:order-2">
-              達成率
-            </span>
-            <span className="text-xl font-bold text-blue-600 md:order-1 md:text-2xl">
-              {completionRate}%
-            </span>
-          </div>
-        </div>
-        <div className="rounded-lg border bg-card p-3 md:p-4 col-span-2 md:col-span-1">
-          <div className="flex flex-wrap gap-x-3 gap-y-1 justify-center md:justify-start">
+
+          {/* 区切り線 */}
+          <div className="hidden sm:block h-6 w-px bg-border" />
+
+          {/* ステータス別内訳 */}
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
             {Object.entries(statusConfig).map(([status, config]) => {
               const count = stats[status as BoardStatus] || 0;
-              if (count === 0) return null;
               return (
                 <div key={status} className="flex items-center gap-1">
-                  <div className={`h-2 w-2 rounded-full ${config.color}`} />
+                  <div className={`h-2.5 w-2.5 rounded-full ${config.color}`} />
                   <span className="text-xs">
-                    <span className="hidden sm:inline">{config.label}:</span>
-                    <span className="sm:hidden">
-                      {config.label.slice(0, 2)}:
-                    </span>
-                    {count}
+                    {config.label}
+                    <span className="ml-0.5 font-semibold">{count}</span>
                   </span>
                 </div>
               );
@@ -382,23 +371,6 @@ export default function PrefecturePosterMapClient({
           </div>
         </div>
       </div>
-
-      {/* Status Legend - コンパクト化 */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">ステータス凡例</CardTitle>
-        </CardHeader>
-        <CardContent className="pt-0">
-          <div className="flex flex-wrap gap-x-4 gap-y-2 text-sm">
-            {Object.entries(statusConfig).map(([status, config]) => (
-              <div key={status} className="flex items-center gap-1.5">
-                <div className={`h-2.5 w-2.5 rounded-full ${config.color}`} />
-                <span className="text-xs">{config.label}</span>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
 
       {/* Update Dialog */}
       <Dialog open={isUpdateDialogOpen} onOpenChange={setIsUpdateDialogOpen}>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -296,21 +296,21 @@ export default function PrefecturePosterMapClient({
     totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
 
   return (
-    <div className="container mx-auto max-w-7xl space-y-6 p-4">
-      {/* Header */}
-      <div className="flex items-center gap-4">
+    <div className="container mx-auto max-w-7xl space-y-3 p-3">
+      {/* Header - コンパクト化 */}
+      <div className="flex items-center gap-3">
         <Link href="/map/poster">
-          <Button variant="ghost" size="icon">
-            <ArrowLeft className="h-5 w-5" />
+          <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+            <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>
-        <div>
-          <h1 className="text-2xl font-bold">
+        <div className="flex items-baseline gap-2 flex-1">
+          <h1 className="text-lg font-bold">
             {prefectureName}のポスター掲示板
           </h1>
-          <p className="text-muted-foreground">
+          <p className="text-xs text-muted-foreground hidden sm:block">
             {userId
-              ? "掲示板をクリックしてステータスを更新できます"
+              ? "掲示板をクリックしてステータスを更新"
               : "ログインするとステータスを更新できます"}
           </p>
         </div>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -416,7 +416,7 @@ export default function PrefecturePosterMapClient({
                         <div
                           className={`h-2 w-2 rounded-full flex-shrink-0 ${config.color}`}
                         />
-                        <span className="truncate">{config.label}</span>
+                        <span>{config.label}</span>
                       </div>
                     </SelectItem>
                   ))}

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -369,9 +369,11 @@ export default function PrefecturePosterMapClient({
               const count = stats[status as BoardStatus] || 0;
               return (
                 <div key={status} className="flex items-center gap-1">
-                  <div className={`h-2.5 w-2.5 rounded-full ${config.color}`} />
-                  <span className="text-xs">
-                    {config.label}
+                  <div
+                    className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${config.color}`}
+                  />
+                  <span className="text-xs whitespace-nowrap">
+                    {config.shortLabel || config.label}
                     <span className="ml-0.5 font-semibold">{count}</span>
                   </span>
                 </div>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -317,43 +317,7 @@ export default function PrefecturePosterMapClient({
         </div>
       </div>
 
-      {/* Stats */}
-      <div className="grid gap-4 md:grid-cols-4">
-        <div className="rounded-lg border bg-card p-4 text-center">
-          <div className="text-2xl font-bold">{totalCount}</div>
-          <div className="text-sm text-muted-foreground">総掲示板数</div>
-        </div>
-        <div className="rounded-lg border bg-card p-4 text-center">
-          <div className="text-2xl font-bold text-green-600">
-            {completedCount}
-          </div>
-          <div className="text-sm text-muted-foreground">貼付完了</div>
-        </div>
-        <div className="rounded-lg border bg-card p-4 text-center">
-          <div className="text-2xl font-bold text-blue-600">
-            {completionRate}%
-          </div>
-          <div className="text-sm text-muted-foreground">達成率</div>
-        </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="space-y-2">
-            {Object.entries(statusConfig).map(([status, config]) => {
-              const count = stats[status as BoardStatus] || 0;
-              if (count === 0) return null;
-              return (
-                <div key={status} className="flex items-center gap-2">
-                  <div className={`h-3 w-3 rounded-full ${config.color}`} />
-                  <span className="text-sm">
-                    {config.label}: {count}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-
-      {/* Map */}
+      {/* Map - 最優先表示 */}
       <div className="overflow-hidden rounded-lg border bg-card">
         <PosterMap
           boards={boards}
@@ -365,17 +329,71 @@ export default function PrefecturePosterMapClient({
         />
       </div>
 
-      {/* Status Legend */}
+      {/* Stats - コンパクト化 */}
+      <div className="grid gap-3 grid-cols-2 md:grid-cols-4">
+        <div className="rounded-lg border bg-card p-3 md:p-4">
+          <div className="flex items-center justify-between md:flex-col md:items-center md:justify-center">
+            <span className="text-xs text-muted-foreground md:order-2">
+              総掲示板数
+            </span>
+            <span className="text-xl font-bold md:order-1 md:text-2xl">
+              {totalCount}
+            </span>
+          </div>
+        </div>
+        <div className="rounded-lg border bg-card p-3 md:p-4">
+          <div className="flex items-center justify-between md:flex-col md:items-center md:justify-center">
+            <span className="text-xs text-muted-foreground md:order-2">
+              貼付完了
+            </span>
+            <span className="text-xl font-bold text-green-600 md:order-1 md:text-2xl">
+              {completedCount}
+            </span>
+          </div>
+        </div>
+        <div className="rounded-lg border bg-card p-3 md:p-4">
+          <div className="flex items-center justify-between md:flex-col md:items-center md:justify-center">
+            <span className="text-xs text-muted-foreground md:order-2">
+              達成率
+            </span>
+            <span className="text-xl font-bold text-blue-600 md:order-1 md:text-2xl">
+              {completionRate}%
+            </span>
+          </div>
+        </div>
+        <div className="rounded-lg border bg-card p-3 md:p-4 col-span-2 md:col-span-1">
+          <div className="flex flex-wrap gap-x-3 gap-y-1 justify-center md:justify-start">
+            {Object.entries(statusConfig).map(([status, config]) => {
+              const count = stats[status as BoardStatus] || 0;
+              if (count === 0) return null;
+              return (
+                <div key={status} className="flex items-center gap-1">
+                  <div className={`h-2 w-2 rounded-full ${config.color}`} />
+                  <span className="text-xs">
+                    <span className="hidden sm:inline">{config.label}:</span>
+                    <span className="sm:hidden">
+                      {config.label.slice(0, 2)}:
+                    </span>
+                    {count}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Status Legend - コンパクト化 */}
       <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">ステータス凡例</CardTitle>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">ステータス凡例</CardTitle>
         </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        <CardContent className="pt-0">
+          <div className="flex flex-wrap gap-x-4 gap-y-2 text-sm">
             {Object.entries(statusConfig).map(([status, config]) => (
-              <div key={status} className="flex items-center gap-2">
-                <div className={`h-3 w-3 rounded-full ${config.color}`} />
-                <span className="text-sm">{config.label}</span>
+              <div key={status} className="flex items-center gap-1.5">
+                <div className={`h-2.5 w-2.5 rounded-full ${config.color}`} />
+                <span className="text-xs">{config.label}</span>
               </div>
             ))}
           </div>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/lib/services/poster-boards";
 import { createClient } from "@/lib/supabase/client";
 import type { Database } from "@/lib/types/supabase";
-import { ArrowLeft, History } from "lucide-react";
+import { ArrowLeft, HelpCircle, History } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -82,6 +82,7 @@ export default function PrefecturePosterMapClient({
   const [history, setHistory] = useState<StatusHistory[]>([]);
   const [showHistory, setShowHistory] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
+  const [showHelpDialog, setShowHelpDialog] = useState(false);
 
   useEffect(() => {
     loadBoards();
@@ -304,7 +305,7 @@ export default function PrefecturePosterMapClient({
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>
-        <div className="flex items-baseline gap-2 flex-1">
+        <div className="flex items-center gap-2 flex-1">
           <h1 className="text-lg font-bold">
             {prefectureName}のポスター掲示板
           </h1>
@@ -313,6 +314,14 @@ export default function PrefecturePosterMapClient({
               ? "掲示板をクリックしてステータスを更新"
               : "ログインするとステータスを更新できます"}
           </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 sm:hidden"
+            onClick={() => setShowHelpDialog(true)}
+          >
+            <HelpCircle className="h-4 w-4" />
+          </Button>
         </div>
       </div>
 
@@ -536,6 +545,59 @@ export default function PrefecturePosterMapClient({
             >
               ログインページへ
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Help Dialog */}
+      <Dialog open={showHelpDialog} onOpenChange={setShowHelpDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>使い方</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <h4 className="font-semibold">地図の操作</h4>
+              <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+                <li>地図をドラッグして移動できます</li>
+                <li>ピンチ操作またはボタンでズームできます</li>
+                <li>現在地ボタンで自分の位置を表示できます</li>
+              </ul>
+            </div>
+
+            {userId ? (
+              <div className="space-y-2">
+                <h4 className="font-semibold">ポスターの状況報告</h4>
+                <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+                  <li>地図上の掲示板マーカーをタップします</li>
+                  <li>ポスターの状況を選択します</li>
+                  <li>必要に応じて連絡事項を入力します</li>
+                  <li>「報告する」ボタンで更新完了です</li>
+                </ul>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <h4 className="font-semibold">ポスターの状況を報告するには</h4>
+                <p className="text-sm text-muted-foreground">
+                  ログインすると、掲示板をタップしてポスターの状況を報告できるようになります。
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <h4 className="font-semibold">マーカーの色の意味</h4>
+              <div className="grid grid-cols-2 gap-2 text-sm">
+                {Object.entries(statusConfig).map(([status, config]) => (
+                  <div key={status} className="flex items-center gap-2">
+                    <div className={`h-3 w-3 rounded-full ${config.color}`} />
+                    <span>{config.label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => setShowHelpDialog(false)}>閉じる</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -342,19 +342,19 @@ export default function PrefecturePosterMapClient({
       <div className="rounded-lg border bg-card p-3">
         <div className="flex flex-wrap items-center gap-3">
           {/* 主要統計 */}
-          <div className="flex items-baseline gap-3">
+          <div className="flex items-baseline gap-4">
             <div className="flex items-baseline gap-1">
-              <span className="text-lg font-bold">{totalCount}</span>
+              <span className="text-2xl font-bold">{totalCount}</span>
               <span className="text-xs text-muted-foreground">総数</span>
             </div>
             <div className="flex items-baseline gap-1">
-              <span className="text-lg font-bold text-green-600">
+              <span className="text-2xl font-bold text-green-600">
                 {completedCount}
               </span>
               <span className="text-xs text-muted-foreground">完了</span>
             </div>
             <div className="flex items-baseline gap-1">
-              <span className="text-lg font-bold text-blue-600">
+              <span className="text-2xl font-bold text-blue-600">
                 {completionRate}%
               </span>
               <span className="text-xs text-muted-foreground">達成率</span>

--- a/app/map/poster/statusConfig.ts
+++ b/app/map/poster/statusConfig.ts
@@ -4,19 +4,29 @@ type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
 
 export const statusConfig: Record<
   BoardStatus,
-  { label: string; color: string }
+  { label: string; shortLabel?: string; color: string }
 > = {
   not_yet: { label: "未貼付", color: "bg-gray-500" },
   reserved: { label: "予約", color: "bg-yellow-500" },
   done: { label: "完了", color: "bg-green-500" },
   error_wrong_place: {
     label: "エラー（ポスター掲示板マップと実際の場所・番号が違う）",
+    shortLabel: "場所違い",
     color: "bg-red-500",
   },
-  error_damaged: { label: "エラー（損傷・破損）", color: "bg-red-500" },
+  error_damaged: {
+    label: "エラー（損傷・破損）",
+    shortLabel: "破損",
+    color: "bg-red-500",
+  },
   error_wrong_poster: {
     label: "エラー（他党のポスターが貼られている）",
+    shortLabel: "他党",
     color: "bg-red-500",
   },
-  other: { label: "その他（詳細をメモに記載）", color: "bg-purple-500" },
+  other: {
+    label: "その他（詳細をメモに記載）",
+    shortLabel: "その他",
+    color: "bg-purple-500",
+  },
 };


### PR DESCRIPTION
## 概要
Issue #890 の要件に基づいて、ポスターマップページのレイアウトを最適化しました。ポスター貼付作業者の利便性を向上させるため、地図を最上部に配置し、統計情報をコンパクト化しました。

## 変更内容

### 📍 レイアウト順序の変更
- **変更前**: ヘッダー → 統計情報 → 地図 → 凡例
- **変更後**: ヘッダー → **地図（最優先表示）** → 統計情報

### 📊 統計情報の最適化
- 統計情報とステータス凡例を1つのコンパクトなセクションに統合
- 主要統計（総数、完了、達成率）を見やすい大きさ（text-2xl）で表示
- エラーステータスに短縮ラベルを追加（「場所違い」「破損」「他党」など）
- 色付き丸が潰れないよう`flex-shrink-0`を適用

### 📱 ヘッダーの最適化
- タイトルサイズを縮小（text-2xl → text-lg）
- 戻るボタンのサイズを最小化
- 全体の余白を削減（p-4→p-3、space-y-6→space-y-3）

### ❓ ヘルプ機能の追加
- すべての画面サイズでヘルプアイコンを表示
- タップ/クリックで使い方の詳細説明を表示するダイアログ
- ログイン状態に応じた適切な内容を表示
- エラーステータスの詳細説明を含む

### 🎨 UI/UXの改善
- 地図により多くのスペースを確保
- 重要な情報を維持しつつ、無駄なスペースを削減
- モバイルとデスクトップの両方で最適な表示

## スクリーンショット
### 変更前
統計情報が上部を占有し、地図までスクロールが必要でした。

### 変更後
- 地図が即座に表示され、作業効率が向上
- 統計情報は1行にコンパクトにまとめられ、必要な情報を一目で確認可能
- ヘルプアイコンから詳細な使い方を確認可能

## テスト
- [x] ローカル環境での動作確認
- [x] モバイル表示の確認
- [x] Biomeによるコード品質チェック
- [x] 色付き丸の表示確認（すべての場所で正常）

## 関連Issue
Closes #890

🤖 Generated with Claude Code