### PR TITLE
fix: デイリーランキングバッジ計算の日付取得処理を共通関数に置き換え(#1097)

### DIFF
--- a/lib/services/badgeCalculation.ts
+++ b/lib/services/badgeCalculation.ts
@@ -1,6 +1,7 @@
 "server-only";
 
 import { PREFECTURES } from "@/lib/address";
+import { getJSTMidnightToday } from "@/lib/dateUtils";
 import { createServiceClient } from "@/lib/supabase/server";
 import { updateBadge } from "./badges";
 
@@ -62,15 +63,7 @@ export async function calculateDailyRankingBadges(): Promise<{
 
   try {
     // 日本時間（JST）で前日の0時と当日の0時を取得
-    const now = new Date();
-
-    // 日本時間の今日の0時を取得（UTC 15:00 = JST 00:00）
-    const todayJST = new Date(now);
-    todayJST.setUTCHours(15, 0, 0, 0);
-    if (todayJST > now) {
-      // まだ日本時間の0時になっていない場合は前日にする
-      todayJST.setUTCDate(todayJST.getUTCDate() - 1);
-    }
+    const todayJST = getJSTMidnightToday();
 
     // 日本時間の昨日の0時を取得
     const yesterdayJST = new Date(todayJST);


### PR DESCRIPTION
# 変更の概要
- バッジ計算・更新処理（全体・デイリー・都道府県・ミッション別）の日付取得処理は、#1091 の対応によって`lib/dateUtils.ts`に共通関数として切り出されていて修正もされているため、そちらを参照するよう修正しました。

# 変更の背景
- 概要を参照
- closes #1097

# 変更点
- lib/dateUtils.ts の getJSTMidnightToday() を参照するように修正
- 重複処理の削除

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# 備考
このイシューは下記の全体方針に基づく分割タスクの一部です
#1089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 日付計算のロジックを簡素化し、より分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->