### PR TITLE
重要ミッションの並び順を指定

### DIFF
--- a/components/mission/missions.tsx
+++ b/components/mission/missions.tsx
@@ -61,15 +61,17 @@ export default async function Missions({
     ]),
   );
 
-  let query = supabase
-    .from("missions")
-    .select()
-    .eq("is_hidden", false) // 非表示のミッションを除外
-    .order("difficulty", { ascending: true })
-    .order("created_at", { ascending: false });
+  let query = supabase.from("missions").select().eq("is_hidden", false); // 非表示のミッションを除外
   if (filterFeatured) {
-    query = query.eq("is_featured", true);
+    query = query
+      .eq("is_featured", true)
+      // 重要度降順に並べる
+      .order("featured_importance", { ascending: false, nullsFirst: false });
   }
+  // 重要度が null のミッションを難易度降順→作成日降順に並べる
+  query = query
+    .order("difficulty", { ascending: false })
+    .order("created_at", { ascending: false });
 
   if (!showAchievedMissions) {
     query = query.not("id", "in", `("${achievedMissionIds.join('","')}")`);

--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -97,6 +97,7 @@ missions:
     required_artifact_type: LINK
     max_achievement_count: null
     is_featured: true
+    featured_importance: 80
     is_hidden: false
     artifact_label: ショート動画のURL（Youtube, TikTokなど）
     ogp_image_url: null
@@ -207,6 +208,7 @@ missions:
     required_artifact_type: REFERRAL
     max_achievement_count: null
     is_featured: true
+    featured_importance: 60
     is_hidden: false
     artifact_label: null
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//12_referral.png
@@ -239,7 +241,7 @@ missions:
     difficulty: 2
     required_artifact_type: TEXT
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     is_hidden: false
     artifact_label: 参加した街頭演説の場所と日付
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//17_street_speech.png
@@ -327,7 +329,7 @@ missions:
     difficulty: 4
     required_artifact_type: TEXT
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     is_hidden: false
     artifact_label: 参加した街頭演説の場所と日付
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//13_event_support.png
@@ -394,6 +396,7 @@ missions:
     required_artifact_type: POSTER
     max_achievement_count: null
     is_featured: true
+    featured_importance: 90
     is_hidden: false
     ogp_image_url: null
   - slug: put-up-proportional-representation-poster
@@ -563,6 +566,7 @@ missions:
     required_artifact_type: NONE
     max_achievement_count: 1
     is_featured: true
+    featured_importance: 100
     is_hidden: false
     artifact_label: null
     ogp_image_url: null

--- a/mission_data/src/sync.ts
+++ b/mission_data/src/sync.ts
@@ -107,6 +107,7 @@ async function syncMissions(missions: Mission[], dryRun: boolean) {
         required_artifact_type: mission.required_artifact_type,
         max_achievement_count: mission.max_achievement_count,
         is_featured: mission.is_featured,
+        featured_importance: mission.featured_importance,
         is_hidden: mission.is_hidden,
         artifact_label: mission.artifact_label,
         ogp_image_url: mission.ogp_image_url,

--- a/mission_data/src/types.ts
+++ b/mission_data/src/types.ts
@@ -14,6 +14,7 @@ export interface Mission {
   required_artifact_type: string;
   max_achievement_count: number | null;
   is_featured: boolean;
+  featured_importance?: number | null;
   is_hidden: boolean;
   artifact_label?: string | null;
   ogp_image_url?: string | null;

--- a/supabase/migrations/20250711021743_add-featured-importance-to-missions.sql
+++ b/supabase/migrations/20250711021743_add-featured-importance-to-missions.sql
@@ -1,0 +1,2 @@
+ALTER TABLE missions ADD COLUMN featured_importance INTEGER;
+COMMENT ON COLUMN missions.featured_importance IS '重要ミッション用の重要度（表示順に用いる）';


### PR DESCRIPTION
# 変更の概要
- missions テーブルに重要ミッション用の重要度（featured_importance）を追加
- 重要ミッションは 重要度降順→難易度降順→作成日降順 で並び替えるように
- 街頭演説系を重要ミッションから外しました

# 変更の背景
- closes #1055

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクリーンショット
<img width="900" height="888" alt="スクリーンショット 2025-07-11 12 25 50" src="https://github.com/user-attachments/assets/f9436a61-7bd6-4031-989c-811eec40a1d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ミッションに「featured_importance（重要度）」属性を追加し、注目ミッションの表示順を調整できるようになりました。

* **改善**
  * ミッション一覧の並び順が難易度降順・作成日降順となり、注目ミッションの場合は重要度順も反映されます。

* **データ更新**
  * 一部ミッションの注目設定や重要度の値を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->