### PR TITLE
feat: 登録やログイン関連ページにFAQ導線を追加(#990)

### DIFF
--- a/app/(auth-pages)/forgot-password/page.tsx
+++ b/app/(auth-pages)/forgot-password/page.tsx
@@ -9,6 +9,35 @@ export default async function ForgotPassword(props: {
   searchParams: Promise<Message>;
 }) {
   const searchParams = await props.searchParams;
+
+  // HTMLタグが含まれている場合はhtmlフラグを追加
+  const messageWithHtml =
+    searchParams &&
+    ("success" in searchParams ||
+      "error" in searchParams ||
+      "message" in searchParams)
+      ? (() => {
+          if (
+            "success" in searchParams &&
+            searchParams.success?.includes("<a href=")
+          ) {
+            return { ...searchParams, html: true };
+          }
+          if (
+            "error" in searchParams &&
+            searchParams.error?.includes("<a href=")
+          ) {
+            return { ...searchParams, html: true };
+          }
+          if (
+            "message" in searchParams &&
+            searchParams.message?.includes("<a href=")
+          ) {
+            return { ...searchParams, html: true };
+          }
+          return searchParams;
+        })()
+      : searchParams;
   return (
     <>
       <form className="flex-1 flex flex-col w-full gap-2 text-foreground [&>input]:mb-6 min-w-72 max-w-72 mx-auto">
@@ -27,7 +56,7 @@ export default async function ForgotPassword(props: {
           <SubmitButton formAction={forgotPasswordAction}>
             パスワードリセットメールを送信
           </SubmitButton>
-          <FormMessage message={searchParams} />
+          <FormMessage message={messageWithHtml} />
         </div>
       </form>
     </>

--- a/app/(auth-pages)/forgot-password/page.tsx
+++ b/app/(auth-pages)/forgot-password/page.tsx
@@ -6,38 +6,28 @@ import { Label } from "@/components/ui/label";
 import Image from "next/image";
 
 export default async function ForgotPassword(props: {
-  searchParams: Promise<Message>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const searchParams = await props.searchParams;
 
-  // HTMLタグが含まれている場合はhtmlフラグを追加
-  const messageWithHtml =
-    searchParams &&
-    ("success" in searchParams ||
-      "error" in searchParams ||
-      "message" in searchParams)
-      ? (() => {
-          if (
-            "success" in searchParams &&
-            searchParams.success?.includes("<a href=")
-          ) {
-            return { ...searchParams, html: true };
-          }
-          if (
-            "error" in searchParams &&
-            searchParams.error?.includes("<a href=")
-          ) {
-            return { ...searchParams, html: true };
-          }
-          if (
-            "message" in searchParams &&
-            searchParams.message?.includes("<a href=")
-          ) {
-            return { ...searchParams, html: true };
-          }
-          return searchParams;
-        })()
-      : searchParams;
+  // Type-based message handling
+  const getMessage = () => {
+    if (searchParams?.success === "password-reset-success") {
+      return { type: "password-reset-success" as const };
+    }
+    if (searchParams?.error && typeof searchParams.error === "string") {
+      return { error: searchParams.error };
+    }
+    if (searchParams?.success && typeof searchParams.success === "string") {
+      return { success: searchParams.success };
+    }
+    if (searchParams?.message && typeof searchParams.message === "string") {
+      return { message: searchParams.message };
+    }
+    return null;
+  };
+
+  const message = getMessage();
   return (
     <>
       <form className="flex-1 flex flex-col w-full gap-2 text-foreground [&>input]:mb-6 min-w-72 max-w-72 mx-auto">
@@ -56,7 +46,7 @@ export default async function ForgotPassword(props: {
           <SubmitButton formAction={forgotPasswordAction}>
             パスワードリセットメールを送信
           </SubmitButton>
-          <FormMessage message={messageWithHtml} />
+          {message && <FormMessage message={message} />}
         </div>
       </form>
     </>

--- a/app/(auth-pages)/sign-in/SignInForm.tsx
+++ b/app/(auth-pages)/sign-in/SignInForm.tsx
@@ -62,7 +62,10 @@ export default function SignInForm({ returnUrl }: SignInFormProps) {
       {/* Email + Passwordログインフォーム */}
       <form action={formAction} className="flex flex-col gap-2 [&>input]:mb-3">
         {state?.error && (
-          <FormMessage message={{ error: state.error }} className="mb-4" />
+          <FormMessage
+            message={{ error: state.error, html: true }}
+            className="mb-4"
+          />
         )}
         {returnUrl && (
           <input type="hidden" name="returnUrl" value={returnUrl} />

--- a/app/(auth-pages)/sign-in/SignInForm.tsx
+++ b/app/(auth-pages)/sign-in/SignInForm.tsx
@@ -63,7 +63,11 @@ export default function SignInForm({ returnUrl }: SignInFormProps) {
       <form action={formAction} className="flex flex-col gap-2 [&>input]:mb-3">
         {state?.error && (
           <FormMessage
-            message={{ error: state.error, html: true }}
+            message={
+              state.error === "login-error"
+                ? { type: "login-error" }
+                : { error: state.error }
+            }
             className="mb-4"
           />
         )}

--- a/app/(auth-pages)/sign-up-success/page.tsx
+++ b/app/(auth-pages)/sign-up-success/page.tsx
@@ -11,18 +11,7 @@ export default function SignUpSuccess() {
         <h1 className="text-2xl font-medium text-center mb-2">
           アカウント作成完了
         </h1>
-        <FormMessage
-          message={{
-            success:
-              "ご登録頂きありがとうございます！\n" +
-              "認証メールをお送りしました。\n" +
-              "メールに記載のURLをクリックして、アカウントを有効化してください。\n" +
-              "なお、迷惑メールフォルダに振り分けられている場合がありますので、そちらもあわせてご確認ください。\n\n" +
-              '会員登録でお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
-            html: true,
-          }}
-          className="mt-8"
-        />
+        <FormMessage message={{ type: "signup-success" }} className="mt-8" />
       </div>
     </div>
   );

--- a/app/(auth-pages)/sign-up-success/page.tsx
+++ b/app/(auth-pages)/sign-up-success/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 
 export default function SignUpSuccess() {
   return (
-    <div className="flex-1 flex flex-col min-w-72">
+    <div className="flex-1 flex flex-col min-w-72 max-w-lg mx-auto px-4">
       <div className="flex justify-center items-center m-4">
         <Image src="/img/logo.png" alt="logo" width={114} height={96} />
       </div>
@@ -17,7 +17,9 @@ export default function SignUpSuccess() {
               "ご登録頂きありがとうございます！\n" +
               "認証メールをお送りしました。\n" +
               "メールに記載のURLをクリックして、アカウントを有効化してください。\n" +
-              "なお、迷惑メールフォルダに振り分けられている場合がありますので、そちらもあわせてご確認ください。",
+              "なお、迷惑メールフォルダに振り分けられている場合がありますので、そちらもあわせてご確認ください。\n\n" +
+              '会員登録でお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
+            html: true,
           }}
           className="mt-8"
         />

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -219,14 +219,16 @@ export const signInActionWithState = async (
   });
   if (!validatedFields.success) {
     return {
-      error: "メールアドレスまたはパスワードが間違っています",
+      error:
+        'メールアドレスまたはパスワードが間違っています\n\nログインでお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
       formData: currentFormData,
     };
   }
 
   if (!email || !password) {
     return {
-      error: "メールアドレスまたはパスワードが間違っています",
+      error:
+        'メールアドレスまたはパスワードが間違っています\n\nログインでお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
       formData: currentFormData,
     };
   }
@@ -240,7 +242,8 @@ export const signInActionWithState = async (
 
   if (error) {
     return {
-      error: "メールアドレスまたはパスワードが間違っています",
+      error:
+        'メールアドレスまたはパスワードが間違っています\n\nログインでお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
       formData: currentFormData,
     };
   }
@@ -324,7 +327,7 @@ export const forgotPasswordAction = async (formData: FormData) => {
   return encodedRedirect(
     "success",
     "/forgot-password",
-    "パスワードリセット用のリンクをメールでお送りしました。",
+    'パスワードリセット用のリンクをメールでお送りしました。\n\nパスワードリセットでお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
   );
 };
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -219,16 +219,14 @@ export const signInActionWithState = async (
   });
   if (!validatedFields.success) {
     return {
-      error:
-        'メールアドレスまたはパスワードが間違っています\n\nログインでお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
+      error: "login-error",
       formData: currentFormData,
     };
   }
 
   if (!email || !password) {
     return {
-      error:
-        'メールアドレスまたはパスワードが間違っています\n\nログインでお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
+      error: "login-error",
       formData: currentFormData,
     };
   }
@@ -242,8 +240,7 @@ export const signInActionWithState = async (
 
   if (error) {
     return {
-      error:
-        'メールアドレスまたはパスワードが間違っています\n\nログインでお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
+      error: "login-error",
       formData: currentFormData,
     };
   }
@@ -327,7 +324,7 @@ export const forgotPasswordAction = async (formData: FormData) => {
   return encodedRedirect(
     "success",
     "/forgot-password",
-    'パスワードリセット用のリンクをメールでお送りしました。\n\nパスワードリセットでお困りの方は<a href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f" target="_blank" rel="noopener noreferrer" style="color: #0d9488; text-decoration: underline;">よくあるご質問 ↗</a>をご確認ください。',
+    "password-reset-success",
   );
 };
 

--- a/components/footer/CopyrightSection.tsx
+++ b/components/footer/CopyrightSection.tsx
@@ -38,6 +38,15 @@ export function CopyrightSection() {
             >
               ご意見箱
             </Link>
+            <span>|</span>
+            <Link
+              href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f"
+              className="hover:text-teal-700 transition-colors duration-200 text-teal-600"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              よくあるご質問
+            </Link>
           </div>
         </div>
         <p className="text-sm text-muted-foreground text-center mt-4">

--- a/components/form-message.tsx
+++ b/components/form-message.tsx
@@ -1,20 +1,123 @@
 import clsx from "clsx";
 import { CheckCircle, Info, XCircle } from "lucide-react";
 
+export type MessageType =
+  | "success"
+  | "error"
+  | "message"
+  | "signup-success"
+  | "password-reset-success"
+  | "login-error";
+
 export type Message =
   | { success: string; html?: boolean }
   | { error: string; html?: boolean }
-  | { message: string; html?: boolean };
+  | { message: string; html?: boolean }
+  | { type: MessageType };
+
+const getMessageContent = (type: MessageType) => {
+  const faqLink = (
+    <a
+      href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-teal-600 hover:text-teal-700 underline"
+    >
+      よくあるご質問 ↗
+    </a>
+  );
+
+  switch (type) {
+    case "signup-success":
+      return (
+        <div>
+          ご登録頂きありがとうございます！
+          <br />
+          認証メールをお送りしました。
+          <br />
+          メールに記載のURLをクリックして、アカウントを有効化してください。
+          <br />
+          なお、迷惑メールフォルダに振り分けられている場合がありますので、そちらもあわせてご確認ください。
+          <br />
+          <br />
+          会員登録でお困りの方は{faqLink}をご確認ください。
+        </div>
+      );
+    case "password-reset-success":
+      return (
+        <div>
+          パスワードリセット用のリンクをメールでお送りしました。
+          <br />
+          <br />
+          パスワードリセットでお困りの方は{faqLink}をご確認ください。
+        </div>
+      );
+    case "login-error":
+      return (
+        <div>
+          メールアドレスまたはパスワードが間違っています
+          <br />
+          <br />
+          ログインでお困りの方は{faqLink}をご確認ください。
+        </div>
+      );
+    default:
+      return null;
+  }
+};
 
 export function FormMessage({
   className,
   message,
 }: { className?: string; message: Message }) {
-  if (
-    !message ||
-    !("success" in message || "error" in message || "message" in message)
-  )
+  if (!message) return null;
+
+  // Type-based message handling
+  if ("type" in message) {
+    const content = getMessageContent(message.type);
+    if (!content) return null;
+
+    const isError = message.type === "login-error";
+    const isSuccess =
+      message.type === "signup-success" ||
+      message.type === "password-reset-success";
+
+    return (
+      <div
+        className={clsx(
+          "relative flex items-start gap-3 w-full max-w-md mx-auto p-4 rounded-xl",
+          "border text-card-foreground shadow-soft-lg",
+          "sm:max-w-lg",
+          {
+            "bg-green-50 border-green-200": isSuccess,
+            "bg-red-50 border-red-200": isError,
+            "bg-blue-50 border-blue-200": !isSuccess && !isError,
+          },
+          className,
+        )}
+      >
+        <div className="flex-1">
+          <div
+            className={clsx(
+              "text-sm whitespace-pre-wrap leading-relaxed space-y-1",
+              {
+                "text-green-700": isSuccess,
+                "text-red-700": isError,
+                "text-blue-700": !isSuccess && !isError,
+              },
+            )}
+          >
+            {content}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Legacy string-based message handling
+  if (!("success" in message || "error" in message || "message" in message)) {
     return null;
+  }
 
   return (
     <div

--- a/components/form-message.tsx
+++ b/components/form-message.tsx
@@ -2,9 +2,9 @@ import clsx from "clsx";
 import { CheckCircle, Info, XCircle } from "lucide-react";
 
 export type Message =
-  | { success: string }
-  | { error: string }
-  | { message: string };
+  | { success: string; html?: boolean }
+  | { error: string; html?: boolean }
+  | { message: string; html?: boolean };
 
 export function FormMessage({
   className,
@@ -19,8 +19,9 @@ export function FormMessage({
   return (
     <div
       className={clsx(
-        "relative flex items-start gap-3 w-full max-w-md p-4 rounded-xl",
+        "relative flex items-start gap-3 w-full max-w-md mx-auto p-4 rounded-xl",
         "border text-card-foreground shadow-soft-lg",
+        "sm:max-w-lg", // スマホよりも大きい画面では少し広く
         {
           "bg-green-50 border-green-200": "success" in message,
           "bg-red-50 border-red-200": "error" in message,
@@ -31,22 +32,46 @@ export function FormMessage({
     >
       {"success" in message && (
         <div className="flex-1">
-          <div className="text-sm text-green-700 whitespace-pre-wrap leading-relaxed">
-            {message.success}
+          <div className="text-sm text-green-700 whitespace-pre-wrap leading-relaxed space-y-1">
+            {message.html ? (
+              <div
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: Controlled HTML content for FAQ links
+                dangerouslySetInnerHTML={{ __html: message.success }}
+                className="[&_a]:inline-block [&_a]:break-words"
+              />
+            ) : (
+              message.success
+            )}
           </div>
         </div>
       )}
       {"error" in message && (
         <div className="flex-1">
-          <div className="text-sm text-red-700 whitespace-pre-wrap leading-relaxed">
-            {message.error}
+          <div className="text-sm text-red-700 whitespace-pre-wrap leading-relaxed space-y-1">
+            {message.html ? (
+              <div
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: Controlled HTML content for FAQ links
+                dangerouslySetInnerHTML={{ __html: message.error }}
+                className="[&_a]:inline-block [&_a]:break-words"
+              />
+            ) : (
+              message.error
+            )}
           </div>
         </div>
       )}
       {"message" in message && (
         <div className="flex-1">
-          <div className="text-sm text-blue-700 whitespace-pre-wrap leading-relaxed">
-            {message.message}
+          <div className="text-sm text-blue-700 whitespace-pre-wrap leading-relaxed space-y-1">
+            {message.html ? (
+              <div
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: Controlled HTML content for FAQ links
+                dangerouslySetInnerHTML={{ __html: message.message }}
+                className="[&_a]:inline-block [&_a]:break-words"
+              />
+            ) : (
+              message.message
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
# 変更の概要
- ユーザーが登録やログインで困った際に、適切な場所にFAQリンクを追加しました。
- 一部スマホ最適化されていないレスポンシブ対応を微修正しました。

# 変更の背景
- 現状、ユーザーが登録やログインで困った際にFAQが明記されていない
- closes #990

# 変更箇所
1. 新規登録完了画面: 登録完了メッセージにFAQリンクを埋め込み
2. ログイン失敗時: エラーメッセージにFAQリンクを埋め込み
3. パスワードリセット完了時: 完了メッセージにFAQリンクを埋め込み
4. フッター: 既存のリンクと統一したスタイルでFAQリンクを追加
5. メッセージエリアの横幅表示の微修正
![FAQリンク追加](https://github.com/user-attachments/assets/8cfee0ef-2c86-4732-a58b-cdd79426be0b)
![メッセージエリアの横幅表示の微修正](https://github.com/user-attachments/assets/4fa3204e-f315-4224-b72e-c3664c646ec5)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * フォームメッセージで型付きメッセージの表示に対応し、メッセージ内容の管理を強化しました。
  * パスワードリセット成功やログインエラーなどのメッセージにFAQページへのリンクを追加しました。
  * フッターに「よくあるご質問」へのリンクを追加しました。

* **スタイル**
  * サインアップ成功画面のコンテナ幅と中央寄せ、パディングを改善しました。
  * メッセージ表示のレイアウトを調整し、横幅制限と中央寄せを強化しました。

* **バグ修正**
  * パスワードリセット画面とサインインフォームのメッセージ表示ロジックを改善し、適切なメッセージが表示されるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->