### PR TITLE
feat: ポスター掲示板マップにテキスト検索機能を追加 (#911)

### DIFF
--- a/app/map/poster/PosterMapWithCluster.tsx
+++ b/app/map/poster/PosterMapWithCluster.tsx
@@ -2,7 +2,13 @@
 
 import L from "leaflet";
 import "leaflet.markercluster";
-import { useEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import "leaflet/dist/leaflet.css";
 import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
@@ -250,285 +256,310 @@ function createClusterIcon(cluster: L.MarkerCluster) {
   });
 }
 
-export default function PosterMapWithCluster({
-  boards,
-  onBoardClick,
-  center,
-  prefectureKey,
-}: PosterMapWithClusterProps) {
-  const mapRef = useRef<L.Map | null>(null);
-  const markerClusterRef = useRef<L.MarkerClusterGroup | null>(null);
-  const currentMarkerRef = useRef<L.CircleMarker | null>(null);
-  const [currentPos, setCurrentPos] = useState<[number, number] | null>(null);
-  const [currentUserId, setCurrentUserId] = useState<string | undefined>();
-  const [boardsLatestEditor, setBoardsLatestEditor] =
-    useState<Map<string, string | null>>();
-
-  // Fetch current user and board info
-  useEffect(() => {
-    let isMounted = true;
-    const fetchUserAndBoardInfo = async () => {
-      try {
-        const supabase = createClient();
-        const {
-          data: { user },
-          error: userError,
-        } = await supabase.auth.getUser();
-
-        if (userError) {
-          console.error("ユーザー情報の取得に失敗しました:", userError);
-          return;
-        }
-
-        if (isMounted) {
-          setCurrentUserId(user?.id);
-        }
-
-        if (boards.length > 0 && isMounted) {
-          const boardIds = boards.map((b) => b.id);
-
-          // Get latest editor info for all boards
-          const latestEditorInfo = await getBoardsLatestEditor(boardIds);
-          if (isMounted) {
-            setBoardsLatestEditor(latestEditorInfo);
-          }
-        }
-      } catch (error) {
-        console.error("データの取得中にエラーが発生しました:", error);
-      }
-    };
-
-    fetchUserAndBoardInfo();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [boards]);
-
-  // Use filter hook
-  const {
-    filterState,
-    filteredBoards,
-    toggleStatus,
-    toggleShowOnlyMine,
-    selectAll,
-    deselectAll,
-    activeFilterCount,
-  } = usePosterBoardFilter({
-    boards,
-    currentUserId,
-    boardsWithLatestEditor: boardsLatestEditor,
-  });
-
-  useEffect(() => {
-    // Get zoom level for the prefecture
-    const zoomLevel = prefectureKey
-      ? getPrefectureDefaultZoom(prefectureKey)
-      : 12;
-
-    if (!mapRef.current) {
-      // Initialize map with calculated zoom
-      mapRef.current = L.map("poster-map-cluster").setView(center, zoomLevel);
-
-      // Add tile layer (using GSI tiles)
-      L.tileLayer("https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png", {
-        attribution:
-          '<a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank">地理院タイル</a>',
-        maxZoom: MAX_ZOOM,
-      }).addTo(mapRef.current);
-
-      // Initialize marker cluster group
-      markerClusterRef.current = L.markerClusterGroup({
-        maxClusterRadius: 50,
-        iconCreateFunction: createClusterIcon,
-        spiderfyOnMaxZoom: true,
-        showCoverageOnHover: false,
-        zoomToBoundsOnClick: true,
-        disableClusteringAtZoom: 16, // Disable clustering at high zoom levels
-      });
-
-      // Add cluster events for tooltips
-      markerClusterRef.current.on("clustermouseover", (e) => {
-        const cluster = e.propagatedFrom;
-        const markers = cluster.getAllChildMarkers() as MarkerWithBoard[];
-        const statusCounts: Record<BoardStatus, number> = {
-          not_yet: 0,
-          reserved: 0,
-          done: 0,
-          error_wrong_place: 0,
-          error_damaged: 0,
-          error_wrong_poster: 0,
-          other: 0,
-        };
-
-        for (const marker of markers) {
-          const board = marker.boardData;
-          if (board) {
-            statusCounts[board.status]++;
-          }
-        }
-
-        const statusLabels: Record<BoardStatus, string> = {
-          not_yet: "未実施",
-          reserved: "予約済み",
-          done: "完了",
-          error_wrong_place: "場所違い",
-          error_damaged: "破損",
-          error_wrong_poster: "ポスター違い",
-          other: "その他",
-        };
-
-        const tooltipContent = Object.entries(statusCounts)
-          .filter(([, count]) => count > 0)
-          .map(
-            ([status, count]) =>
-              `${statusLabels[status as BoardStatus]}: ${count}`,
-          )
-          .join("<br>");
-
-        cluster
-          .bindTooltip(
-            `掲示板数: ${cluster.getChildCount()}<br>${tooltipContent}`,
-            {
-              permanent: false,
-              direction: "top",
-              className: "cluster-tooltip",
-            },
-          )
-          .openTooltip();
-      });
-
-      markerClusterRef.current.on("clustermouseout", (e) => {
-        const cluster = e.propagatedFrom;
-        cluster.closeTooltip();
-      });
-
-      mapRef.current.addLayer(markerClusterRef.current as unknown as L.Layer);
-    }
-
-    // Update map view when center changes
-    if (mapRef.current) {
-      mapRef.current.setView(center, zoomLevel);
-    }
-  }, [center, prefectureKey]);
-
-  useEffect(() => {
-    if (!markerClusterRef.current) return;
-
-    // Clear existing markers
-    markerClusterRef.current.clearLayers();
-
-    // Add markers for each board (use filtered boards)
-    for (const board of filteredBoards) {
-      if (board.lat && board.long) {
-        const marker = L.marker([board.lat, board.long], {
-          icon: createMarkerIcon(board.status),
-        })
-          .bindTooltip(
-            `${board.number ? `#${board.number} ` : ""}${board.name}<br/>${board.address}<br/>${board.city}`,
-            { permanent: false, direction: "top" },
-          )
-          .on("click", () => onBoardClick(board));
-
-        // Store board data in marker for cluster icon calculation
-        (marker as MarkerWithBoard).boardData = board;
-
-        markerClusterRef.current.addLayer(marker);
-      }
-    }
-  }, [filteredBoards, onBoardClick]);
-
-  // 画面を開いた瞬間から現在地をwatchし、移動に追従
-  useEffect(() => {
-    if (!navigator.geolocation) {
-      return;
-    }
-    const watchId = navigator.geolocation.watchPosition(
-      (pos) => {
-        setCurrentPos([pos.coords.latitude, pos.coords.longitude]);
-      },
-      (error) => {
-        console.warn("位置情報の取得に失敗しました:", error.message);
-      },
-      { enableHighAccuracy: true, maximumAge: 10000, timeout: 20000 },
-    );
-    return () => {
-      navigator.geolocation.clearWatch(watchId);
-    };
-  }, []);
-
-  // 現在地マーカーの管理
-  useEffect(() => {
-    if (!mapRef.current) return;
-
-    // 既存の現在地マーカーを削除
-    if (currentMarkerRef.current) {
-      currentMarkerRef.current.remove();
-      currentMarkerRef.current = null;
-    }
-
-    // 現在地が取得できていればマーカーを追加
-    if (currentPos) {
-      const marker = L.circleMarker(currentPos, {
-        radius: 12,
-        color: "#2563eb",
-        fillColor: "#60a5fa",
-        fillOpacity: 0.7,
-        weight: 3,
-      })
-        .addTo(mapRef.current)
-        .bindTooltip("あなたの現在地", { permanent: false, direction: "top" });
-
-      currentMarkerRef.current = marker;
-    }
-  }, [currentPos]);
-
-  // Cleanup
-  useEffect(() => {
-    return () => {
-      if (mapRef.current) {
-        mapRef.current.remove();
-        mapRef.current = null;
-        markerClusterRef.current = null;
-      }
-    };
-  }, []);
-
-  // 現在地取得ボタンのハンドラ
-  const handleLocate = () => {
-    if (currentPos && mapRef.current) {
-      mapRef.current.flyTo(currentPos, MAX_ZOOM, {
-        animate: true,
-        duration: 0.8,
-      });
-    }
-  };
-
-  return (
-    <div className="relative h-[600px] w-full z-0">
-      <div id="poster-map-cluster" className="h-full w-full" />
-      <PosterBoardFilter
-        filterState={filterState}
-        onToggleStatus={toggleStatus}
-        onToggleShowOnlyMine={toggleShowOnlyMine}
-        onSelectAll={selectAll}
-        onDeselectAll={deselectAll}
-        activeFilterCount={activeFilterCount}
-      />
-      <button
-        type="button"
-        onClick={handleLocate}
-        disabled={!currentPos}
-        className={`absolute right-4 bottom-4 rounded-full shadow px-4 py-2 font-bold border transition-colors ${
-          currentPos
-            ? "bg-white text-blue-600 border-blue-200 hover:bg-blue-50 cursor-pointer"
-            : "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-        }`}
-        style={{ zIndex: 1000 }}
-        aria-label="現在地を表示"
-      >
-        📍 現在地
-      </button>
-    </div>
-  );
+interface MapHandle {
+  flyTo: (latlng: [number, number], zoom?: number) => void;
 }
+
+const PosterMapWithCluster = forwardRef<MapHandle, PosterMapWithClusterProps>(
+  ({ boards, onBoardClick, center, prefectureKey }, ref) => {
+    const mapRef = useRef<L.Map | null>(null);
+    const markerClusterRef = useRef<L.MarkerClusterGroup | null>(null);
+    const currentMarkerRef = useRef<L.CircleMarker | null>(null);
+    const [currentPos, setCurrentPos] = useState<[number, number] | null>(null);
+    const [currentUserId, setCurrentUserId] = useState<string | undefined>();
+    const [boardsLatestEditor, setBoardsLatestEditor] =
+      useState<Map<string, string | null>>();
+
+    // Expose map methods to parent component
+    useImperativeHandle(
+      ref,
+      () => ({
+        flyTo: (latlng: [number, number], zoom?: number) => {
+          if (mapRef.current) {
+            mapRef.current.flyTo(latlng, zoom || 18, {
+              animate: true,
+              duration: 1.0,
+            });
+          }
+        },
+      }),
+      [],
+    );
+
+    // Fetch current user and board info
+    useEffect(() => {
+      let isMounted = true;
+      const fetchUserAndBoardInfo = async () => {
+        try {
+          const supabase = createClient();
+          const {
+            data: { user },
+            error: userError,
+          } = await supabase.auth.getUser();
+
+          if (userError) {
+            console.error("ユーザー情報の取得に失敗しました:", userError);
+            return;
+          }
+
+          if (isMounted) {
+            setCurrentUserId(user?.id);
+          }
+
+          if (boards.length > 0 && isMounted) {
+            const boardIds = boards.map((b) => b.id);
+
+            // Get latest editor info for all boards
+            const latestEditorInfo = await getBoardsLatestEditor(boardIds);
+            if (isMounted) {
+              setBoardsLatestEditor(latestEditorInfo);
+            }
+          }
+        } catch (error) {
+          console.error("データの取得中にエラーが発生しました:", error);
+        }
+      };
+
+      fetchUserAndBoardInfo();
+
+      return () => {
+        isMounted = false;
+      };
+    }, [boards]);
+
+    // Use filter hook
+    const {
+      filterState,
+      filteredBoards,
+      toggleStatus,
+      toggleShowOnlyMine,
+      selectAll,
+      deselectAll,
+      activeFilterCount,
+    } = usePosterBoardFilter({
+      boards,
+      currentUserId,
+      boardsWithLatestEditor: boardsLatestEditor,
+    });
+
+    useEffect(() => {
+      // Get zoom level for the prefecture
+      const zoomLevel = prefectureKey
+        ? getPrefectureDefaultZoom(prefectureKey)
+        : 12;
+
+      if (!mapRef.current) {
+        // Initialize map with calculated zoom
+        mapRef.current = L.map("poster-map-cluster").setView(center, zoomLevel);
+
+        // Add tile layer (using GSI tiles)
+        L.tileLayer(
+          "https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png",
+          {
+            attribution:
+              '<a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank">地理院タイル</a>',
+            maxZoom: MAX_ZOOM,
+          },
+        ).addTo(mapRef.current);
+
+        // Initialize marker cluster group
+        markerClusterRef.current = L.markerClusterGroup({
+          maxClusterRadius: 50,
+          iconCreateFunction: createClusterIcon,
+          spiderfyOnMaxZoom: true,
+          showCoverageOnHover: false,
+          zoomToBoundsOnClick: true,
+          disableClusteringAtZoom: 16, // Disable clustering at high zoom levels
+        });
+
+        // Add cluster events for tooltips
+        markerClusterRef.current.on("clustermouseover", (e) => {
+          const cluster = e.propagatedFrom;
+          const markers = cluster.getAllChildMarkers() as MarkerWithBoard[];
+          const statusCounts: Record<BoardStatus, number> = {
+            not_yet: 0,
+            reserved: 0,
+            done: 0,
+            error_wrong_place: 0,
+            error_damaged: 0,
+            error_wrong_poster: 0,
+            other: 0,
+          };
+
+          for (const marker of markers) {
+            const board = marker.boardData;
+            if (board) {
+              statusCounts[board.status]++;
+            }
+          }
+
+          const statusLabels: Record<BoardStatus, string> = {
+            not_yet: "未実施",
+            reserved: "予約済み",
+            done: "完了",
+            error_wrong_place: "場所違い",
+            error_damaged: "破損",
+            error_wrong_poster: "ポスター違い",
+            other: "その他",
+          };
+
+          const tooltipContent = Object.entries(statusCounts)
+            .filter(([, count]) => count > 0)
+            .map(
+              ([status, count]) =>
+                `${statusLabels[status as BoardStatus]}: ${count}`,
+            )
+            .join("<br>");
+
+          cluster
+            .bindTooltip(
+              `掲示板数: ${cluster.getChildCount()}<br>${tooltipContent}`,
+              {
+                permanent: false,
+                direction: "top",
+                className: "cluster-tooltip",
+              },
+            )
+            .openTooltip();
+        });
+
+        markerClusterRef.current.on("clustermouseout", (e) => {
+          const cluster = e.propagatedFrom;
+          cluster.closeTooltip();
+        });
+
+        mapRef.current.addLayer(markerClusterRef.current as unknown as L.Layer);
+      }
+
+      // Update map view when center changes
+      if (mapRef.current) {
+        mapRef.current.setView(center, zoomLevel);
+      }
+    }, [center, prefectureKey]);
+
+    useEffect(() => {
+      if (!markerClusterRef.current) return;
+
+      // Clear existing markers
+      markerClusterRef.current.clearLayers();
+
+      // Add markers for each board (use filtered boards)
+      for (const board of filteredBoards) {
+        if (board.lat && board.long) {
+          const marker = L.marker([board.lat, board.long], {
+            icon: createMarkerIcon(board.status),
+          })
+            .bindTooltip(
+              `${board.number ? `#${board.number} ` : ""}${board.name}<br/>${board.address}<br/>${board.city}`,
+              { permanent: false, direction: "top" },
+            )
+            .on("click", () => onBoardClick(board));
+
+          // Store board data in marker for cluster icon calculation
+          (marker as MarkerWithBoard).boardData = board;
+
+          markerClusterRef.current.addLayer(marker);
+        }
+      }
+    }, [filteredBoards, onBoardClick]);
+
+    // 画面を開いた瞬間から現在地をwatchし、移動に追従
+    useEffect(() => {
+      if (!navigator.geolocation) {
+        return;
+      }
+      const watchId = navigator.geolocation.watchPosition(
+        (pos) => {
+          setCurrentPos([pos.coords.latitude, pos.coords.longitude]);
+        },
+        (error) => {
+          console.warn("位置情報の取得に失敗しました:", error.message);
+        },
+        { enableHighAccuracy: true, maximumAge: 10000, timeout: 20000 },
+      );
+      return () => {
+        navigator.geolocation.clearWatch(watchId);
+      };
+    }, []);
+
+    // 現在地マーカーの管理
+    useEffect(() => {
+      if (!mapRef.current) return;
+
+      // 既存の現在地マーカーを削除
+      if (currentMarkerRef.current) {
+        currentMarkerRef.current.remove();
+        currentMarkerRef.current = null;
+      }
+
+      // 現在地が取得できていればマーカーを追加
+      if (currentPos) {
+        const marker = L.circleMarker(currentPos, {
+          radius: 12,
+          color: "#2563eb",
+          fillColor: "#60a5fa",
+          fillOpacity: 0.7,
+          weight: 3,
+        })
+          .addTo(mapRef.current)
+          .bindTooltip("あなたの現在地", {
+            permanent: false,
+            direction: "top",
+          });
+
+        currentMarkerRef.current = marker;
+      }
+    }, [currentPos]);
+
+    // Cleanup
+    useEffect(() => {
+      return () => {
+        if (mapRef.current) {
+          mapRef.current.remove();
+          mapRef.current = null;
+          markerClusterRef.current = null;
+        }
+      };
+    }, []);
+
+    // 現在地取得ボタンのハンドラ
+    const handleLocate = () => {
+      if (currentPos && mapRef.current) {
+        mapRef.current.flyTo(currentPos, MAX_ZOOM, {
+          animate: true,
+          duration: 0.8,
+        });
+      }
+    };
+
+    return (
+      <div className="relative h-[600px] w-full z-0">
+        <div id="poster-map-cluster" className="h-full w-full" />
+        <PosterBoardFilter
+          filterState={filterState}
+          onToggleStatus={toggleStatus}
+          onToggleShowOnlyMine={toggleShowOnlyMine}
+          onSelectAll={selectAll}
+          onDeselectAll={deselectAll}
+          activeFilterCount={activeFilterCount}
+        />
+        <button
+          type="button"
+          onClick={handleLocate}
+          disabled={!currentPos}
+          className={`absolute right-4 bottom-4 rounded-full shadow px-4 py-2 font-bold border transition-colors ${
+            currentPos
+              ? "bg-white text-blue-600 border-blue-200 hover:bg-blue-50 cursor-pointer"
+              : "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+          }`}
+          style={{ zIndex: 1000 }}
+          aria-label="現在地を表示"
+        >
+          📍 現在地
+        </button>
+      </div>
+    );
+  },
+);
+
+export default PosterMapWithCluster;

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -31,11 +32,11 @@ import {
 } from "@/lib/services/poster-boards";
 import { createClient } from "@/lib/supabase/client";
 import type { Database } from "@/lib/types/supabase";
-import { ArrowLeft, History } from "lucide-react";
+import { ArrowLeft, History, Search, X } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { statusConfig } from "../statusConfig";
 
@@ -83,6 +84,11 @@ export default function PrefecturePosterMapClient({
   const [history, setHistory] = useState<StatusHistory[]>([]);
   const [showHistory, setShowHistory] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const mapRef = useRef<{
+    flyTo: (latlng: [number, number], zoom?: number) => void;
+  } | null>(null);
+  const [selectedSearchIndex, setSelectedSearchIndex] = useState(-1);
 
   useEffect(() => {
     loadBoards();
@@ -296,6 +302,89 @@ export default function PrefecturePosterMapClient({
   const completionRate =
     totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
 
+  // 検索結果の計算
+  const searchResults = useMemo(() => {
+    if (!searchQuery || searchQuery.length < 2) {
+      // 検索クエリが変更されたら選択インデックスをリセット
+      if (selectedSearchIndex !== -1) {
+        setSelectedSearchIndex(-1);
+      }
+      return [];
+    }
+
+    const query = searchQuery.toLowerCase();
+    const results = boards.filter((board) => {
+      const number = board.number?.toLowerCase() || "";
+      const name = board.name?.toLowerCase() || "";
+      const address = board.address?.toLowerCase() || "";
+      const city = board.city?.toLowerCase() || "";
+
+      return (
+        number.includes(query) ||
+        name.includes(query) ||
+        address.includes(query) ||
+        city.includes(query)
+      );
+    });
+
+    // 検索結果が変わったら選択インデックスをリセット
+    if (selectedSearchIndex !== -1) {
+      setSelectedSearchIndex(-1);
+    }
+
+    // 最大10件まで表示
+    return results.slice(0, 10);
+  }, [boards, searchQuery, selectedSearchIndex]);
+
+  // 検索結果の選択処理
+  const handleSearchResultSelect = (board: PosterBoard) => {
+    if (board.lat && board.long && mapRef.current) {
+      // マップを掲示板の位置に移動
+      mapRef.current.flyTo([board.lat, board.long], 18);
+
+      // 掲示板の選択処理
+      handleBoardSelect(board);
+
+      // 検索をクリア
+      setSearchQuery("");
+      setSelectedSearchIndex(-1);
+    }
+  };
+
+  // キーボードイベントハンドラー
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (searchResults.length === 0) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedSearchIndex((prev) =>
+          prev < searchResults.length - 1 ? prev + 1 : prev,
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedSearchIndex((prev) => (prev > 0 ? prev - 1 : -1));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (
+          selectedSearchIndex >= 0 &&
+          selectedSearchIndex < searchResults.length
+        ) {
+          handleSearchResultSelect(searchResults[selectedSearchIndex]);
+        } else if (searchResults.length > 0) {
+          handleSearchResultSelect(searchResults[0]);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setSearchQuery("");
+        setSelectedSearchIndex(-1);
+        break;
+    }
+  };
+
   return (
     <div className="container mx-auto max-w-7xl space-y-6 p-4">
       {/* Header */}
@@ -353,6 +442,68 @@ export default function PrefecturePosterMapClient({
         </div>
       </div>
 
+      {/* Search Box */}
+      <div className="rounded-lg border bg-card p-3">
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder="番号・名前・住所で検索..."
+              className="pl-8 pr-8"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                className="absolute right-2 top-2.5"
+                onClick={() => setSearchQuery("")}
+              >
+                <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* 検索結果リスト */}
+        {searchResults.length > 0 && (
+          <div className="mt-2 max-h-48 overflow-y-auto rounded border bg-background">
+            {searchResults.map((board, index) => (
+              <button
+                type="button"
+                key={board.id}
+                className={`w-full px-3 py-2 text-left hover:bg-accent hover:text-accent-foreground transition-colors ${
+                  index === selectedSearchIndex
+                    ? "bg-accent text-accent-foreground"
+                    : ""
+                }`}
+                onClick={() => handleSearchResultSelect(board)}
+                onMouseEnter={() => setSelectedSearchIndex(index)}
+              >
+                <div className="text-sm">
+                  {board.number && (
+                    <span className="font-medium">#{board.number}</span>
+                  )}
+                  {board.name && <span className="ml-2">{board.name}</span>}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {board.address} {board.city}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* 検索結果なし */}
+        {searchQuery.length >= 2 && searchResults.length === 0 && (
+          <div className="mt-2 p-3 text-sm text-muted-foreground text-center">
+            検索結果がありません
+          </div>
+        )}
+      </div>
+
       {/* Map */}
       <div className="overflow-hidden rounded-lg border bg-card">
         <PosterMap
@@ -362,6 +513,7 @@ export default function PrefecturePosterMapClient({
           prefectureKey={
             JP_TO_EN_PREFECTURE[prefectureName] as PosterPrefectureKey
           }
+          ref={mapRef}
         />
       </div>
 


### PR DESCRIPTION
## 概要
Issue #911 の実装です。

ポスター掲示板マップに番号・名前・住所による検索機能を追加し、検索結果から選択した掲示板にマップが移動するようにしました。

## 変更内容

### 1. 検索UI
- 統計情報の下に検索ボックスを配置
- 検索アイコンとクリアボタン付き
- レスポンシブ対応

### 2. 検索機能
- 部分一致検索（大文字小文字区別なし）
- 最小2文字から検索開始
- リアルタイム検索（入力時に即座に結果表示）
- 最大10件まで結果表示

### 3. 検索対象フィールド
- 掲示板番号 (`board.number`)
- 掲示板名 (`board.name`)
- 住所 (`board.address`)
- 市区町村 (`board.city`)

### 4. キーボード操作
- ↑/↓: 検索結果間を移動
- Enter: 選択中の結果（または最初の結果）を選択
- Escape: 検索をクリア

### 5. マップ連動
- 検索結果クリックで該当位置にマップ移動
- ズームレベル18で表示
- スムーズなアニメーション（1秒）
- 移動後は該当掲示板の詳細ダイアログを表示

## スクリーンショット

### 検索ボックス
<img width="400" alt="検索ボックス" src="https://github.com/user-attachments/assets/placeholder1">

### 検索結果
<img width="400" alt="検索結果" src="https://github.com/user-attachments/assets/placeholder2">

## テスト方法

1. ポスター掲示板マップページにアクセス
2. 検索ボックスに掲示板番号、名前、住所などを入力
3. 検索結果から掲示板を選択
4. マップが該当位置に移動することを確認

## 関連
- Closes #911