### PR TITLE
ナビゲーションメニューにチームみらい公式リンクを追加 (#1102)

### DIFF
--- a/components/header-auth.tsx
+++ b/components/header-auth.tsx
@@ -44,6 +44,9 @@ export default async function AuthButton() {
             <DropdownMenuItem asChild>
               <Link href="/map/poster">ポスター掲示板マップ</Link>
             </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="https://team-mir.ai/">チームみらい公式</Link>
+            </DropdownMenuItem>
             {/*
             <DropdownMenuItem asChild>
               <Link href="/missions">ミッション</Link>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -65,6 +65,9 @@ export default async function Navbar() {
                     <DropdownMenuItem asChild>
                       <Link href="/map/poster">ポスター掲示板マップ</Link>
                     </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link href="https://team-mir.ai/">チームみらい公式</Link>
+                    </DropdownMenuItem>
                   </DropdownMenuGroup>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>


### PR DESCRIPTION
# 変更の概要
- ナビゲーションメニューにチームみらい公式ページのリンクを追加します。
<img width="465" height="387" alt="Screenshot 2025-07-10 at 22 40 08" src="https://github.com/user-attachments/assets/c281d550-886e-49e6-a138-b50e6d09d87b" />

# 変更の背景
- チームみらいを知らない人がホームページやマニフェストを見ずにアクションボードに入ってきたとき、チームみらいの公式ページをすぐ見つけられるようにするためにした方が優しいのではないかというIssueがあったため。
- closes #1102 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました