### PR TITLE
SNS投稿系ミッションに推奨ハッシュタグを補足する

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -78,7 +78,7 @@ missions:
   - slug: share-manifest-sns
     title: マニフェストの感想をSNSでシェアしよう
     icon_url: /img/mission_fallback.svg
-    content: <a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>の内容を確認し、気になった政策や共感した提案について、あなたの言葉でSNSに感想を発信してみよう。難しく考えなくてOK。「ここがいいな」「もっとこうしてほしい」など、素直な声が広がることで、政治はもっと身近になります。<br><a href="javascript:void(0)" onclick="navigator.clipboard.writeText('#チームみらい &#x0023みらいを選ぼう');alert('ハッシュタグをコピーしました')">公式ハッシュタグ &#x0023チームみらい &#x0023みらいを選ぼう をコピーする</a>
+    content: <a href="https://policy.team-mir.ai/view/README.md" target="_blank" rel="noopener noreferrer">チームみらいマニフェスト</a>の内容を確認し、気になった政策や共感した提案について、あなたの言葉でSNSに感想を発信してみよう。難しく考えなくてOK。「ここがいいな」「もっとこうしてほしい」など、素直な声が広がることで、政治はもっと身近になります。<br><br><a href="javascript:void(0)" onclick="navigator.clipboard.writeText('#チームみらい &#x0023みらいを選ぼう');alert('ハッシュタグをコピーしました')">公式ハッシュタグ &#x0023チームみらい &#x0023みらいを選ぼう をコピーする</a>
     difficulty: 2
     required_artifact_type: LINK
     max_achievement_count: null
@@ -92,7 +92,7 @@ missions:
     content: |-
       ショート動画を投稿して、チームみらいの魅力をもっと多くの人に届けよう。
       SNSでの拡散や、仲間との共有も大歓迎！あなたの編集が、新しい支持を生み出すかもしれません。
-      <a href="https://team-mirai.notion.site/206f6f56bae180d7b7e9e5afff07e2b3" target="_blank" rel="noopener noreferrer">動画切り抜きガイド</a><br><a href="javascript:void(0)" onclick="navigator.clipboard.writeText('&#x0023安野たかひろ &#x0023チームみらい');alert('ハッシュタグをコピーしました')">公式ハッシュタグ &#x0023安野たかひろ &#x0023チームみらい をコピーする</a>
+      <a href="https://team-mirai.notion.site/206f6f56bae180d7b7e9e5afff07e2b3" target="_blank" rel="noopener noreferrer">動画切り抜きガイド</a><br><br><a href="javascript:void(0)" onclick="navigator.clipboard.writeText('&#x0023安野たかひろ &#x0023チームみらい');alert('ハッシュタグをコピーしました')">公式ハッシュタグ &#x0023安野たかひろ &#x0023チームみらい をコピーする</a>
     difficulty: 4
     required_artifact_type: LINK
     max_achievement_count: null
@@ -170,7 +170,7 @@ missions:
   - slug: threads-post
     title: Threads でチームみらいに関する投稿をしよう
     icon_url: /img/mission_fallback.svg
-    content: チームみらいの活動について、あなたの声をThreadsで発信してみよう！イベント参加の感想やチームみらいへの思い、何でも投稿してください。たとえば『共感した』だけでもうれしいです。政治をもっと身近に感じる第一歩を踏み出そう！<br><a href="javascript:void(0)" onclick="navigator.clipboard.writeText('#チームみらい &#x0023みらいを選ぼう');alert('ハッシュタグをコピーしました')">公式ハッシュタグ &#x0023チームみらい &#x0023みらいを選ぼう をコピーする</a>
+    content: チームみらいの活動について、あなたの声をThreadsで発信してみよう！イベント参加の感想やチームみらいへの思い、何でも投稿してください。たとえば『共感した』だけでもうれしいです。政治をもっと身近に感じる第一歩を踏み出そう！<br><br><a href="javascript:void(0)" onclick="navigator.clipboard.writeText('#チームみらい &#x0023みらいを選ぼう');alert('ハッシュタグをコピーしました')">公式ハッシュタグ &#x0023チームみらい &#x0023みらいを選ぼう をコピーする</a>
     difficulty: 2
     required_artifact_type: LINK
     max_achievement_count: null
@@ -312,7 +312,7 @@ missions:
   - slug: x-post
     title: Xでチームみらいに関する投稿をしよう
     icon_url: /img/mission_fallback.svg
-    content: チームみらいの活動について、あなたの声をXで発信してみよう！イベント参加の感想やチームみらいへの思い、何でも投稿してください。たとえば『共感した』だけでもうれしいです。政治をもっと身近に感じる第一歩を踏み出そう！<br><a href="javascript:void(0)" onclick="navigator.clipboard.writeText('#チームみらい &#x0023みらいを選ぼう');alert('ハッシュタグをコピーしました')">公式ハッシュタグ &#x0023チームみらい &#x0023みらいを選ぼう をコピーする</a>
+    content: チームみらいの活動について、あなたの声をXで発信してみよう！イベント参加の感想やチームみらいへの思い、何でも投稿してください。たとえば『共感した』だけでもうれしいです。政治をもっと身近に感じる第一歩を踏み出そう！<br><br><a href="javascript:void(0)" onclick="navigator.clipboard.writeText('#チームみらい &#x0023みらいを選ぼう');alert('ハッシュタグをコピーしました')">公式ハッシュタグ &#x0023チームみらい &#x0023みらいを選ぼう をコピーする</a>
     difficulty: 2
     required_artifact_type: LINK
     max_achievement_count: null


### PR DESCRIPTION
# 変更の概要

## 追加するハッシュタグ

Youtubeの投稿には勢いのある#安野たかひろ #チームみらい、その他のSNS投稿には公式の基本セット#チームみらい　#みらいを選ぼう、を例示する。

> 現在、YouTube単体だけでも #安野たかひろ あるいは #チームみらいとハッシュタグがついた動画は累計600万再生を超えています

https://team-mirai-volunteer.slack.com/archives/C08R104BR5L/p1752109261397569

>・ハッシュタグの基本セットは、#チームみらい　#みらいを選ぼう　の2つとする。Xの場合は、2つまでが良いらしい。インスタやTikTokでは、他も追加して5個程度でも可。

https://team-mirai-volunteer.slack.com/archives/C08R104BR5L/p1751986914417319

## 画面

投稿ミッションの最後にハッシュタグをコピーするためのリンクを追加する：

#チームみらい #みらいを選ぼう
<img width="527" height="340" alt="image" src="https://github.com/user-attachments/assets/01981651-448e-4e1d-9028-3b0a57f2aa71" />
#チームみらい #みらいを選ぼう
<img width="534" height="338" alt="image" src="https://github.com/user-attachments/assets/fab7a6f6-5e83-4c61-bf53-463b16bc9c88" />
#安野たかひろ #チームみらい
<img width="526" height="368" alt="image" src="https://github.com/user-attachments/assets/2af821e8-9995-48e2-9328-a4e6f047bc5f" />
#チームみらい #みらいを選ぼう
<img width="529" height="367" alt="image" src="https://github.com/user-attachments/assets/baf17fee-db06-4170-b583-fd7d83706fb5" />

クリックするとポップアップが出ます：

<img width="464" height="157" alt="image" src="https://github.com/user-attachments/assets/c485f90b-7250-44c4-b918-0c21f3be0f1c" />


リポストのミッションは例示なので文章中に含める：

<img width="530" height="316" alt="image" src="https://github.com/user-attachments/assets/988335ba-0cb8-4353-ab24-d5a2d17e9059" />


# 変更の背景
- ポストのひな形や、使用すると良いハッシュタグなどをまとめたものがほしいという要望があったため。
- 似た投稿が多数投稿されることでヤラセ感が出る恐れがあるため、ひな形は提供しない。
- closes #1075

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * SNS関連のミッションに新しいハッシュタグ（#みらいを選ぼう、#安野たかひろ など）が追加され、投稿時のタグ付けが統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->