### PR TITLE
ポスターマップにフルスクリーン表示機能を追加 (#1149)

### DIFF
--- a/app/map/poster/PosterMapWithCluster.tsx
+++ b/app/map/poster/PosterMapWithCluster.tsx
@@ -17,6 +17,7 @@ import {
 import { usePosterBoardFilterOptimized } from "@/lib/hooks/usePosterBoardFilterOptimized";
 import { createClient } from "@/lib/supabase/client";
 import type { Database } from "@/lib/types/supabase";
+import { Expand, Minimize } from "lucide-react";
 
 // Fix Leaflet default marker icon issue with Next.js
 // biome-ignore lint/performance/noDelete: Required for Leaflet icon fix
@@ -271,6 +272,7 @@ export default function PosterMapWithCluster({
   const [currentUserId, setCurrentUserId] = useState<string | undefined>(
     userIdFromProps,
   );
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   // Fetch current user and board info
   useEffect(() => {
@@ -563,8 +565,52 @@ export default function PosterMapWithCluster({
     }
   };
 
+  // フルスクリーンモードの切り替え
+  const toggleFullscreen = () => {
+    setIsFullscreen(!isFullscreen);
+  };
+
+  // ESCキーでフルスクリーン解除
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isFullscreen) {
+        setIsFullscreen(false);
+      }
+    };
+
+    if (isFullscreen) {
+      document.addEventListener("keydown", handleEscape);
+      // フルスクリーン時はbodyのスクロールを無効化
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "";
+    };
+  }, [isFullscreen]);
+
+  // フルスクリーン時に地図サイズを更新
+  useEffect(() => {
+    if (mapRef.current) {
+      // 少し遅延を入れてから地図サイズを更新
+      const timeoutId = setTimeout(() => {
+        mapRef.current?.invalidateSize();
+      }, 100);
+      return () => clearTimeout(timeoutId);
+    }
+  });
+
   return (
-    <div className="relative h-[600px] w-full z-0">
+    <div
+      className={
+        isFullscreen
+          ? "fixed inset-0 z-50 h-screen w-screen bg-white"
+          : "relative h-[600px] w-full z-0"
+      }
+    >
       <div id="poster-map-cluster" className="h-full w-full" />
 
       <PosterBoardFilter
@@ -575,6 +621,36 @@ export default function PosterMapWithCluster({
         onDeselectAll={deselectAll}
         activeFilterCount={activeFilterCount}
       />
+
+      {/* フルスクリーンボタン */}
+      {!isFullscreen && (
+        <button
+          type="button"
+          onClick={toggleFullscreen}
+          className="absolute left-4 bottom-4 rounded-full shadow px-3 py-3 bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 transition-all duration-200"
+          style={{ zIndex: 1000 }}
+          aria-label="フルスクリーン表示"
+          title="フルスクリーン表示"
+        >
+          <Expand size={20} />
+        </button>
+      )}
+
+      {/* フルスクリーン解除ボタン */}
+      {isFullscreen && (
+        <button
+          type="button"
+          onClick={toggleFullscreen}
+          className="absolute left-4 bottom-4 rounded-full shadow px-3 py-3 bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 transition-all duration-200"
+          style={{ zIndex: 1000 }}
+          aria-label="フルスクリーン解除"
+          title="フルスクリーン解除 (ESC)"
+        >
+          <Minimize size={20} />
+        </button>
+      )}
+
+      {/* 現在地ボタン */}
       <button
         type="button"
         onClick={handleLocate}


### PR DESCRIPTION
# 変更の概要
- ポスターマップに地図を最大表示（フルスクリーン）できるモードを追加
- 左下にフルスクリーン切り替えボタンを追加
- フルスクリーン時は画面全体に地図を表示
- ESCキーでフルスクリーン解除対応
- 地図サイズの自動調整とページスクロール制御

# 変更の背景
- ユーザーから「PC で貼付ルートを俯瞰把握して効率良く掲示板を回りたい」との要望
- 印刷して紙上でチェックしたい（オフライン確認、圏外対策）のニーズ
- 外枠がなくなることで地図キャプチャのスクショが撮りやすくなる
- closes #1149

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました