### PR TITLE
feat: ポスターマップページのパフォーマンスを最適化

### DIFF
--- a/app/map/poster/page.tsx
+++ b/app/map/poster/page.tsx
@@ -1,6 +1,6 @@
 import {
+  getPosterBoardSummaryByPrefecture,
   getPosterBoardTotals,
-  getPosterBoards,
 } from "@/lib/services/poster-boards";
 import type { Metadata } from "next";
 import PosterMapPageClientOptimized from "./PosterMapPageClientOptimized";
@@ -11,15 +11,15 @@ export const metadata: Metadata = {
 };
 
 export default async function PosterMapPage() {
-  // サーバーサイドでデータを取得
-  const [boards, totals] = await Promise.all([
-    getPosterBoards(),
+  // サーバーサイドで統計データのみを取得
+  const [summary, totals] = await Promise.all([
+    getPosterBoardSummaryByPrefecture(),
     getPosterBoardTotals(),
   ]);
 
   return (
     <PosterMapPageClientOptimized
-      initialBoards={boards}
+      initialSummary={summary}
       initialTotals={totals}
     />
   );


### PR DESCRIPTION
## Summary
- `/map/poster`ページの初期ロード時間を20秒から数秒に短縮
- 120,000件の全データ取得を廃止し、統計情報のみを取得する軽量なアプローチに変更
- データベースクエリを120回から1回に削減

## 変更内容
### 1. 新しい関数`getPosterBoardSummaryByPrefecture()`を追加
- 都道府県別の統計情報のみを取得（prefecture, statusフィールドのみ）
- 全データではなく集計に必要な最小限のデータを取得

### 2. `PosterMapPageClientOptimized`コンポーネントを最適化
- `initialBoards`（全データ）から`initialSummary`（統計データ）に変更
- クライアント側の計算処理を削減

### 3. ページコンポーネントの更新
- `getPosterBoards()`の呼び出しを削除
- `getPosterBoardSummaryByPrefecture()`を使用

## パフォーマンス改善
- **Before**: 120,000件のデータを1,000件ずつ120回のクエリで取得（約20秒）
- **After**: prefecture, statusフィールドのみを1回のクエリで取得（数秒）

## Test plan
- [ ] `/map/poster`ページが正常に表示される
- [ ] 都道府県別の統計が正しく表示される
- [ ] 進捗率の計算が正しい
- [ ] ページロード時間が改善されている

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ポスターボードの統計情報を都道府県ごとに集計したサマリーデータの取得と表示に対応しました。

* **改善**
  * 詳細なポスターボード一覧の代わりに、集計済みのサマリーデータを利用することで、ページのパフォーマンスが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->