### PR TITLE
掲示板住所マスキングロジックの改善

### DIFF
--- a/poster_data/mask-names.ts
+++ b/poster_data/mask-names.ts
@@ -69,21 +69,10 @@ function removePersonalNameFromAddress(address: string): string {
   }
 
   // 個人名部分のパターンを定義
-  const personalNamePatterns = [
-    /[一-龯]+様.*$/, // 漢字+様
-    /[一-龯]+宅$/, // 漢字+宅
-    /[ひらがな]+様.*$/, // ひらがな+様
-    /[ひらがな]+宅$/, // ひらがな+宅
-    /[カタカナ]+様.*$/, // カタカナ+様
-    /[カタカナ]+宅$/, // カタカナ+宅
-    /[A-Za-z]+様.*$/, // アルファベット+様
-    /[A-Za-z]+宅$/, // アルファベット+宅
-  ];
+  const personalNamePattern = /[一-龯ぁ-んァ-ヶｱ-ﾝﾞﾟA-Za-z\s・]+(様|宅).*$/;
 
   let cleanedAddress = address;
-  for (const pattern of personalNamePatterns) {
-    cleanedAddress = cleanedAddress.replace(pattern, "").trim();
-  }
+  cleanedAddress = cleanedAddress.replace(personalNamePattern, "").trim();
 
   // 住宅は除外しない（個人名ではないため）
   if (


### PR DESCRIPTION
# 変更の概要
- 掲示板データの住所フィールドから個人名のみを除去し、住所情報を保持するマスキングロジックを実装
- 正規表現パターンを最適化し、効率的な個人名検出を実現

# 変更の背景
- 現在のシステムでは、住所フィールドに個人名が含まれる場合、フィールド全体が「masked」に置き換えられ、有用な住所情報も失われてしまう問題があった
- 例：「美浜区美浜1-2-3田中宅」→「masked」（従来）→「美浜区美浜1-2-3」（改善後）
- closes #1205

## 主な変更内容
- `removePersonalNameFromAddress` 関数を新規実装
- 統合された正規表現パターンで効率的な個人名検出：`/[一-龯ぁ-んァ-ヶｱ-ﾝﾞﾟA-Za-z\s・]+(様|宅).*$/`
- 住所情報の30%以上を保持できる場合は住所部分を維持
- 「住宅」などの建物名は除去対象外として適切に処理

## 技術的改善点
- 複数の分離された正規表現パターンを単一の統合パターンに最適化
- 漢字、ひらがな、カタカナ（全角・半角）、アルファベット、スペース、中点を包括的にサポート
- パフォーマンス向上とコードの簡素化

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました