### PR TITLE
ポスターマップにミッション「選挙区ポスターを貼ろう」への誘導を追加

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -123,13 +123,18 @@ export default function PrefecturePosterMapClient({
   // ポスター貼りミッションのミッションIDを取得
   useEffect(() => {
     const fetchMissionId = async () => {
-      const supabase = createClient();
-      const { data: mission } = await supabase
-        .from("missions")
-        .select("id")
-        .eq("slug", "put-up-poster-on-board")
-        .single();
-      setPutUpPosterMissionId(mission?.id ?? null);
+      try {
+        const supabase = createClient();
+        const { data: mission } = await supabase
+          .from("missions")
+          .select("id")
+          .eq("slug", "put-up-poster-on-boardd")
+          .single();
+        setPutUpPosterMissionId(mission?.id ?? null);
+      } catch (error) {
+        console.error("ミッションIDの取得に失敗しました:", error);
+        setPutUpPosterMissionId(null);
+      }
     };
     fetchMissionId();
   }, []);


### PR DESCRIPTION
# 変更の概要
- ポスターマップに、「ポスターマップ上に掲示板が見当たらない」「ポスターを貼ったがポイントに反映されなかった」などの問題がある場合にミッション「選挙区ポスターを貼ろう」へ誘導する文言を追加

# 変更の背景
- closes #941

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクリーンショット
### 通常の表示
<img width="900" alt="スクリーンショット 2025-07-09 17 07 55" src="https://github.com/user-attachments/assets/b924571b-e608-427e-ad6b-562e12a853c7" />

### ミッションページが見つからなかった場合の表示
<img width="900" alt="スクリーンショット 2025-07-09 17 09 39" src="https://github.com/user-attachments/assets/5f0ee8d1-5cec-4394-8ded-d4af6dd760fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ポスター掲示板の地図ページに、問題報告用の案内セクションを追加しました。該当ミッションページへのリンクが表示され、ミッションIDの取得に失敗した場合は代替案内が表示されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->