### PR TITLE
マップアプリの修正と起動機能の追加

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -505,7 +505,7 @@ function NameConfirmDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[95vw] max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-md w-[95vw] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>どの範囲で検索しますか？</DialogTitle>
         </DialogHeader>

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -151,7 +151,7 @@ function LocationInfo({
     <div className="text-sm text-muted-foreground">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0 flex-1">
-          <span className="truncate">{displayText}</span>
+          <span className="break-words">{displayText}</span>
           <Button
             variant="ghost"
             size="sm"

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -70,7 +70,7 @@ import {
   getUserEditedBoardIdsAction,
 } from "@/lib/actions/poster-boards";
 
-type MapAppType = "Google Maps" | "Gpple Maps";
+type MapAppType = "Google Maps" | "Apple Maps";
 type DisplayType = "address" | "coordinates" | "name";
 
 // 表示タイプに応じて日本語テキストを生成
@@ -133,7 +133,7 @@ function LocationInfo({
   const getDisplayText = () => {
     switch (displayType) {
       case "address":
-        return `${selectedBoard.city} ${selectedBoard.address} (${selectedBoard.number})`;
+        return `${selectedBoard.city} ${selectedBoard.address}`;
       case "coordinates":
         return `${selectedBoard.lat}, ${selectedBoard.long}`;
       case "name":
@@ -148,14 +148,14 @@ function LocationInfo({
   const displayText = getDisplayText();
 
   return (
-    <div className="mb-4 text-sm text-muted-foreground">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span>{displayText}</span>
+    <div className="text-sm text-muted-foreground">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <span className="truncate">{displayText}</span>
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 w-6 p-0"
+            className="h-6 w-6 p-0 flex-shrink-0"
             onClick={() => copyToClipboard(displayType, displayText)}
             title={`${getDisplayTypeText(displayType)}をコピー`}
           >
@@ -168,7 +168,7 @@ function LocationInfo({
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 px-2"
+              className="h-8 px-2 flex-shrink-0 whitespace-nowrap"
               onClick={() => onNameConfirm(preferredMapApp)}
             >
               <MapPin className="h-4 w-4 mr-1" />
@@ -185,18 +185,26 @@ function LocationInfo({
               )}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center h-8 px-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent hover:bg-accent/50 rounded-md transition-colors"
+              className="inline-flex items-center h-8 px-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent hover:bg-accent/50 rounded-md transition-colors flex-shrink-0 whitespace-nowrap"
             >
               <MapPin className="h-4 w-4 mr-1" />
-              {`${getDisplayTypeText(displayType)}で開く`}
+              {`${getDisplayTypeText(displayType)}で開く${
+                displayType === "coordinates" ? "(推奨)" : ""
+              }`}
             </a>
           )
         ) : (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 px-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2 flex-shrink-0 whitespace-nowrap"
+              >
                 <MapPin className="h-4 w-4 mr-1" />
-                {`${getDisplayTypeText(displayType)}で開く`}
+                {`${getDisplayTypeText(displayType)}で開く${
+                  displayType === "coordinates" ? "(推奨)" : ""
+                }`}
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -475,7 +483,8 @@ function NameConfirmDialog({
   selectedBoard: PosterBoard | null;
   addressConfirmApp: MapAppType | null;
 }) {
-  const defaultText = selectedBoard?.name || "名称なし";
+  const defaultText =
+    `${selectedBoard?.city} ${selectedBoard?.name}` || "名称なし";
   const [selectedText, setSelectedText] = useState(defaultText);
 
   // selectedBoardが変更されたときにselectedTextを更新
@@ -1010,9 +1019,7 @@ export default function PrefecturePosterMapClient({
           <DialogHeader>
             <DialogTitle>ポスターの状況を報告</DialogTitle>
             <DialogDescription>
-              {selectedBoard?.name ||
-                selectedBoard?.address ||
-                selectedBoard?.number}
+              {selectedBoard?.city} ({selectedBoard?.number})
               の状況を教えてください
             </DialogDescription>
           </DialogHeader>
@@ -1044,16 +1051,18 @@ export default function PrefecturePosterMapClient({
               />
             </>
           )}
-          <div className="flex justify-end">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={resetMapAppPreference}
-              className="text-xs text-muted-foreground hover:text-foreground cursor-pointer underline"
-            >
-              デフォルトのマップアプリをリセット
-            </Button>
-          </div>
+          {preferredMapApp && (
+            <div className="flex justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={resetMapAppPreference}
+                className="text-xs text-muted-foreground hover:text-foreground cursor-pointer underline"
+              >
+                デフォルトのマップアプリをリセット
+              </Button>
+            </div>
+          )}
           <div className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="status">ポスターの状況</Label>


### PR DESCRIPTION
# 変更の概要
- コピーボタンを押した時に出るメッセージの修正
- Google MapとApple Mapのコードの共通化
- 前回使用したマップアプリを記憶し、次回からはワンタップで開けるように
- 座標だけでなく、住所や名称からもマップアプリを開けるように
- 名称の一部を選択してマップを開ける機能

# 変更の背景
- closes #1113

# スクリーンショット
<img height="700" alt="localhost_3000_map_poster_saitama(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/146a44d5-5ab3-4622-9250-6931acc12440"/>
<img height="700" alt="localhost_3000_map_poster_saitama(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/69d30a71-7479-4db2-b537-72f7606ecff2" />

# CLAへの同意
- [x] CLAの内容を読み、同意しました