### PR TITLE
ポスターマップCSVの個人名マスク処理改善 #1139

### DIFF
--- a/poster_data/mask-names.ts
+++ b/poster_data/mask-names.ts
@@ -24,14 +24,15 @@ function maskNamesInCsv(filePath: string): void {
     return;
   }
 
-  // Mask names containing '様' or '宅'
+  // Mask names containing personal name
   let modified = false;
   for (const record of records) {
-    if (
-      record.name &&
-      (record.name.includes("様") || record.name.includes("宅"))
-    ) {
+    if (record.name && hasPersonalName(record.name)) {
       record.name = "masked";
+      modified = true;
+    }
+    if (record.address && hasPersonalName(record.address)) {
+      record.address = "masked";
       modified = true;
     }
   }
@@ -47,6 +48,16 @@ function maskNamesInCsv(filePath: string): void {
   } else {
     console.log(`No names to mask in: ${filePath}`);
   }
+}
+
+function hasPersonalName(str: string): boolean {
+  if (str.includes("様")) {
+    return true;
+  }
+  if (str.includes("宅") && !str.includes("住宅")) {
+    return true;
+  }
+  return false;
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
# 変更の概要
- ポスターマップのcsvのname列に個人名が含まれる場合にマスク（maskedに置換）しているが、
  - xxx住宅の場合はマスクしないようにする。
  - 住所にも個人名が含まれる場合があるのでマスクする。

# 変更の背景
- #1139

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 個人名が含まれる場合、氏名だけでなく住所もマスキングされるようになりました。

* **リファクタ**
  * 個人名の判定ロジックが整理され、より一貫性のある処理となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->