### PR TITLE
ポスターの状況を報告モーダルに、掲示板番号を表示する

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -448,13 +448,18 @@ export default function PrefecturePosterMapClient({
           <DialogHeader>
             <DialogTitle>ポスターの状況を報告</DialogTitle>
             <DialogDescription>
-              {selectedBoard?.name}の状況を教えてください
+              {selectedBoard?.name ||
+                selectedBoard?.address ||
+                selectedBoard?.number}
+              の状況を教えてください
             </DialogDescription>
           </DialogHeader>
           {selectedBoard && (
             <div className="mb-4 text-sm text-muted-foreground">
-              <div>{selectedBoard.address}</div>
-              <div>{selectedBoard.city}</div>
+              <div>
+                {selectedBoard.city} {selectedBoard.address} (
+                {selectedBoard.number})
+              </div>
             </div>
           )}
           <div className="space-y-4">


### PR DESCRIPTION
# 変更の概要
- ポスターの状況を報告モーダルに、掲示板番号を表示する
- ポスターの状況を報告モーダルで、掲示板名`selectedBoard.name`が空欄の場合、（空欄）の状況を教えてください　と表示されてしまうため、代替として所在地やIDを表示する

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #986

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **改善**
  * 状況報告ダイアログで、選択した掲示板の説明が掲示板名・住所・IDのいずれか最初に利用可能な情報を表示するようになりました。
  * 詳細情報が「市区町村・住所・ID」を1行でまとめて表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->