### PR TITLE
fix #995 掲示番号を報告モーダルに表示

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -448,7 +448,8 @@ export default function PrefecturePosterMapClient({
           <DialogHeader>
             <DialogTitle>ポスターの状況を報告</DialogTitle>
             <DialogDescription>
-              {selectedBoard?.number}の状況を教えてください
+              {selectedBoard?.number || selectedBoard?.name || "この掲示板"}
+              の状況を教えてください
             </DialogDescription>
           </DialogHeader>
           {selectedBoard && (

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -448,13 +448,14 @@ export default function PrefecturePosterMapClient({
           <DialogHeader>
             <DialogTitle>ポスターの状況を報告</DialogTitle>
             <DialogDescription>
-              {selectedBoard?.name}の状況を教えてください
+              {selectedBoard?.number}の状況を教えてください
             </DialogDescription>
           </DialogHeader>
           {selectedBoard && (
             <div className="mb-4 text-sm text-muted-foreground">
-              <div>{selectedBoard.address}</div>
               <div>{selectedBoard.city}</div>
+              <div>{selectedBoard.address}</div>
+              <div>{selectedBoard.name}</div>
             </div>
           )}
           <div className="space-y-4">


### PR DESCRIPTION
# 変更の概要
- 「ポスターの状況を報告」モーダルに掲示板番号を表示

# 変更の背景
- 掲示板番号はツールチップには表示されていたが、タッチデバイスではツールチップが表示されない
- 掲示板番号を確認する手段がなくなったことで、ピン位置のズレている掲示板の報告で混乱が生じている
- closes #995 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **改善**
  * ポスターボードの状態報告ダイアログで、報告対象の表示がボード名からボード番号優先表示に変更され、番号・名前がない場合は「この掲示板」と表示されるようになりました。
  * ダイアログ内の詳細情報が「市区町村」「住所」「ボード名」の順で表示され、より詳細な情報が確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->