### PR TITLE
FAQリンクのリファクタリング(#1086)

### DIFF
--- a/components/footer/CopyrightSection.tsx
+++ b/components/footer/CopyrightSection.tsx
@@ -1,3 +1,4 @@
+import { EXTERNAL_LINKS } from "@/lib/constants";
 import Link from "next/link";
 import { FOOTER_CONFIG } from "./footer";
 
@@ -40,7 +41,7 @@ export function CopyrightSection() {
             </Link>
             <span>|</span>
             <Link
-              href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f"
+              href={EXTERNAL_LINKS.FAQ}
               className="hover:text-teal-700 transition-colors duration-200 text-teal-600"
               target="_blank"
               rel="noopener noreferrer"

--- a/components/form-message.tsx
+++ b/components/form-message.tsx
@@ -1,3 +1,4 @@
+import { EXTERNAL_LINKS } from "@/lib/constants";
 import clsx from "clsx";
 import { CheckCircle, Info, XCircle } from "lucide-react";
 
@@ -18,7 +19,7 @@ export type Message =
 const getMessageContent = (type: MessageType) => {
   const faqLink = (
     <a
-      href="https://team-mirai.notion.site/228f6f56bae18037957dd5f108d00e2f"
+      href={EXTERNAL_LINKS.FAQ}
       target="_blank"
       rel="noopener noreferrer"
       className="text-teal-600 hover:text-teal-700 underline"

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -20,3 +20,9 @@ export const MAX_POSTER_COUNT = 1;
 
 // ポスターマップの最大ズーム値
 export const MAX_ZOOM = 18;
+
+// 外部リンクURL
+export const EXTERNAL_LINKS = {
+  // よくあるご質問(FAQ)
+  FAQ: "https://www.notion.so/team-mirai/228f6f56bae18037957dd5f108d00e2f",
+} as const;


### PR DESCRIPTION
# 変更の概要
- PR #1049 で追加されたFAQリンクのURLがハードコードされていたため、保守性向上のために定数化しました。

# 変更の背景
- #1049 の残指摘の対応
- closes #1086

# 変更内容
- lib/constants.ts: `EXTERNAL_LINKS.FAQ` 定数を追加してFAQのURLを一元管理
- components/form-message.tsx: ハードコードされたFAQのURLを `EXTERNAL_LINKS.FAQ` に置き換え
- components/footer/CopyrightSection.tsx: ハードコードされたFAQのURLを `EXTERNAL_LINKS.FAQ` に置き換え

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * FAQリンクのURLをハードコーディングから定数参照に変更し、管理性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->