### PR TITLE
ミッション非表示: 在外投票をしよう！

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -589,7 +589,7 @@ missions:
     required_artifact_type: NONE
     max_achievement_count: 1
     is_featured: false
-    is_hidden: false
+    is_hidden: true
     artifact_label: null
     ogp_image_url: null
   - slug: youtube-comment


### PR DESCRIPTION
# 変更の概要
- 在外投票ミッション非表示

# 変更の背景
- 在外投票が可能な期日が過ぎたため
- closes #1196 

# 変更確認
<img width="1105" height="607" alt="image" src="https://github.com/user-attachments/assets/a9e5357b-b068-447f-8200-0d930eb6d8d2" />


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更点**
  * 「overseas-vote」と「youtube-comment」の2つのミッションが非表示になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->