### PR TITLE
既存外部リンク移行(#1247)

### DIFF
--- a/components/footer/CopyrightSection.tsx
+++ b/components/footer/CopyrightSection.tsx
@@ -1,6 +1,5 @@
-import { EXTERNAL_LINKS } from "@/lib/constants";
+import { EXTERNAL_LINKS } from "@/lib/links";
 import Link from "next/link";
-import { FOOTER_CONFIG } from "./footer";
 
 export function CopyrightSection() {
   return (
@@ -9,7 +8,7 @@ export function CopyrightSection() {
         <div className="text-center">
           <div className="flex justify-center items-center gap-2 text-sm">
             <Link
-              href="https://team-mir.ai/"
+              href={EXTERNAL_LINKS.team_mirai_main}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-teal-700 transition-colors duration-200 text-teal-600"
@@ -32,7 +31,7 @@ export function CopyrightSection() {
             </Link>
             <span>|</span>
             <Link
-              href={FOOTER_CONFIG.feedback.url}
+              href={EXTERNAL_LINKS.feedback_action_board}
               className="hover:text-teal-700 transition-colors duration-200 text-teal-600"
               target="_blank"
               rel="noopener noreferrer"
@@ -41,7 +40,7 @@ export function CopyrightSection() {
             </Link>
             <span>|</span>
             <Link
-              href={EXTERNAL_LINKS.FAQ}
+              href={EXTERNAL_LINKS.faq}
               className="hover:text-teal-700 transition-colors duration-200 text-teal-600"
               target="_blank"
               rel="noopener noreferrer"

--- a/components/footer/FeedbackSection.tsx
+++ b/components/footer/FeedbackSection.tsx
@@ -1,5 +1,5 @@
+import { EXTERNAL_LINKS } from "@/lib/links";
 import Link from "next/link";
-import { FOOTER_CONFIG } from "./footer";
 
 export function FeedbackSection() {
   return (
@@ -14,7 +14,7 @@ export function FeedbackSection() {
           いただいたフィードバックは 今後の改善に活用させていただきます。
         </p>
         <Link
-          href={FOOTER_CONFIG.feedback.poster_map_url}
+          href={EXTERNAL_LINKS.feedback_poster_map}
           target="_blank"
           rel="noopener noreferrer"
           aria-label="ポスターマップへのご意見フォーム（新しいタブで開きます）"
@@ -39,7 +39,7 @@ export function FeedbackSection() {
           ポスターマップへのご意見
         </Link>
         <Link
-          href={FOOTER_CONFIG.feedback.url}
+          href={EXTERNAL_LINKS.feedback_action_board}
           target="_blank"
           rel="noopener noreferrer"
           aria-label="アクションボードへのご意見フォーム（新しいタブで開きます）"

--- a/components/metrics/donation-metric.tsx
+++ b/components/metrics/donation-metric.tsx
@@ -5,6 +5,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { EXTERNAL_LINKS } from "@/lib/links";
 import type { DonationData } from "@/lib/types/metrics";
 import { formatAmount } from "@/lib/utils/metrics-formatter";
 import { useEffect, useState } from "react";
@@ -141,7 +142,7 @@ export function DonationMetric({
       {/* 寄付リンク */}
       <div className="mt-4 text-center">
         <a
-          href="https://team-mir.ai/support/donation"
+          href={EXTERNAL_LINKS.team_mirai_donation}
           className="inline-flex items-center gap-1 text-teal-600 hover:text-teal-700 text-sm transition-colors"
           target="_blank"
           rel="noopener noreferrer"

--- a/components/metrics/index.test.tsx
+++ b/components/metrics/index.test.tsx
@@ -6,6 +6,7 @@ jest.mock("@/lib/services/metrics", () => ({
   fetchAllMetricsData: jest.fn(),
 }));
 
+import { EXTERNAL_LINKS } from "@/lib/links";
 import { fetchAllMetricsData } from "@/lib/services/metrics";
 import Metrics from "./index";
 
@@ -250,7 +251,7 @@ describe("Metrics", () => {
       expect(donationLink).toBeInTheDocument();
       expect(donationLink.closest("a")).toHaveAttribute(
         "href",
-        "https://team-mir.ai/support/donation",
+        EXTERNAL_LINKS.team_mirai_donation,
       );
     });
 

--- a/lib/links/index.ts
+++ b/lib/links/index.ts
@@ -12,8 +12,9 @@ export const EXTERNAL_LINKS = {
   team_mirai_main: "https://team-mir.ai/",
   team_mirai_policy: "https://policy.team-mir.ai/view/README.md",
   team_mirai_action_board: "https://action.team-mir.ai/",
+  team_mirai_donation: "https://team-mir.ai/support/donation",
 
-  // SNS
+  // SNSアカウント
   x_team_mirai: "https://x.com/team_mirai_jp",
   x_anno_takahiro: "https://x.com/takahiroanno",
   youtube_team_mirai:
@@ -23,6 +24,12 @@ export const EXTERNAL_LINKS = {
   note_anno_takahiro: "https://note.com/annotakahiro24",
   tiktok_anno_takahiro: "https://www.tiktok.com/@annotakahiro2024",
   threads_anno_takahiro: "https://www.threads.com/@annotakahiro2024",
+
+  // SNS指名検索
+  x_search_team_mirai: "https://x.com/search?q=%23チームみらい",
+  note_search_team_mirai: "https://note.com/search?q=チームみらい",
+  youtube_search_team_mirai:
+    "https://www.youtube.com/results?search_query=%E3%83%81%E3%83%BC%E3%83%A0%E3%81%BF%E3%82%89%E3%81%84",
 
   // その他
   speakerdeck_manifest:


### PR DESCRIPTION
# 変更の概要
- すべての外部リンクが #1250 で実装された`lib/links/index.ts`で管理するようにしました。

# 変更の背景
- #1247 参照

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 外部リンク集に「チームみらい」寄付ページと、X・Note・YouTubeでの「チームみらい」検索用リンクを追加しました。

* **改善**
  * フッターやフィードバック、寄付リンクなどの外部URLを一元管理し、リンクの表記ゆれや誤りを修正しました。

* **テスト**
  * テスト内の寄付リンク参照を定数化し、管理を統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->