### PR TITLE
fix: Slack参加ミッションのリンク先をNotionページに変更 (#1137)

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -226,7 +226,7 @@ missions:
   - slug: join-slack
     title: サポーターSlackに入ろう
     icon_url: /img/mission_fallback.svg
-    content: <a href="https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-397eiqk1g-xGljR5LdplaMod6n7sToUQ" target="_blank" rel="noopener noreferrer">チームみらいサポーターのSlack</a>に参加しよう！開発・デザイン・動画編集・記事化・オフィスワークなどなど、実際に手を動かし、サポーター作業に関わることにご興味・関心があるチームサポーターの方は、ぜひ「Slack」にご参加ください。
+    content: <a href="https://team-mirai.notion.site/Slack-20af6f56bae180289341c49a2b395ea3" target="_blank" rel="noopener noreferrer">チームみらいサポーターのSlack</a>に参加しよう！開発・デザイン・動画編集・記事化・オフィスワークなどなど、実際に手を動かし、サポーター作業に関わることにご興味・関心があるチームサポーターの方は、ぜひ「Slack」にご参加ください。
     difficulty: 1
     required_artifact_type: EMAIL
     max_achievement_count: 1


### PR DESCRIPTION
# 変更の概要
- join-slackミッションのリンク先を期限切れしないNotionページに変更しました

# 変更の背景
- Slack招待リンクは期限があるため、定期的な更新が必要でした
- 期限切れるたびに更新しなければならないページを減らすため、常時有効なNotionページにリンクを変更します
- closes #1137

# 変更点
## 修正ファイル
- `mission_data/missions.yaml`: join-slackミッションのcontentを修正

## 具体的な変更内容
- 旧URL: `https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-397eiqk1g-xGljR5LdplaMod6n7sToUQ`
- 新URL: `https://team-mirai.notion.site/Slack-20af6f56bae180289341c49a2b395ea3`

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 「join-slack」ミッションのリンクがSlack招待URLからNotionページへの案内リンクに変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->