### PR TITLE
fix: 掲示板更新後に「自分が更新したもののみ」フィルタに即座に反映されない問題

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -58,6 +58,7 @@ type StatusHistory =
 import {
   getBoardStatusHistoryAction,
   getPosterBoardStatsAction,
+  getUserEditedBoardIdsAction,
 } from "@/lib/actions/poster-boards";
 
 interface PrefecturePosterMapClientProps {
@@ -108,7 +109,9 @@ export default function PrefecturePosterMapClient({
     ] as BoardStatus[],
     showOnlyMine: false,
   });
-  const [userEditedBoardIdsSet] = useState<Set<string>>(() => {
+  const [userEditedBoardIdsSet, setUserEditedBoardIdsSet] = useState<
+    Set<string>
+  >(() => {
     return new Set(userEditedBoardIds || []);
   });
 
@@ -153,6 +156,15 @@ export default function PrefecturePosterMapClient({
         prefecture as Parameters<typeof getPosterBoardStatsAction>[0],
       );
       setStats(newStats);
+
+      // ユーザーがログインしている場合は、編集した掲示板IDも再取得
+      if (userId) {
+        const updatedUserEditedBoardIds = await getUserEditedBoardIdsAction(
+          prefecture as Parameters<typeof getUserEditedBoardIdsAction>[0],
+          userId,
+        );
+        setUserEditedBoardIdsSet(new Set(updatedUserEditedBoardIds || []));
+      }
     } catch (error) {
       toast.error("ポスター掲示板の読み込みに失敗しました");
     } finally {


### PR DESCRIPTION
## 概要
掲示板のステータスを更新した直後、「自分が更新したもののみ」フィルタを適用しても、更新したばかりの掲示板が表示されない問題を修正しました。

Fixes #961

## 変更内容
- `getUserEditedBoardIdsAction`をインポートに追加
- `userEditedBoardIdsSet`をstateとして管理できるように変更
- `loadBoards`関数内で、掲示板データ再取得時に`userEditedBoardIds`も再取得するように修正

## テスト方法
1. ポスター掲示板マップにアクセス
2. 任意の掲示板のステータスを更新
3. 「自分が更新したもののみ」フィルタを適用
4. 更新した掲示板が表示されることを確認

## スクリーンショット
（該当なし）

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ログインユーザーが編集したポスターボードIDの一覧を自動的に取得・更新し、常に最新の編集状況を反映するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->