### PR TITLE
feat: 特定のナビアプリをワンボタンで起動(#1014)

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -10,6 +10,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -40,7 +46,7 @@ import {
   calculateProgressRate,
   getCompletedCount,
 } from "@/lib/utils/poster-progress";
-import { ArrowLeft, HelpCircle, History } from "lucide-react";
+import { ArrowLeft, Copy, HelpCircle, History, MapPin } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -146,6 +152,16 @@ export default function PrefecturePosterMapClient({
       }
     }
   }, [userId, boards, prefecture]);
+
+  // 住所をクリップボードにコピー
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success("住所をコピーしました");
+    } catch (error) {
+      toast.error("コピーに失敗しました");
+    }
+  };
 
   const loadBoards = async () => {
     try {
@@ -456,17 +472,94 @@ export default function PrefecturePosterMapClient({
           <DialogHeader>
             <DialogTitle>ポスターの状況を報告</DialogTitle>
             <DialogDescription>
-              {selectedBoard?.name ||
-                selectedBoard?.address ||
-                selectedBoard?.number}
-              の状況を教えてください
+              <div className="flex items-center gap-2">
+                <span>
+                  {selectedBoard?.name ||
+                    selectedBoard?.address ||
+                    selectedBoard?.number}
+                  の状況を教えてください
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  onClick={() => {
+                    const text =
+                      selectedBoard?.name ||
+                      selectedBoard?.address ||
+                      selectedBoard?.number;
+                    if (text) copyToClipboard(text);
+                  }}
+                  title="名前/住所をコピー"
+                >
+                  <Copy className="h-3 w-3" />
+                </Button>
+              </div>
             </DialogDescription>
           </DialogHeader>
           {selectedBoard && (
             <div className="mb-4 text-sm text-muted-foreground">
-              <div>
-                {selectedBoard.city} {selectedBoard.address} (
-                {selectedBoard.number})
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span>
+                    {selectedBoard.city} {selectedBoard.address} (
+                    {selectedBoard.number})
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0"
+                    onClick={() => {
+                      const address = `${selectedBoard.city} ${selectedBoard.address}`;
+                      copyToClipboard(address);
+                    }}
+                    title="住所をコピー"
+                  >
+                    <Copy className="h-3 w-3" />
+                  </Button>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" className="h-8 px-2">
+                      <MapPin className="h-4 w-4 mr-1" />
+                      地図で開く
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem asChild>
+                      <a
+                        href={
+                          selectedBoard.lat && selectedBoard.long
+                            ? `https://www.google.com/maps?q=${selectedBoard.lat},${selectedBoard.long}`
+                            : `https://www.google.com/maps/search/${encodeURIComponent(
+                                `${selectedBoard.city}${selectedBoard.address}`,
+                              )}`
+                        }
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center w-full"
+                      >
+                        Google Maps
+                      </a>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <a
+                        href={
+                          selectedBoard.lat && selectedBoard.long
+                            ? `maps://maps.apple.com/?q=${selectedBoard.lat},${selectedBoard.long}`
+                            : `maps://maps.apple.com/?q=${encodeURIComponent(
+                                `${selectedBoard.city}${selectedBoard.address}`,
+                              )}`
+                        }
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center w-full"
+                      >
+                        Apple Maps
+                      </a>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </div>
             </div>
           )}


### PR DESCRIPTION
# 変更の概要
- Google MapsとApple Mapsへのリンクをドロップダウンメニューに追加
- 住所のコピーボタンを追加

# 変更の背景
- ポスター貼り作業中に、目的地までの経路を簡単に確認したい
- 現在のUIでは住所のコピーが困難で、作業効率が低下している
- closes #1014 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ポスターのステータス更新ダイアログに、住所やボード名などをワンクリックでコピーできるボタンを追加しました。
  * 住所の横に「地図で開く」ドロップダウンメニューを追加し、GoogleマップおよびAppleマップで簡単に位置を表示できるようになりました。
  * コピーやマップリンクの操作時にトースト通知が表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="443" alt="スクリーンショット 2025-07-10 6 14 14" src="https://github.com/user-attachments/assets/d11c9081-a110-4cfa-9265-2ccbba07f72e" />
<img width="432" alt="スクリーンショット 2025-07-10 6 14 08" src="https://github.com/user-attachments/assets/617bb507-a402-458c-97d1-0de4484d1f0a" />
<img width="436" alt="スクリーンショット 2025-07-10 6 14 03" src="https://github.com/user-attachments/assets/eff6adf1-77b8-4de8-8bf7-b9944dcf9820" />
<img width="509" alt="スクリーンショット 2025-07-10 6 13 36" src="https://github.com/user-attachments/assets/e46ed352-3892-4306-937b-ad3a4d259b08" />
<img width="518" alt="スクリーンショット 2025-07-10 6 13 29" src="https://github.com/user-attachments/assets/598398d3-d0f3-41a2-8461-afaf0f4b120e" />
<img width="520" alt="スクリーンショット 2025-07-10 6 13 23" src="https://github.com/user-attachments/assets/40a0f444-b005-4e91-9a9d-93e475cad327" />
