### PR TITLE
fix: ポスター貼りの説明Notionのリンク切れ(#1198)

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -380,7 +380,7 @@ missions:
   - slug: put-up-poster
     title: チームみらいの政党ポスターを貼ろう
     icon_url: /img/mission-icons/actionboard_icon_work_20250713_ol_mission_fallback.svg
-    content: チームみらいの政党ポスターを貼って、地域の人々に政策を広めよう！<br><br>詳しいポスター貼りの方法や注意点については、こちらのページをご確認ください：<br><a href="https://team-mirai.notion.site/206f6f56bae180e6b471ec5360653227" target="_blank">政治ポスターを貼る</a>
+    content: チームみらいの政党ポスターを貼って、地域の人々に政策を広めよう！<br><br>詳しいポスター貼りの方法や注意点については、こちらのページをご確認ください：<br><a href="https://team-mirai.notion.site/222f6f56bae1802aaed2c98f36e2c46a" target="_blank">政治ポスターを貼る</a>
     difficulty: 4
     required_artifact_type: TEXT
     max_achievement_count: null

--- a/supabase/migrations/20250622100837_add_mission_poster.sql
+++ b/supabase/migrations/20250622100837_add_mission_poster.sql
@@ -17,7 +17,7 @@ VALUES (
   gen_random_uuid(),
   'チームみらいの政党ポスターを貼ろう',
   '/img/mission_fallback.svg',
-  'チームみらいの政党ポスターを貼って、地域の人々に政策を広めよう！<br><br>詳しいポスター貼りの方法や注意点については、こちらのページをご確認ください：<br><a href="https://team-mirai.notion.site/206f6f56bae180e6b471ec5360653227" target="_blank">政治ポスターを貼る</a>',
+  'チームみらいの政党ポスターを貼って、地域の人々に政策を広めよう！<br><br>詳しいポスター貼りの方法や注意点については、こちらのページをご確認ください：<br><a href="https://team-mirai.notion.site/222f6f56bae1802aaed2c98f36e2c46a" target="_blank">政治ポスターを貼る</a>',
   4,
   NULL,
   'TEXT',


### PR DESCRIPTION
# 変更の概要
- ポスター貼りの方法と注意点を説明するNotionリンクを、リンク切れの`https://team-mirai.notion.site/206f6f56bae180e6b471ec5360653227` → 正しいページ`https://team-mirai.notion.site/222f6f56bae1802aaed2c98f36e2c46a`に修正しました。

# 変更の背景
- ミッション「チームみらいの政党ポスターを貼ろう」にてリンク切れ
- closes #1198

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 「チームみらいの政党ポスターを貼ろう」ミッションのリンク先URLを新しいものに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->