### PR TITLE
fix: ランキング機能のJST対応 (#1048, #1094, #1095, #1096)

### DIFF
--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -5,6 +5,7 @@ import {
   type RankingPeriod,
 } from "@/components/ranking/period-toggle";
 import { RankingTabs } from "@/components/ranking/ranking-tabs";
+import { getJSTMidnightToday } from "@/lib/dateUtils";
 import { createClient } from "@/lib/supabase/server";
 
 interface PageProps {
@@ -36,18 +37,10 @@ export default async function RankingPage({ searchParams }: PageProps) {
       userRanking = data;
     } else {
       // 期間別の場合は関数を使用
-      const now = new Date();
       let dateFilter: Date | null = null;
       if (period === "daily") {
-        // 本日の0時0分を基準にする
-        dateFilter = new Date(
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDate(),
-          0,
-          0,
-          0,
-        );
+        // 日本時間の今日の0時0分を基準にする
+        dateFilter = getJSTMidnightToday();
       }
 
       const { data } = await supabase.rpc("get_user_period_ranking", {

--- a/lib/services/missionsRanking.ts
+++ b/lib/services/missionsRanking.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { RankingPeriod } from "@/components/ranking/period-toggle";
+import { getJSTMidnightToday } from "@/lib/dateUtils";
 import { createClient } from "@/lib/supabase/server";
 import type { UserRanking } from "./ranking";
 
@@ -19,19 +20,11 @@ export async function getMissionRanking(
 
     // 期間に応じた日付フィルタを設定
     let dateFilter: Date | null = null;
-    const now = new Date();
 
     switch (period) {
       case "daily":
-        // 本日の0時0分を基準にする
-        dateFilter = new Date(
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDate(),
-          0,
-          0,
-          0,
-        );
+        // 日本時間の今日の0時0分を基準にする
+        dateFilter = getJSTMidnightToday();
         break;
       default:
         dateFilter = null;
@@ -111,19 +104,11 @@ export async function getUserMissionRanking(
 
     // 期間に応じた日付フィルタを設定
     let dateFilter: Date | null = null;
-    const now = new Date();
 
     switch (period) {
       case "daily":
-        // 本日の0時0分を基準にする
-        dateFilter = new Date(
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDate(),
-          0,
-          0,
-          0,
-        );
+        // 日本時間の今日の0時0分を基準にする
+        dateFilter = getJSTMidnightToday();
         break;
       default:
         dateFilter = null;

--- a/lib/services/prefecturesRanking.ts
+++ b/lib/services/prefecturesRanking.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { RankingPeriod } from "@/components/ranking/period-toggle";
+import { getJSTMidnightToday } from "@/lib/dateUtils";
 import { createClient } from "@/lib/supabase/server";
 import type { UserRanking } from "./ranking";
 
@@ -14,19 +15,11 @@ export async function getPrefecturesRanking(
 
     // 期間に応じた日付フィルタを設定
     let dateFilter: Date | null = null;
-    const now = new Date();
 
     switch (period) {
       case "daily":
-        // 本日の0時0分を基準にする
-        dateFilter = new Date(
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDate(),
-          0,
-          0,
-          0,
-        );
+        // 日本時間の今日の0時0分を基準にする
+        dateFilter = getJSTMidnightToday();
         break;
       default:
         dateFilter = null;
@@ -104,19 +97,11 @@ export async function getUserPrefecturesRanking(
 
     // 期間に応じた日付フィルタを設定
     let dateFilter: Date | null = null;
-    const now = new Date();
 
     switch (period) {
       case "daily":
-        // 本日の0時0分を基準にする
-        dateFilter = new Date(
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDate(),
-          0,
-          0,
-          0,
-        );
+        // 日本時間の今日の0時0分を基準にする
+        dateFilter = getJSTMidnightToday();
         break;
       default:
         dateFilter = null;

--- a/lib/services/ranking.ts
+++ b/lib/services/ranking.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { RankingPeriod } from "@/components/ranking/period-toggle";
+import { getJSTMidnightToday } from "@/lib/dateUtils";
 import { createClient } from "@/lib/supabase/server";
 
 export interface UserRanking {
@@ -22,19 +23,11 @@ export async function getRanking(
 
     // 期間に応じた日付フィルタを設定
     let dateFilter: Date | null = null;
-    const now = new Date();
 
     switch (period) {
       case "daily":
-        // 本日の0時0分を基準にする
-        dateFilter = new Date(
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDate(),
-          0,
-          0,
-          0,
-        );
+        // 日本時間の今日の0時0分を基準にする
+        dateFilter = getJSTMidnightToday();
         break;
       default:
         dateFilter = null;


### PR DESCRIPTION
# 変更の概要
- ランキング機能（全体・ミッション別・都道府県別）の日付取得処理にて、JST（日本標準時）対応を行いました
- lib/dateUtils.tsのgetJSTMidnightToday()共通関数を使用して、重複処理を削除しました

# 変更の背景
- デイリーランキングの取得時刻がUTC基準となっており、日本時間の0時ではなく9時にリセットされる問題がありました
- 既に #1089 の対応によって`lib/dateUtils.ts`に共通関数として切り出されていて修正もされているため、そちらを参照するよう修正しました
- closes #1048
- closes #1094 
- closes #1095
- closes #1096

# 変更点
## 修正ファイル
- `app/ranking/page.tsx`: 全体ランキングページの日付計算をJST対応
- `lib/services/ranking.ts`: デイリーランキングサービスの日付計算をJST対応
- `lib/services/missionsRanking.ts`: ミッション別ランキングサービスの日付計算をJST対応（2箇所）
- `lib/services/prefecturesRanking.ts`: 都道府県別ランキングサービスの日付計算をJST対応（2箇所）

## 具体的な変更内容
- UTC基準の日付計算処理を削除
- lib/dateUtils.tsのgetJSTMidnightToday()を参照するように修正
- 重複していた日付計算ロジックを共通化

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# 備考
これらのイシューは下記の全体方針に基づく分割タスクです
#1089