### PR TITLE
feat: チームみらいの活動状況にダッシュボードリンクを追加

### DIFF
--- a/components/metrics/donation-metric.tsx
+++ b/components/metrics/donation-metric.tsx
@@ -100,6 +100,17 @@ export function DonationMetric({
           +{formatAmount(donationIncrease)}
         </span>
       </p>
+      {/* ダッシュボードへのリンク */}
+      <p className="mt-2 text-xs whitespace-nowrap">
+        <a
+          href="https://lookerstudio.google.com/u/0/reporting/e4efc74f-051c-4815-87f1-e4b5e93a3a8c/page/p_lvnweavysd"
+          className="text-teal-600 underline hover:text-teal-700"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          詳細を見る
+        </a>
+      </p>
       {/* ここでリンクを追加 */}
       <p className="mt-2 text-xs whitespace-nowrap">
         <a

--- a/components/metrics/supporter-metric.tsx
+++ b/components/metrics/supporter-metric.tsx
@@ -45,6 +45,17 @@ export function SupporterMetric({
             <span className="text-xs">人！</span>
           </span>
         </p>
+        {/* ダッシュボードへのリンク */}
+        <p className="mt-2 text-xs whitespace-nowrap">
+          <a
+            href="https://lookerstudio.google.com/u/0/reporting/e4efc74f-051c-4815-87f1-e4b5e93a3a8c/page/p_p5421pqhtd"
+            className="text-teal-600 underline hover:text-teal-700"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            詳細を見る
+          </a>
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
# 変更の概要
- チームみらいの活動状況ページにGoogle Looker Studioのダッシュボードリンクを追加
- サポーター数の部分に登録数ダッシュボードへの「詳細を見る」リンクを追加
- 寄付金額の部分に寄付金額ダッシュボードへの「詳細を見る」リンクを追加
- 既存の「ご支援はこちらから」リンクは維持

## Screenshots
### Before
<img width="582" height="361" alt="image" src="https://github.com/user-attachments/assets/d7953c92-3b6a-421e-b28d-9a2131af66a7" />

### After
<img width="583" height="441" alt="image" src="https://github.com/user-attachments/assets/74c9a6f7-ad88-4e33-93ef-e600b0ede968" />

# 変更の背景
- 活動状況ページにて、サポーター数と寄付金額の詳細データを確認したいユーザーのニーズに応えるため
- Google Looker Studioで作成されたダッシュボードへの導線を追加することで、より詳細な分析データを提供
- 既存のリンク構造を維持しながら、新しい詳細リンクを追加することで機能拡張を実現
- closes #1118

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました