### PR TITLE
docs: README の文言修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@
 
    - Hyper-Vの有効化
       1. コントロールパネル > プログラムと機能 > Windowsの機能の有効化または無効化 > Windows ハイパーバイザープラットフォーム > チェックが入っているか確認 (デフォルトでは有効化)
-      1. 入ってない場合、チェックマークをつける。チェックマークをつけてもHyper-vが有効になっていない場合があるので、以下で確認
-      1. PowerShell(管理者権限)でHyper-vが有効になっているか確認 : `bcdedit` > hypervisorlaunchtype を参照 (AutoであればOK)
-      1. Offになっている場合、Hyper-vをAuto(有効)に変更 `bcdedit /set hypervisorlaunchtype auto`
+      1. 入ってない場合、チェックマークをつける。チェックマークをつけてもHyper-Vが有効になっていない場合があるので、以下で確認
+      1. PowerShell(管理者権限)でHyper-Vが有効になっているか確認 : `bcdedit` > hypervisorlaunchtype を参照 (AutoであればOK)
+      1. Offになっている場合、Hyper-VをAuto(有効)に変更 `bcdedit /set hypervisorlaunchtype auto`
       1. Autoに変更したあとPCの再起動が必要です
 
 #### インストール
@@ -111,7 +111,7 @@
    supabase db reset
    ```
 
-  supabase/migrations以下にあるマイグレーションを実行し、supabase/seed.sqlにあるシードデータをローカルデータベースに流し込みみます。
+  supabase/migrations配下にあるマイグレーションを実行し、supabase/seed.sqlにあるシードデータをローカルデータベースに流し込みます。
 
 5. 必要なパッケージをインストール:
 


### PR DESCRIPTION
# 変更の概要
- README 内の文言が気になったので修正しました
  -  Hyper-v → Hyper-V に統一
  - 以下 → 配下 に修正
  - 流し込みみます → 流し込みます に修正

# 変更の背景


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * READMEのWindowsインストール手順で「Hyper-V」の表記を正しい大文字小文字に修正しました。
  * マイグレーションファイルの場所説明について表現を微調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->