### PR TITLE
本番デプロイ 07/07 16:49

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -448,13 +448,18 @@ export default function PrefecturePosterMapClient({
           <DialogHeader>
             <DialogTitle>ポスターの状況を報告</DialogTitle>
             <DialogDescription>
-              {selectedBoard?.name}の状況を教えてください
+              {selectedBoard?.name ||
+                selectedBoard?.address ||
+                selectedBoard?.number}
+              の状況を教えてください
             </DialogDescription>
           </DialogHeader>
           {selectedBoard && (
             <div className="mb-4 text-sm text-muted-foreground">
-              <div>{selectedBoard.address}</div>
-              <div>{selectedBoard.city}</div>
+              <div>
+                {selectedBoard.city} {selectedBoard.address} (
+                {selectedBoard.number})
+              </div>
             </div>
           )}
           <div className="space-y-4">


### PR DESCRIPTION
* Add poster ID in the situation report modal

* Add poster ID in the situation report modal and fix board ID display

- Show board number in parentheses in the address
- Use board name, address, or number as fallback for dialog title
- Combine city and address display into single line

🤖 Generated with [Claude Code](https://claude.ai/code)



---------

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました