### PR TITLE
fix: いどばたシステムをツール、チームみらいマニフェストをツール上のコンテンツと解釈し修正

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -31,9 +31,9 @@ missions:
     is_hidden: false
     ogp_image_url: null
   - slug: propose-manifest-idobata
-    title: チームみらいマニフェストから政策を提案しよう
+    title: チームみらいマニフェストに提案をしてみよう
     icon_url: /img/mission_fallback.svg
-    content: AIと一緒に、あなたの意見を政策にしよう。<a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>は、AIとチャットしながら政策に意見を出せる新しい仕組みです。気になるテーマに質問したり、自分の考えを提案としてまとめると、実際に「チームみらい」へ提出されます。提案にはURLが付き、どう検討されたかも追跡できます。
+    content: AIと一緒に、あなたの意見を政策にしよう。<a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>では、AIとチャットしながら政策に意見を出すことができます。気になるテーマに質問したり、自分の考えを提案としてまとめると、実際に「チームみらい」へ提出されます。提案にはURLが付き、どう検討されたかも追跡できます。
     difficulty: 3
     required_artifact_type: LINK
     max_achievement_count: null

--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -31,7 +31,7 @@ missions:
     is_hidden: false
     ogp_image_url: null
   - slug: propose-manifest-idobata
-    title: チームみらいマニフェストからマニフェストを提案しよう
+    title: チームみらいマニフェストから政策を提案しよう
     icon_url: /img/mission_fallback.svg
     content: AIと一緒に、あなたの意見を政策にしよう。<a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>は、AIとチャットしながら政策に意見を出せる新しい仕組みです。気になるテーマに質問したり、自分の考えを提案としてまとめると、実際に「チームみらい」へ提出されます。提案にはURLが付き、どう検討されたかも追跡できます。
     difficulty: 3
@@ -78,7 +78,7 @@ missions:
   - slug: share-manifest-sns
     title: マニフェストの感想をSNSでシェアしよう
     icon_url: /img/mission_fallback.svg
-    content: <a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>でマニフェストを読み、気になった政策や共感した提案について、あなたの言葉でSNSに感想を発信してみよう。難しく考えなくてOK。「ここがいいな」「もっとこうしてほしい」など、素直な声が広がることで、政治はもっと身近になります。
+    content: <a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>の内容を確認し、気になった政策や共感した提案について、あなたの言葉でSNSに感想を発信してみよう。難しく考えなくてOK。「ここがいいな」「もっとこうしてほしい」など、素直な声が広がることで、政治はもっと身近になります。
     difficulty: 2
     required_artifact_type: LINK
     max_achievement_count: null
@@ -352,13 +352,13 @@ missions:
   - slug: chat-idobata-ai
     title: チームみらいマニフェストでAIとチャットしよう
     icon_url: /img/mission_fallback.svg
-    content: チームみらいでは、みんなで政治をもっと身近に、もっとおもしろくする取り組みを進めています！そのひとつ、<a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>でAIとチャットしてみましょう！チャットに使った「チームみらいマニフェストのユーザー名」を入力してください。
+    content: チームみらいでは、みんなで政治をもっと身近に、もっとおもしろくする取り組みを進めています！そのひとつ、<a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>でAIとチャットしてみましょう！チャットに使った「いどばたのユーザー名」を入力してください。
     difficulty: 2
     required_artifact_type: TEXT
     max_achievement_count: 1
     is_featured: false
     is_hidden: false
-    artifact_label: チームみらいマニフェストのユーザー名
+    artifact_label: いどばたのユーザー名
     ogp_image_url: null
   - slug: quiz-teammirai-anno
     title: チームみらいクイズ（安野編）に挑戦しよう

--- a/mission_data/quiz_questions.yaml
+++ b/mission_data/quiz_questions.yaml
@@ -398,10 +398,10 @@ quiz_questions:
     question: "オープンな政策立案プロセスを支える基盤として挙げられているデジタル民主主義2030由来のシステムはどれ？"
     option1: "電子投票ブロックチェーン"
     option2: "気候予測AI"
-    option3: "チームみらいマニフェスト"
+    option3: "いどばたシステム"
     option4: "スマート市役所ダッシュボード"
     correct_answer: 3
-    explanation: "ユーティリティ政党フェーズでは『チームみらいマニフェスト』や広聴AI・YouTube中継を組み合わせてオープンな政策議論を行うと書かれています。"
+    explanation: "ユーティリティ政党フェーズでは『いどばたシステム』や広聴AI・YouTube中継を組み合わせてオープンな政策議論を行うと書かれています。"
     question_order: 2
     is_active: true
 


### PR DESCRIPTION
# 変更の概要
- 過去の修正内容が適切ではなかったため、表題の通り修正

# 変更の背景
- https://github.com/team-mirai-volunteer/action-board/pull/951

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 「チームみらいマニフェスト」に関連する3つのミッションのタイトルや説明文、アーティファクトラベルの表現をより明確に修正しました。
  * クイズ問題の選択肢および解説文における「チームみらいマニフェスト」の表記を「いどばたシステム」に変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->