### PR TITLE
feat: HubSpotに都道府県情報の連携機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ poster_data/processed-files.json
 /supabase/archive/
 
 temp
+
+# csv export
+users-prefecture-export.csv

--- a/app/(protected)/settings/profile/actions.ts
+++ b/app/(protected)/settings/profile/actions.ts
@@ -285,6 +285,7 @@ export async function updateProfile(
       {
         email: user.email || "",
         firstname: user.email || "", // firstnameにもemailを設定
+        state: validatedData.address_prefecture,
       },
       hubspot_contact_id,
     );

--- a/lib/services/hubspot.ts
+++ b/lib/services/hubspot.ts
@@ -6,6 +6,7 @@
 export interface HubSpotContactData {
   email: string;
   firstname?: string;
+  state?: string;
 }
 
 export interface HubSpotContact {
@@ -13,6 +14,7 @@ export interface HubSpotContact {
   properties: {
     email: string;
     firstname?: string;
+    state?: string;
   };
 }
 
@@ -97,6 +99,10 @@ async function createHubSpotContact(
     firstname: contactData.email, // firstnameにもemailを設定
   };
 
+  if (contactData.state) {
+    properties.state = contactData.state;
+  }
+
   const response = await fetch(url, {
     method: "POST",
     headers: {
@@ -148,6 +154,10 @@ async function updateHubSpotContact(
   const properties: Record<string, string> = {
     firstname: contactData.email, // firstnameにemailを設定
   };
+
+  if (contactData.state) {
+    properties.state = contactData.state;
+  }
 
   const response = await fetch(url, {
     method: "PATCH",
@@ -203,7 +213,7 @@ async function findAndUpdateExistingContact(
           ],
         },
       ],
-      properties: ["email", "firstname"],
+      properties: ["email", "firstname", "state"],
     }),
   });
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "poster:auto-load:log": "./poster_data/auto-load-with-log.sh && npm run poster:mask-names",
     "poster:clear": "./poster_data/clear.sh",
     "poster:mask-names": "tsx poster_data/mask-names.ts",
-    "calculate-badges": "tsx scripts/calculate-badges.ts"
+    "calculate-badges": "tsx scripts/calculate-badges.ts",
+    "export-users-prefecture": "tsx scripts/export-users-prefecture.ts"
   },
   "dependencies": {
     "@geoman-io/leaflet-geoman-free": "^2.18.3",

--- a/scripts/export-users-prefecture.ts
+++ b/scripts/export-users-prefecture.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env tsx
+
+import { createWriteStream } from "node:fs";
+import { join } from "node:path";
+import { createServiceClient } from "@/lib/supabase/server";
+
+interface UserData {
+  id: string;
+  email: string;
+  address_prefecture: string;
+}
+
+async function getAllUsers(): Promise<UserData[]> {
+  const supabase = await createServiceClient();
+  const allUsers: UserData[] = [];
+  let hasMore = true;
+  let offset = 0;
+  const limit = 1000;
+
+  console.log("Supabaseから全ユーザーデータを取得中...");
+
+  // まず全ての認証ユーザーを取得
+  console.log("認証ユーザーを全件取得中...");
+  const allAuthUsers = new Map<string, string>(); // id -> email のマップ
+  let authHasMore = true;
+  let currentAuthPage = 1;
+
+  while (authHasMore) {
+    const { data: authData, error: authError } =
+      await supabase.auth.admin.listUsers({
+        page: currentAuthPage,
+        perPage: 1000,
+      });
+
+    if (authError) {
+      console.error("認証テーブルからのデータ取得エラー:", authError);
+      throw authError;
+    }
+
+    if (authData?.users) {
+      for (const user of authData.users) {
+        if (user.email) {
+          allAuthUsers.set(user.id, user.email);
+        }
+      }
+      console.log(`認証ユーザー取得済み: ${allAuthUsers.size} 件`);
+
+      // 次のページがあるかチェック
+      authHasMore = authData.users.length === 1000;
+      currentAuthPage++;
+    } else {
+      authHasMore = false;
+    }
+  }
+
+  console.log(`認証ユーザー取得完了: ${allAuthUsers.size} 件`);
+
+  // 次にprivate_usersを取得してマッピング
+  while (hasMore) {
+    const { data: privateUsers, error: privateError } = await supabase
+      .from("private_users")
+      .select("id, address_prefecture")
+      .range(offset, offset + limit - 1);
+
+    if (privateError) {
+      console.error(
+        "private_usersテーブルからのデータ取得エラー:",
+        privateError,
+      );
+      throw privateError;
+    }
+
+    if (!privateUsers || privateUsers.length === 0) {
+      hasMore = false;
+      break;
+    }
+
+    // データを結合
+    const usersWithEmail = privateUsers
+      .map((privateUser) => {
+        const email = allAuthUsers.get(privateUser.id);
+        return {
+          id: privateUser.id,
+          email: email || "",
+          address_prefecture: privateUser.address_prefecture,
+        };
+      })
+      .filter((user) => user.email); // メールアドレスがあるユーザーのみ
+
+    allUsers.push(...usersWithEmail);
+
+    console.log(`取得済み: ${allUsers.length} 件`);
+
+    // 次のページへ
+    offset += limit;
+    hasMore = privateUsers.length === limit;
+  }
+
+  console.log(`全ユーザーデータ取得完了: ${allUsers.length} 件`);
+  return allUsers;
+}
+
+function escapeCSV(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function exportToCSV(users: UserData[]): string {
+  const outputPath = join(process.cwd(), "users-prefecture-export.csv");
+  const writeStream = createWriteStream(outputPath);
+
+  console.log("CSV出力開始...");
+
+  // CSVヘッダー
+  const headers = ["user_id", "email", "address_prefecture"];
+  writeStream.write(`${headers.join(",")}\n`);
+
+  // データ出力
+  for (const user of users) {
+    const row = [
+      escapeCSV(user.id),
+      escapeCSV(user.email),
+      escapeCSV(user.address_prefecture),
+    ];
+    writeStream.write(`${row.join(",")}\n`);
+  }
+
+  writeStream.end();
+  console.log(`CSV出力完了: ${outputPath}`);
+  return outputPath;
+}
+
+async function main() {
+  try {
+    console.log("=== HubSpot都道府県情報エクスポート開始 ===");
+
+    // 環境変数の確認
+    const requiredEnvVars = [
+      "NEXT_PUBLIC_SUPABASE_URL",
+      "SUPABASE_SERVICE_ROLE_KEY",
+    ];
+
+    for (const envVar of requiredEnvVars) {
+      if (!process.env[envVar]) {
+        console.error(`必要な環境変数が設定されていません: ${envVar}`);
+        process.exit(1);
+      }
+    }
+
+    // 全ユーザーデータを取得
+    const users = await getAllUsers();
+
+    // CSVに出力
+    const outputPath = exportToCSV(users);
+
+    console.log("=== エクスポート完了 ===");
+    console.log(`出力ファイル: ${outputPath}`);
+    console.log(`処理件数: ${users.length} 件`);
+
+    // 都道府県別の統計表示
+    const prefectureStats = users.reduce(
+      (acc, user) => {
+        acc[user.address_prefecture] = (acc[user.address_prefecture] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    console.log("\n=== 都道府県別統計 ===");
+    for (const [prefecture, count] of Object.entries(prefectureStats).sort(
+      ([, a], [, b]) => b - a,
+    )) {
+      console.log(`${prefecture}: ${count} 件`);
+    }
+  } catch (error) {
+    console.error("エラーが発生しました:", error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
# 変更の概要
- HubSpotContactDataインターフェースにstateフィールドを追加
- HubSpot作成・更新・検索処理で都道府県情報をサポート
- プロフィール更新時にHubSpotに都道府県情報を送信
- ユーザー都道府県情報をCSV出力するスクリプトを追加（ページネーション対応）
  - 実際にローカルに2000件のテストデータを書き込み、全件出力されることを確認

# 変更の背景
- HubSpotに都道府県情報を同期する必要があった
- 既存ユーザーの都道府県情報をCSV形式で出力してHubSpotに取り込む必要があった
- closes #1060

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Supabaseからユーザーの都道府県情報を含むCSVファイルをエクスポートする新しいスクリプトを追加しました。
  * エクスポート後、都道府県ごとのユーザー数を集計して表示します。

* **改善**
  * HubSpot連携時にユーザーの都道府県情報を追加で送信するようになりました。

* **その他**
  * エクスポート用CSVファイルがバージョン管理から除外されるようになりました。
  * 新しいエクスポートスクリプト用のnpmスクリプトを追加しました。

https://github.com/user-attachments/assets/7ad4bb02-6b0c-42a6-b500-5bd304160c7b


<!-- end of auto-generated comment: release notes by coderabbit.ai -->