### PR TITLE
OGP画像のキャッシュ回避のため defaultImage にクエリパラメータを追加

### DIFF
--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -16,7 +16,7 @@ export const config = {
   title: "チームみらい アクションボード",
   description:
     "政治活動をもっと身近に。政治活動をゲーム感覚で楽しめる、チームみらいのアクションボード。",
-  defaultImage: "/img/ogp-default.png",
+  defaultImage: "/img/ogp-default.png?v=20250714",
   icons: {
     icon: [
       { url: "/favicon.ico", sizes: "any" },


### PR DESCRIPTION
# 変更の概要
- Twitter のキャッシュによりOGP画像が更新されないため、クエリパラメータを付与して再取得を促す対応です。

# 変更の背景
- ツイート時のOGPが更新されていない

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * デフォルトのOpen Graph画像のURLにバージョンパラメータ（?v=20250714）を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->