### PR TITLE
feat: プロフィール初回設定およびアカウント画面で生年月日を編集可能に変更(#940)

### DIFF
--- a/app/(protected)/settings/profile/ProfileForm.tsx
+++ b/app/(protected)/settings/profile/ProfileForm.tsx
@@ -276,7 +276,7 @@ export default function ProfileForm({
             <Label htmlFor="date_of_birth">生年月日</Label>
             <p className="text-sm text-gray-500">この項目は公開されません</p>
             {/* 生年月日が必要な理由の説明エリア（折りたたみ可能） */}
-            <CollapsibleInfo title="なぜ生年月日が必要ですか？" variant="gray">
+            <CollapsibleInfo title="生年月日が必要な理由" variant="gray">
               <p>
                 法律により、サポーター登録は満18歳以上の方に限定されているため、年齢確認が必要です。
               </p>
@@ -288,7 +288,7 @@ export default function ProfileForm({
               className="grid grid-cols-3 gap-2"
               aria-labelledby="date_of_birth"
             >
-              <legend className="sr-only">生年月日</legend>
+              <legend className="sr-only">生年月日の選択</legend>
               <div>
                 <Label htmlFor="date_of_birth_year" className="sr-only">
                   年

--- a/app/(protected)/settings/profile/ProfileForm.tsx
+++ b/app/(protected)/settings/profile/ProfileForm.tsx
@@ -15,12 +15,26 @@ import {
 import { CollapsibleInfo } from "@/components/ui/collapsible-info";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { getAvatarUrl } from "@/lib/avatar";
 import { AVATAR_MAX_FILE_SIZE } from "@/lib/avatar";
 import { createClient } from "@/lib/supabase/client";
+import { calculateAge } from "@/lib/utils/utils";
 import { X } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useActionState, useEffect, useRef, useState } from "react";
+import {
+  useActionState,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { PrefectureSelect } from "./PrefectureSelect";
 import { updateProfile } from "./actions";
 
@@ -66,8 +80,64 @@ export default function ProfileForm({
   const [selectedPrefecture, setSelectedPrefecture] = useState<string>(
     initialProfile?.address_prefecture || "",
   );
+
+  // 生年月日の状態を追加
+  const initialDate = initialProfile?.date_of_birth
+    ? new Date(initialProfile.date_of_birth)
+    : null;
+  const [selectedYear, setSelectedYear] = useState(
+    initialDate?.getFullYear() || 1990,
+  );
+  const [selectedMonth, setSelectedMonth] = useState(
+    (initialDate?.getMonth() || 0) + 1,
+  );
+  const [selectedDay, setSelectedDay] = useState(initialDate?.getDate() || 1);
+  const [ageError, setAgeError] = useState<string | null>(null);
+  const [isAgeValid, setIsAgeValid] = useState(true);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
+
+  // 年月日の選択肢を生成
+  const birthYearThreshold = new Date().getFullYear() - 18;
+  const years = Array.from({ length: 100 }, (_, i) => birthYearThreshold - i);
+  const months = Array.from({ length: 12 }, (_, i) => i + 1);
+  const days = Array.from(
+    { length: new Date(selectedYear, selectedMonth, 0).getDate() },
+    (_, i) => i + 1,
+  );
+
+  // 日付フォーマット関数
+  const formatDate = useCallback(
+    (year: number | null, month: number | null, day: number | null): string => {
+      if (!year || !month || !day) return "";
+      const pad = (n: number) => n.toString().padStart(2, "0");
+      return `${year}-${pad(month)}-${pad(day)}`;
+    },
+    [],
+  );
+
+  const formattedDate = formatDate(selectedYear, selectedMonth, selectedDay);
+
+  // 年齢チェック関数
+  const verifyAge = useCallback((birthdate: string): boolean => {
+    if (!birthdate) return false;
+
+    const age = calculateAge(birthdate);
+    if (age < 18) {
+      const yearsToWait = 18 - age;
+      const waitText = yearsToWait > 1 ? `あと${yearsToWait}年で` : "もうすぐ";
+      setAgeError(
+        `18歳以上の方のみご登録いただけます。${waitText}登録できますので、その日を楽しみにお待ちください！`,
+      );
+      setIsAgeValid(false);
+      return false;
+    }
+
+    setAgeError(null);
+    setIsAgeValid(true);
+    return true;
+  }, []);
 
   useEffect(() => {
     // フォーム送信成功時の処理
@@ -78,6 +148,19 @@ export default function ProfileForm({
       setQueryMessage(undefined);
     }
   }, [state?.success, isNew, router]);
+
+  // 生年月日が変更された際に年齢チェックを実行
+  useEffect(() => {
+    verifyAge(formattedDate);
+  }, [formattedDate, verifyAge]);
+
+  // 月を変更した際、日付が月の日数を超えていたら1日に変更する
+  useEffect(() => {
+    const daysInMonth = new Date(selectedYear, selectedMonth, 0).getDate();
+    if (selectedDay > daysInMonth) {
+      setSelectedDay(1);
+    }
+  }, [selectedYear, selectedMonth, selectedDay]);
 
   // ファイル選択時のプレビュー処理
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -201,13 +284,88 @@ export default function ProfileForm({
                 プライバシーポリシーに従って厳重に管理され、他の目的には使用されません。
               </p>
             </CollapsibleInfo>
-            <Input
-              type="date"
-              name="date_of_birth"
-              required
-              readOnly
-              value={initialProfile?.date_of_birth || ""}
-            />
+            <fieldset
+              className="grid grid-cols-3 gap-2"
+              aria-labelledby="date_of_birth"
+            >
+              <legend className="sr-only">生年月日</legend>
+              <div>
+                <Label htmlFor="date_of_birth_year" className="sr-only">
+                  年
+                </Label>
+                <Select
+                  name="year_select"
+                  value={selectedYear.toString()}
+                  onValueChange={(value) => setSelectedYear(Number(value))}
+                  required
+                  disabled={isPending}
+                >
+                  <SelectTrigger data-testid="year_select">
+                    <SelectValue placeholder="年" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {years.map((year) => (
+                      <SelectItem key={year} value={year.toString()}>
+                        {year}年
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="date_of_birth_month" className="sr-only">
+                  月
+                </Label>
+                <Select
+                  name="month_select"
+                  value={selectedMonth.toString()}
+                  onValueChange={(value) => setSelectedMonth(Number(value))}
+                  required
+                  disabled={isPending}
+                >
+                  <SelectTrigger data-testid="month_select">
+                    <SelectValue placeholder="月" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {months.map((month) => (
+                      <SelectItem key={month} value={month.toString()}>
+                        {month}月
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="date_of_birth_day" className="sr-only">
+                  日
+                </Label>
+                <Select
+                  name="day_select"
+                  value={selectedDay.toString()}
+                  onValueChange={(value) => setSelectedDay(Number(value))}
+                  required
+                  disabled={isPending}
+                >
+                  <SelectTrigger data-testid="day_select">
+                    <SelectValue placeholder="日" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {days.map((day) => (
+                      <SelectItem key={day} value={day.toString()}>
+                        {day}日
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </fieldset>
+            {ageError && (
+              <p className="text-primary text-sm font-medium mb-2">
+                {ageError}
+              </p>
+            )}
+            {/* 隠しフィールドでフォーマット済みの日付を送信 */}
+            <input type="hidden" name="date_of_birth" value={formattedDate} />
           </div>
 
           <div className="space-y-2">
@@ -304,7 +462,7 @@ export default function ProfileForm({
           )}
         </CardContent>
         <CardFooter>
-          <SubmitButton className="w-full" disabled={isPending}>
+          <SubmitButton className="w-full" disabled={isPending || !isAgeValid}>
             {isNew ? "登録する" : "更新する"}
           </SubmitButton>
         </CardFooter>


### PR DESCRIPTION
# 変更の概要
- プロフィール新規登録`/settings/profile?new=true`とプロフィール編集画面`/settings/profile`で、生年月日を編集できるようにしました。これまで、`/sign-up`で入力した生年月日が持ち回され、読み取り専用でしたが、ユーザーが後から修正できるよう、サインアップ時と同様の年月日セレクトボックス形式に変更しました。

# 変更の背景
- アクションボード登録時に生年月日が1990年1月1日から変更できない、とのフィードバックが複数あった
- 変更不可がより望ましいかもしれないが、注意書きがちゃんと読まれない可能性も高いため、編集可とするPMによる意思決定
- closes #940

# 主な変更点
- 生年月日の入力フィールドを読み取り専用から編集可能な年月日セレクトボックスに変更
https://github.com/user-attachments/assets/2fa0ee65-2c90-4944-95eb-20499eb36444

# テスト項目
- `<input disabled="" type="checkbox">` 既存の生年月日データが正しく表示される
- `<input disabled="" type="checkbox">` 年月日セレクトボックスでの編集が正常に動作する
- `<input disabled="" type="checkbox">` 18歳未満の日付を選択した場合にエラーが表示される
- `<input disabled="" type="checkbox">` 2月29日など存在しない日付の適切な処理
- `<input disabled="" type="checkbox">` フォーム送信時のデータ形式が正しい
- `<input disabled="" type="checkbox">` プロフィール更新が正常に完了する

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 生年月日入力が年・月・日の3つのドロップダウン選択に変更され、より細かく選択できるようになりました。
  * 選択された生年月日から年齢を自動計算し、18歳未満の場合はエラーメッセージを表示し、送信ボタンが無効化されます。

* **改善**
  * 入力内容に応じて日付の選択肢が自動調整されるようになりました。
  * アクセシビリティとユーザビリティが向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->