### PR TITLE
チームみらいの活動状況レイアウトの改善 - 誤タップ防止とデザイン調整

### DIFF
--- a/components/metrics/achievement-metric.tsx
+++ b/components/metrics/achievement-metric.tsx
@@ -22,21 +22,24 @@ export function AchievementMetric({
   const todayAchievementCount = data.todayCount ?? fallbackToday;
 
   return (
-    <div className="flex-1 text-center flex flex-col justify-center">
-      <p className="text-sm font-bold text-black mb-2">達成済アクション数</p>
-      {/* 総アクション数（Supabaseから取得、失敗時は環境変数フォールバック） */}
-      <p className="text-2xl font-black text-black mb-1">
-        {formatNumber(achievementCount)}
-        <span className="text-lg">件</span>
-      </p>
-      {/* 24時間のアクション増加数 */}
-      <p className="text-xs text-black">
-        1日で{" "}
-        <span className="font-bold text-teal-700">
-          +{formatNumber(todayAchievementCount)}
-          <span className="text-xs">件</span>
-        </span>
-      </p>
+    <div className="flex items-center justify-between py-6">
+      <div>
+        <p className="text-base font-bold text-black">達成アクションの数</p>
+      </div>
+      <div className="text-right">
+        {/* 総アクション数（Supabaseから取得、失敗時は環境変数フォールバック） */}
+        <p className="text-2xl font-black text-gray-800">
+          {formatNumber(achievementCount)}
+          <span className="text-lg">件</span>
+        </p>
+        {/* 24時間のアクション増加数 */}
+        <p className="text-xs text-gray-600">
+          1日で{" "}
+          <span className="font-bold text-teal-700">
+            +{formatNumber(todayAchievementCount)}件
+          </span>
+        </p>
+      </div>
     </div>
   );
 }

--- a/components/metrics/donation-metric.tsx
+++ b/components/metrics/donation-metric.tsx
@@ -60,9 +60,9 @@ export function DonationMetric({
   };
 
   return (
-    <div className="flex-1 text-center flex flex-col justify-center">
-      <div className="flex items-center justify-center gap-2 mb-2">
-        <p className="text-sm font-bold text-black">現在の寄付金額</p>
+    <div className="flex items-center justify-between py-6">
+      <div className="flex items-center gap-2">
+        <p className="text-base font-bold text-black">現在の寄付金額</p>
         {/* 寄付金額の詳細説明ツールチップ */}
         <Popover open={isMobile ? isTooltipOpen : undefined}>
           <PopoverTrigger asChild>
@@ -89,39 +89,19 @@ export function DonationMetric({
           </PopoverContent>
         </Popover>
       </div>
-      {/* 総寄付金額（外部APIから取得、失敗時は環境変数フォールバック） */}
-      <p className="text-2xl font-black text-black mb-1">
-        {formatAmount(donationAmount)}
-      </p>
-      {/* 24時間の寄付金増加額 */}
-      <p className="text-xs text-black">
-        1日で{" "}
-        <span className="font-bold text-teal-700">
-          +{formatAmount(donationIncrease)}
-        </span>
-      </p>
-      {/* ダッシュボードへのリンク */}
-      <p className="mt-2 text-xs whitespace-nowrap">
-        <a
-          href="https://lookerstudio.google.com/u/0/reporting/e4efc74f-051c-4815-87f1-e4b5e93a3a8c/page/p_lvnweavysd"
-          className="text-teal-600 underline hover:text-teal-700"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          詳細を見る
-        </a>
-      </p>
-      {/* ここでリンクを追加 */}
-      <p className="mt-2 text-xs whitespace-nowrap">
-        <a
-          href="https://team-mir.ai/support/donation"
-          className="text-teal-600 underline hover:text-teal-700"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ご支援はこちらから
-        </a>
-      </p>
+      <div className="text-right">
+        {/* 総寄付金額（外部APIから取得、失敗時は環境変数フォールバック） */}
+        <p className="text-2xl font-black text-gray-800">
+          {formatAmount(donationAmount)}
+        </p>
+        {/* 24時間の寄付金増加額 */}
+        <p className="text-xs text-gray-600">
+          1日で{" "}
+          <span className="font-bold text-teal-700">
+            +{formatAmount(donationIncrease)}
+          </span>
+        </p>
+      </div>
     </div>
   );
 }

--- a/components/metrics/index.tsx
+++ b/components/metrics/index.tsx
@@ -41,31 +41,80 @@ export default async function Metrics() {
 
   return (
     <MetricsLayout title="チームみらいの活動状況🚀" lastUpdated={lastUpdated}>
-      {/* サポーター数表示エリア（メインハイライト） */}
+      {/* アクション達成数 */}
+      <AchievementMetric
+        data={metricsData.achievement}
+        fallbackTotal={fallbackAchievementCount}
+        fallbackToday={fallbackTodayAchievementCount}
+      />
+
+      {/* 水平セパレーター */}
+      <Separator orientation="horizontal" className="my-4" />
+
+      {/* サポーター数 */}
       <SupporterMetric
         data={metricsData.supporter}
         fallbackCount={fallbackSupporterCount}
         fallbackIncrease={fallbackSupporterIncrease}
       />
 
-      {/* 下段：アクション数と寄付金額を左右に分割表示 */}
-      <div className="flex items-start">
-        {/* 左側：アクション達成数 */}
-        <AchievementMetric
-          data={metricsData.achievement}
-          fallbackTotal={fallbackAchievementCount}
-          fallbackToday={fallbackTodayAchievementCount}
-        />
+      {/* 水平セパレーター */}
+      <Separator orientation="horizontal" className="my-4" />
 
-        {/* 中央：縦線セパレーター */}
-        <Separator orientation="vertical" className="mx-4 h-full" />
+      {/* 寄付金額 */}
+      <DonationMetric
+        data={metricsData.donation}
+        fallbackAmount={fallbackDonationAmount}
+        fallbackIncrease={fallbackDonationIncrease}
+      />
 
-        {/* 右側：寄付金額 */}
-        <DonationMetric
-          data={metricsData.donation}
-          fallbackAmount={fallbackDonationAmount}
-          fallbackIncrease={fallbackDonationIncrease}
-        />
+      {/* リンクセクション */}
+      <div className="flex flex-col items-center gap-3 mt-6 pt-4 border-t border-gray-200">
+        <a
+          href="https://team-mir.ai/support/donation"
+          className="flex items-center gap-2 text-teal-600 hover:text-teal-700 font-medium text-sm transition-colors"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span>チームみらいを寄付で応援する</span>
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <title>ご寄付に関するご案内</title>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+            />
+          </svg>
+        </a>
+
+        <a
+          href="https://lookerstudio.google.com/u/0/reporting/e4efc74f-051c-4815-87f1-e4b5e93a3a8c/page/p_p5421pqhtd"
+          className="flex items-center gap-2 text-gray-600 hover:text-gray-700 font-medium text-sm transition-colors"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span>もっと詳しい活動状況を見る</span>
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <title>チームみらいダッシュボード</title>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+            />
+          </svg>
+        </a>
       </div>
     </MetricsLayout>
   );

--- a/components/metrics/supporter-metric.tsx
+++ b/components/metrics/supporter-metric.tsx
@@ -22,39 +22,22 @@ export function SupporterMetric({
   const supporterIncrease = data?.last24hCount ?? fallbackIncrease;
 
   return (
-    <div className="mb-6">
-      <div
-        className="p-4 text-center rounded"
-        style={{ backgroundColor: "#F9F9F9" }}
-      >
-        <div className="flex items-center justify-center gap-2 mb-2">
-          <p className="text-sm font-bold text-black">
-            チームみらい サポーター数
-          </p>
-        </div>
+    <div className="flex items-center justify-between py-6">
+      <div>
+        <p className="text-base font-bold text-black">サポーター数</p>
+      </div>
+      <div className="text-right">
         {/* 総サポーター数（大きく表示） */}
-        <p className="text-3xl font-bold text-teal-700 mb-1">
+        <p className="text-3xl font-bold text-gray-800">
           {formatNumber(supporterCount)}
           <span className="text-xl">人</span>
         </p>
         {/* 24時間の増加数 */}
-        <p className="text-sm text-black">
+        <p className="text-sm text-gray-600">
           1日で{" "}
           <span className="font-bold text-teal-700">
-            +{formatNumber(supporterIncrease)}
-            <span className="text-xs">人！</span>
+            +{formatNumber(supporterIncrease)}人
           </span>
-        </p>
-        {/* ダッシュボードへのリンク */}
-        <p className="mt-2 text-xs whitespace-nowrap">
-          <a
-            href="https://lookerstudio.google.com/u/0/reporting/e4efc74f-051c-4815-87f1-e4b5e93a3a8c/page/p_p5421pqhtd"
-            className="text-teal-600 underline hover:text-teal-700"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            詳細を見る
-          </a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## 概要
PR #1144で追加されたダッシュボードリンクが誤タップを引き起こす問題を修正し、チームみらいの活動状況表示のレイアウトを改善しました。

## 変更内容
- **誤タップ防止**: 各指標の個別「詳細を見る」リンクを削除
- **統合リンクセクション**: 下部に2つのリンクを集約
  - 「チームみらいを寄付で応援する」→ 寄付ページ
  - 「もっと詳しい活動状況を見る」→ ダッシュボード
- **レイアウト改善**: 縦並びレイアウト（左ラベル・右数値）に変更
- **デザイン調整**: 
  - 文字色を調整（黒→グレー系）
  - パディングとスペーシングを改善
  - 外部リンクアイコンを追加（アクセシビリティ対応）

## 変更ファイル
- `components/metrics/index.tsx` - メインレイアウトとリンクセクション
- `components/metrics/achievement-metric.tsx` - 達成アクション数表示
- `components/metrics/supporter-metric.tsx` - サポーター数表示  
- `components/metrics/donation-metric.tsx` - 寄付金額表示

## テスト
- [ ] デスクトップでの表示確認
- [ ] モバイルでの表示確認
- [ ] リンクの動作確認
- [ ] アクセシビリティ確認

Closes #1169