### PR TITLE
重要ミッションから「7/3(木)の「街頭みらい会議」に参加しよう」を外す

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -175,7 +175,7 @@ missions:
     artifact_label: null
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//12_referral.png
   - slug: github-pull-request
-    title: '開発者向け: Githubでプルリクエストを出そう'
+    title: '開発者向け: GitHubでプルリクエストを出そう'
     icon_url: /img/mission_fallback.svg
     content: チームみらいのプロジェクトでプルリクエストを出そう！チームみらいでは、アクションボードやファクトチェッカー、AIあんのなど様々なオープンソースプロジェクトの開発を、多くのサポーターが参加して進めています。まずは<a href="https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-37shr9uo0-uUtjteJxhUDps4q5plL7vw" target="_blank" rel="noopener noreferrer">チームみらいのSlack</a>に参加して、気になるプロジェクトを探してみてください！
     difficulty: 3
@@ -228,7 +228,7 @@ missions:
     difficulty: 5
     required_artifact_type: TEXT
     max_achievement_count: 1
-    is_featured: true
+    is_featured: false
     is_hidden: false
     artifact_label: 「参加します または 参加しました」のテキスト
     ogp_image_url: null


### PR DESCRIPTION
# 変更の概要
- ミッション「7/3(木)の「街頭みらい会議」に参加しよう」から重要フラグを外す
- ついでに気になっていた誤字も修正しました

# 変更の背景
- closes #914 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました