### PR TITLE
feat: ポスターマップ不具合報告Formに"1-1-1"(丁目-番地-号)を入力できるようにする

### DIFF
--- a/components/mission/PosterForm.test.tsx
+++ b/components/mission/PosterForm.test.tsx
@@ -123,7 +123,7 @@ describe("PosterForm", () => {
     expect(boardNumberInput).toHaveAttribute("type", "text");
     expect(boardNumberInput).toHaveAttribute("name", "boardNumber");
     expect(boardNumberInput).toHaveAttribute("maxLength", "20");
-    expect(boardNumberInput).toHaveAttribute("pattern", "^(\\d+|\\d+-\\d+)$");
+    expect(boardNumberInput).toHaveAttribute("pattern", "^(\\d+(-\\d){0,2})$");
     expect(boardNumberInput).toBeRequired();
   });
 
@@ -203,7 +203,7 @@ describe("PosterForm", () => {
       screen.getByPlaceholderText("例：渋谷区、名古屋市中区"),
     ).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText("例：10-1、27-2、00"),
+      screen.getByPlaceholderText("例：10-1、27-2-1、00"),
     ).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("例：東小学校前、駅前商店街"),

--- a/components/mission/PosterForm.tsx
+++ b/components/mission/PosterForm.tsx
@@ -102,11 +102,11 @@ export function PosterForm({ disabled }: PosterFormProps) {
           required
           maxLength={20}
           disabled={disabled}
-          placeholder="例：10-1、27-2、00"
-          pattern="^(\d+|\d+-\d+)$"
+          placeholder="例：10-1、27-2-1、00"
+          pattern="^(\d+(-\d){0,2})$"
         />
         <p className="text-xs text-gray-500">
-          番号を入力してください（例：10-1、27-2、00）
+          番号を入力してください（例：10-1、27-2-1、00）
         </p>
       </div>
 


### PR DESCRIPTION
# 変更の概要
- ポスターマップ不具合報告Formに"1-1-1"(丁目-番地-号)を入力できるようにする。

# 変更の背景
- Validationの正規表現がハイフン0-1個の"1", "1-1"のみ通るようになっていた。
- closes #1020

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました