### PR TITLE
fix: 生年月日が必要な理由の説明文を修正

### DIFF
--- a/app/(protected)/settings/profile/ProfileForm.tsx
+++ b/app/(protected)/settings/profile/ProfileForm.tsx
@@ -276,7 +276,7 @@ export default function ProfileForm({
             <Label htmlFor="date_of_birth">生年月日</Label>
             <p className="text-sm text-gray-500">この項目は公開されません</p>
             {/* 生年月日が必要な理由の説明エリア（折りたたみ可能） */}
-            <CollapsibleInfo title="生年月日が必要な理由" variant="gray">
+            <CollapsibleInfo title="なぜ生年月日が必要ですか？" variant="gray">
               <p>
                 法律により、サポーター登録は満18歳以上の方に限定されているため、年齢確認が必要です。
               </p>


### PR DESCRIPTION
# 変更の概要
- プロフィール登録ページで、生年月日が必要な理由の説明文を修正しました。

# 変更の背景
- 自分が対応した #939 で、追加修正の際に意図しないtypoをしてしまいました。クリティカルじゃないものの、郵便番号の説明文と揃いたいのと、自分のミスが気持ち悪いので😇修正させてください。
![PR用](https://github.com/user-attachments/assets/f84f287f-26c7-4cb4-aef5-b6521f85f07f)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました