### PR TITLE
chore: tiktok-clip-final-pushのfeatured_importanceを調整

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -94,7 +94,7 @@ missions:
     required_artifact_type: LINK
     max_achievement_count: null
     is_featured: true
-    featured_importance: 1000
+    featured_importance: 100
     is_hidden: false
     artifact_label: ショート動画のURL（TikTok）
     ogp_image_url: null


### PR DESCRIPTION
# 変更の概要
- tiktok-clip-final-pushのfeatured_importanceを1000→100に変更
- マイク納めミッション(featured_importance: 110)が最上位表示になるよう調整

# 変更の背景
- upstreamマージにより新しく追加されたtiktok-clip-final-pushミッションのfeatured_importance: 1000により、マイク納めミッション(110)の表示順位が下がった
- issue #1224 で要求されたマイク納めの最上位表示を維持するため調整が必要
- https://github.com/team-mirai-volunteer/action-board/issues/1224#issuecomment-3076648278

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました