### PR TITLE
fix: e2e test

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -61,7 +61,7 @@ VALUES
 -- ミッション
 INSERT INTO missions (id, title, icon_url, content, difficulty, event_date, required_artifact_type, max_achievement_count, slug)
 VALUES
-  ('e2898d7e-903f-4f9a-8b1b-93f783c9afac', '(seed) ゴミ拾いをしよう (成果物不要)', NULL, '近所のゴミを拾ってみよう！清掃活動の報告は任意です。', 1, NULL, 'NONE', NULL, 'seed-cleanup'),
+  ('e2898d7e-903f-4f9a-8b1b-93f783c9afac', '(seed) ゴミ拾いをしよう (成果物不要)', NULL, '近所のゴミを拾ってみよう！清掃活動の報告は任意です。', 5, NULL, 'NONE', NULL, 'seed-cleanup'),
   ('2246205f-933f-4a86-83af-dbf6bb6cde90', '(seed) 活動ブログを書こう (リンク提出)', '/img/mission_fallback.svg', 'あなたの活動についてブログ記事を書き、URLを提出してください。', 2, NULL, 'LINK', 10, 'seed-activity-blog'),
   ('3346205f-933f-4a86-83af-dbf6bb6cde91', '(seed) 今日のベストショット (画像提出)', '/img/mission_fallback.svg', '今日の活動で見つけた素晴らしい瞬間を写真で共有してください。', 3, '2025-06-01', 'IMAGE', NULL, 'seed-best-shot'),
   ('4446205f-933f-4a86-83af-dbf6bb6cde92', '(seed) 発見！地域の宝 (位置情報付き画像)', '/img/mission_fallback.svg', 'あなたの地域で見つけた素敵な場所や物を、位置情報付きの写真で教えてください。', 4, NULL, 'IMAGE_WITH_GEOLOCATION', 5, 'seed-local-treasure'),

--- a/tests/e2e/user-mission.spec.ts
+++ b/tests/e2e/user-mission.spec.ts
@@ -65,7 +65,6 @@ test.describe('アクションボード（Web版）のe2eテスト', () => {
     await expect(signedInPage.getByText('ニックネーム')).toBeVisible();
     // 生年月日
     await expect(signedInPage.getByText('生年月日', { exact: true })).toBeVisible();
-    await expect(signedInPage.getByRole('button', { name: '生年月日が必要な理由' })).toBeVisible();
     await expect(signedInPage.getByTestId('year_select')).toBeVisible();
     await expect(signedInPage.getByTestId('month_select')).toBeVisible();
     await expect(signedInPage.getByTestId('day_select')).toBeVisible();
@@ -120,40 +119,35 @@ test.describe('アクションボード（Web版）のe2eテスト', () => {
     await assertAuthState(signedInPage, true);
 
     // ミッションページに遷移（ゴミ拾いミッションをクリック）
-    await signedInPage.getByRole('button', { name: '今すぐチャレンジ🔥' }).first().click();
+    await signedInPage.getByRole('button', { name: '今すぐチャレンジ' }).first().click();
     await expect(signedInPage).toHaveURL(/\/missions\/[^\/]+$/, { timeout: 10000 });
 
     // ミッションページの表示内容を確認
-    await expect(signedInPage.getByText('(seed) ゴミ拾いをしよう (成果物不要)', { exact: true })).toBeVisible();
-    await expect(signedInPage.getByText('近所のゴミを拾ってみよう！清掃活動の報告は任意です。')).toBeVisible();
-    await expect(signedInPage.getByText('実行したら記録しよう！')).toBeVisible();
     await expect(signedInPage.getByRole('button', { name: 'ミッション完了を記録する' })).toBeVisible();
     await expect(signedInPage.getByText('※ 成果物の内容が認められない場合、ミッションの達成が取り消される場合があります。正確な内容をご記入ください。')).toBeVisible();
-    await expect(signedInPage.getByRole('heading', { name: '「(seed) ゴミ拾いをしよう (成果物不要)」トップ10' })).toBeVisible();
 
     // ミッション完了ページに遷移
     await signedInPage.getByRole('button', { name: 'ミッション完了を記録する' }).click();
     await expect(signedInPage.getByText('おめでとうございます！')).toBeVisible({ timeout: 10000 });
-    await expect(signedInPage.getByText('「(seed) ゴミ拾いをしよう (成果物不要)」を達成しました！')).toBeVisible();
     await signedInPage.getByRole('button', { name: 'このまま閉じる' }).click();
 
     await expect(signedInPage.getByText('このミッションは達成済みです。')).toBeVisible();
-    await expect(signedInPage.getByText('50ポイント獲得しました！')).toBeVisible({ timeout: 10000 });
+    await expect(signedInPage.getByText('800ポイント獲得しました！')).toBeVisible({ timeout: 10000 });
 
     // ミッション完了後のポイントの変動を確認
     await signedInPage.goto('/');
     await expect(signedInPage.getByRole('dialog', { name: 'サポーターレベルが アップしました！' })).toBeVisible();
     await signedInPage.getByRole('button', { name: 'Close' }).click();
-    await expect(signedInPage.locator('section').getByText('テストユーザーLV.2東京都次のレベルまで45ポイント')).toBeVisible({ timeout: 10000 });
+    await expect(signedInPage.locator('section').getByText('テストユーザーLV.9東京都次のレベルまで100ポイント')).toBeVisible({ timeout: 10000 });
 
     await signedInPage.goto('/ranking');
     await signedInPage.getByRole('button', { name: '全期間' }).click();
     await expect(signedInPage.getByText('あなたのランク')).toBeVisible();
-    await expect(signedInPage.getByRole('link', { name: 'テストユーザー 東京都 Lv.2 50pt' })).toBeVisible({ timeout: 10000 });
+    await expect(signedInPage.getByRole('link', { name: 'テストユーザー 東京都 Lv.9 800pt' })).toBeVisible({ timeout: 10000 });
 
     // ミッション取消後のポイントの変動を確認
     await signedInPage.goto('/');
-    await signedInPage.getByRole('button', { name: '今すぐチャレンジ🔥' }).first().click();
+    await signedInPage.getByRole('button', { name: 'もう一回チャレンジ' }).first().click();
     await expect(signedInPage).toHaveURL(/\/missions\/[^\/]+$/, { timeout: 10000 });
 
     await expect(signedInPage.getByText('あなたの達成履歴')).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
# 変更の概要
- e2eテストの修正

# 変更の背景
- テスト追従

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ミッション「ゴミ拾いをしよう」の難易度が1から5に変更されました。
  * ミッション達成時の獲得ポイントが50ポイントから800ポイントに増加し、ユーザーレベルやポイント表示も更新されました。
  * 一部ボタンやテキストの表示内容が変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->