### PR TITLE
fix(load-csv.ts): noteなしCSVのCOPYクエリのカラム順序を修正

### DIFF
--- a/poster_data/load-csv.ts
+++ b/poster_data/load-csv.ts
@@ -153,7 +153,7 @@ async function main() {
         `);
 
         const copyQuery = copyFrom(
-          `COPY ${tempTable} (prefecture, city, number, name, address, lat, long) FROM STDIN WITH (FORMAT csv, HEADER true, DELIMITER ',')`,
+          `COPY ${tempTable} (prefecture, city, number, address, name, lat, long) FROM STDIN WITH (FORMAT csv, HEADER true, DELIMITER ',')`,
         );
 
         await pipeline(createReadStream(file), db.query(copyQuery));


### PR DESCRIPTION
## 概要
`poster_data/load-csv.ts`の7カラム版COPYクエリでカラム順序がCSVファイルの実際の順序と異なっていた問題を修正

## 変更内容
- 7カラム版COPYクエリの順序を `number, name, address` から `number, address, name` に修正
- CSVファイルの実際の順序 `prefecture,city,number,address,name,lat,long` に合わせて統一

## 問題の詳細
- CSVファイル: `prefecture,city,number,address,name,lat,long,note`
- 7カラム版（修正前）: `prefecture, city, number, name, address, lat, long` ← nameとaddressが逆
- 8カラム版: `prefecture, city, number, address, name, lat, long, note` ← 既に正しい

## テスト計画
- [ ] CSVファイル読み込みテストの実行
- [ ] poster_boardsテーブルへの正しいデータ投入の確認

Closes #1181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * CSVデータのインポート時、列の順序が修正され、正しい情報が読み込まれるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->