### PR TITLE
本番デプロイ 07/16 13:12

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -94,7 +94,7 @@ missions:
     required_artifact_type: LINK
     max_achievement_count: null
     is_featured: true
-    featured_importance: 1000
+    featured_importance: 100
     is_hidden: false
     artifact_label: ショート動画のURL（TikTok）
     ogp_image_url: null


### PR DESCRIPTION
refs #1224

- tiktok-clip-final-pushのfeatured_importanceを1000→100に変更
- マイク納めミッション(110)が最上位表示になるよう調整

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました