### PR TITLE
#931: 掲示板ポスターフォームは1枚ずつのみの提出とする

### DIFF
--- a/app/missions/[id]/actions.ts
+++ b/app/missions/[id]/actions.ts
@@ -127,12 +127,6 @@ const postingArtifactSchema = baseMissionFormSchema.extend({
 // POSTERタイプ用スキーマ
 const posterArtifactSchema = baseMissionFormSchema.extend({
   requiredArtifactType: z.literal(ARTIFACT_TYPES.POSTER.key),
-  posterCount: z.coerce
-    .number()
-    .min(1, { message: "ポスター枚数は1枚以上で入力してください" })
-    .max(MAX_POSTER_COUNT, {
-      message: `ポスター枚数は${MAX_POSTER_COUNT}枚以下で入力してください`,
-    }),
   prefecture: z
     .string()
     .min(1, { message: "都道府県を選択してください" })
@@ -241,7 +235,6 @@ export const achieveMissionAction = async (formData: FormData) => {
   const postingCount = formData.get("postingCount")?.toString();
   const locationText = formData.get("locationText")?.toString();
   // ポスター用データの取得
-  const posterCount = formData.get("posterCount")?.toString();
   const prefecture = formData.get("prefecture")?.toString();
   const city = formData.get("city")?.toString();
   const boardNumber = formData.get("boardNumber")?.toString();
@@ -265,7 +258,6 @@ export const achieveMissionAction = async (formData: FormData) => {
     accuracy,
     altitude,
     postingCount,
-    posterCount,
     locationText,
     prefecture,
     city,
@@ -503,7 +495,7 @@ export const achieveMissionAction = async (formData: FormData) => {
           ? ` - 状況: ${validatedData.boardNote}`
           : "";
 
-        artifactPayload.text_content = `${validatedData.posterCount}枚を${locationInfo}${nameInfo}に貼付${statusInfo}`;
+        artifactPayload.text_content = `${locationInfo}${nameInfo}に貼付${statusInfo}`;
         // CHECK制約: text_content必須、他はnull
         artifactPayload.link_url = null;
         artifactPayload.image_storage_path = null;
@@ -668,7 +660,7 @@ export const achieveMissionAction = async (formData: FormData) => {
       const posterActivityPayload = {
         user_id: authUser.id,
         mission_artifact_id: newArtifact.id,
-        poster_count: validatedData.posterCount,
+        poster_count: MAX_POSTER_COUNT,
         prefecture:
           validatedData.prefecture as Database["public"]["Enums"]["poster_prefecture_enum"],
         city: validatedData.city,
@@ -699,7 +691,7 @@ export const achieveMissionAction = async (formData: FormData) => {
 
       // ポスター用のポイント計算とXP付与
       const pointsPerUnit = POSTER_POINTS_PER_UNIT;
-      const totalPoints = validatedData.posterCount * pointsPerUnit;
+      const totalPoints = MAX_POSTER_COUNT * pointsPerUnit;
 
       // 通常のXP（ミッション難易度ベース）に加えて、ポスターボーナスXPを付与
       const bonusXpResult = await grantXp(
@@ -707,7 +699,7 @@ export const achieveMissionAction = async (formData: FormData) => {
         totalPoints,
         "BONUS",
         achievement.id,
-        `ポスターボーナス（${validatedData.posterCount}枚×${pointsPerUnit}ポイント）`,
+        `ポスターボーナス（${MAX_POSTER_COUNT}枚×${pointsPerUnit}ポイント）`,
       );
 
       if (!bonusXpResult.success) {

--- a/components/mission/ArtifactForm.test.tsx
+++ b/components/mission/ArtifactForm.test.tsx
@@ -149,7 +149,11 @@ describe("ArtifactForm", () => {
       />,
     );
 
-    expect(screen.getByText("ポスター枚数")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "ポスターマップ上にデータが見つからないなど、マップで報告できない場合は以下のフォームに入力してください。",
+      ),
+    ).toBeInTheDocument();
     // 詳細はPosterForm.test.tsxで確認
   });
 

--- a/components/mission/PosterForm.test.tsx
+++ b/components/mission/PosterForm.test.tsx
@@ -49,7 +49,6 @@ describe("PosterForm", () => {
     render(<PosterForm disabled={false} />);
 
     // 必須フィールドの確認
-    expect(screen.getByLabelText(/ポスター枚数/)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Select Prefecture/i }),
     ).toBeInTheDocument(); // Selectボタンの存在確認
@@ -57,7 +56,7 @@ describe("PosterForm", () => {
     expect(screen.getByLabelText(/番号/)).toBeInTheDocument();
 
     // 必須マークの確認
-    expect(screen.getAllByText("*")).toHaveLength(4);
+    expect(screen.getAllByText("*")).toHaveLength(3);
   });
 
   it("renders all optional fields", () => {
@@ -75,9 +74,6 @@ describe("PosterForm", () => {
     render(<PosterForm disabled={true} />);
 
     // すべての入力フィールドが無効化されていることを確認
-    expect(
-      screen.getByRole("spinbutton", { name: /ポスター枚数/ }),
-    ).toBeDisabled();
     expect(screen.getByTestId("select")).toHaveAttribute(
       "data-disabled",
       "true",
@@ -95,9 +91,6 @@ describe("PosterForm", () => {
     render(<PosterForm disabled={false} />);
 
     // すべての入力フィールドが有効化されていることを確認
-    expect(
-      screen.getByRole("spinbutton", { name: /ポスター枚数/ }),
-    ).not.toBeDisabled();
     expect(screen.getByTestId("select")).toHaveAttribute(
       "data-disabled",
       "false",
@@ -111,19 +104,6 @@ describe("PosterForm", () => {
     expect(screen.getByRole("textbox", { name: /住所/ })).not.toBeDisabled();
     expect(screen.getByRole("spinbutton", { name: /緯度/ })).not.toBeDisabled();
     expect(screen.getByRole("spinbutton", { name: /経度/ })).not.toBeDisabled();
-  });
-
-  it("has correct input attributes for poster count", () => {
-    render(<PosterForm disabled={false} />);
-
-    const posterCountInput = screen.getByRole("spinbutton", {
-      name: /ポスター枚数/,
-    });
-    expect(posterCountInput).toHaveAttribute("type", "number");
-    expect(posterCountInput).toHaveAttribute("name", "posterCount");
-    expect(posterCountInput).toHaveAttribute("min", "1");
-    expect(posterCountInput).toHaveAttribute("max", "10000"); // MAX_POSTER_COUNT
-    expect(posterCountInput).toBeRequired();
   });
 
   it("has correct input attributes for city field", () => {
@@ -196,9 +176,6 @@ describe("PosterForm", () => {
 
     // ヘルプテキストの確認
     expect(
-      screen.getByText(/貼り付けた枚数を入力してください/),
-    ).toBeInTheDocument();
-    expect(
       screen.getByText(/市町村名と区名を入力してください/),
     ).toBeInTheDocument();
     expect(screen.getByText(/番号を入力してください/)).toBeInTheDocument();
@@ -222,7 +199,6 @@ describe("PosterForm", () => {
     render(<PosterForm disabled={false} />);
 
     // プレースホルダーテキストの確認
-    expect(screen.getByPlaceholderText("例：10")).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("例：渋谷区、名古屋市中区"),
     ).toBeInTheDocument();
@@ -279,9 +255,6 @@ describe("PosterForm", () => {
 
     // 各フィールドがラベルと一緒にレンダリングされていることを確認
     expect(
-      screen.getByRole("spinbutton", { name: /ポスター枚数/ }),
-    ).toBeInTheDocument();
-    expect(
       screen.getByRole("textbox", { name: /市町村＋区/ }),
     ).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /番号/ })).toBeInTheDocument();
@@ -291,10 +264,6 @@ describe("PosterForm", () => {
     render(<PosterForm disabled={false} />);
 
     // アクセシビリティ属性の確認
-    const posterCountInput = screen.getByRole("spinbutton", {
-      name: /ポスター枚数/,
-    });
-    expect(posterCountInput).toHaveAttribute("id", "posterCount");
 
     const cityInput = screen.getByRole("textbox", { name: /市町村＋区/ });
     expect(cityInput).toHaveAttribute("id", "city");

--- a/components/mission/PosterForm.tsx
+++ b/components/mission/PosterForm.tsx
@@ -10,7 +10,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { MAX_POSTER_COUNT, POSTER_POINTS_PER_UNIT } from "@/lib/constants";
 import { VALID_JP_PREFECTURES } from "@/lib/constants/poster-prefectures";
 import { useState } from "react";
 import { Button } from "../ui/button";
@@ -44,25 +43,6 @@ export function PosterForm({ disabled }: PosterFormProps) {
         <Separator className="my-4" />
         <p>
           ポスターマップ上にデータが見つからないなど、マップで報告できない場合は以下のフォームに入力してください。
-        </p>
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="posterCount">
-          ポスター枚数 <span className="text-red-500">*</span>
-        </Label>
-        <Input
-          type="number"
-          name="posterCount"
-          id="posterCount"
-          min="1"
-          max={MAX_POSTER_COUNT}
-          required
-          disabled={disabled}
-          placeholder="例：10"
-        />
-        <p className="text-xs text-gray-500">
-          貼り付けた枚数を入力してください（1枚＝{POSTER_POINTS_PER_UNIT}
-          ポイント）
         </p>
       </div>
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,7 +16,7 @@ export const YOUTUBE_MISSION_CONFIG = {
 export const MAX_POSTING_COUNT = 100000;
 
 // ポスターミッションでの最大枚数
-export const MAX_POSTER_COUNT = 10000;
+export const MAX_POSTER_COUNT = 1;
 
 // ポスターマップの最大ズーム値
 export const MAX_ZOOM = 18;


### PR DESCRIPTION
# 変更の概要
- 選挙区ポスターを貼ろう のミッションで1度に1枚のみの完了を記録できるようにしました
- フォームの「ポスター枚数」入力欄を削除しました
- 併せて actions.ts も修正しました
- MAX_POSTER_COUNT を 1 に変更しました

<table>
  <tr>
    <th>修正前</th>
    <th>修正後</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/38377020-5d85-4162-9bd7-3bbc9f033ef8" width="300"></td>
    <td><img src="https://github.com/user-attachments/assets/2866a90d-1fa6-4c19-9500-9572336a17f8" width="300"></td>
  </tr>
</table>

# 変更の背景
- 1住所1ポスターのため
- closes #931 

# 補足

テスト失敗していますが、この PR の修正には関係ない箇所で、develop ブランチでも失敗しているものです。
```
FAIL components/ranking/ranking-mission.test.tsx
  ● RankingMission › サービス関数の呼び出し › getMissionRankingが正しいパラメータで呼ばれる

FAIL components/ranking/ranking-prefecture.test.tsx
  ● RankingPrefecture › サービス関数の呼び出し › getPrefecturesRankingが正しいパラメータで呼ばれる
```

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **新機能の変更**
  * ポスター枚数の入力欄をフォームから削除しました。  
  * ポスター関連のポイントやXP付与は常に1枚分で計算されるようになりました。

* **仕様変更**
  * ポスターの最大枚数が10,000枚から1枚に変更されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->