### PR TITLE
show mased username on history

### DIFF
--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -46,6 +46,7 @@ import {
   calculateProgressRate,
   getCompletedCount,
 } from "@/lib/utils/poster-progress";
+import { maskUsername } from "@/lib/utils/privacy";
 import { ArrowLeft, Copy, HelpCircle, History, MapPin } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -677,6 +678,11 @@ export default function PrefecturePosterMapClient({
                       </div>
                       <div className="text-muted-foreground text-xs">
                         {new Date(item.created_at).toLocaleString("ja-JP")}
+                        {item.user?.name && (
+                          <span className="ml-2">
+                            by {maskUsername(item.user.name)}
+                          </span>
+                        )}
                         {item.note && (
                           <span className="ml-2">「{item.note}」</span>
                         )}

--- a/lib/utils/privacy.test.ts
+++ b/lib/utils/privacy.test.ts
@@ -1,0 +1,28 @@
+import { maskUsername } from "./privacy";
+
+describe("maskUsername", () => {
+  test("masks username with first letter and x's", () => {
+    expect(maskUsername("shota")).toBe("sxxxx");
+    expect(maskUsername("john")).toBe("jxxx");
+    expect(maskUsername("a")).toBe("a");
+    expect(maskUsername("alice")).toBe("axxxx");
+  });
+
+  test("handles empty or null values", () => {
+    expect(maskUsername("")).toBe("");
+    expect(maskUsername(null)).toBe("");
+    expect(maskUsername(undefined)).toBe("");
+  });
+
+  test("preserves the exact length of the username", () => {
+    expect(maskUsername("ab")).toBe("ax");
+    expect(maskUsername("abc")).toBe("axx");
+    expect(maskUsername("verylongusername")).toBe("vxxxxxxxxxxxxxxx");
+  });
+
+  test("handles special characters in first position", () => {
+    expect(maskUsername("@user")).toBe("@xxxx");
+    expect(maskUsername("123user")).toBe("1xxxxxx");
+    expect(maskUsername("日本語")).toBe("日xx");
+  });
+});

--- a/lib/utils/privacy.ts
+++ b/lib/utils/privacy.ts
@@ -1,0 +1,19 @@
+/**
+ * Masks a username for privacy protection
+ * Shows first letter + x's for the length of the remaining username
+ * e.g., "shota" -> "sxxxx", "john" -> "jxxx"
+ *
+ * @param username - The username to mask
+ * @returns The masked username
+ */
+export function maskUsername(username: string | null | undefined): string {
+  if (!username || username.length === 0) {
+    return "";
+  }
+
+  // Get the first character and create x's for the rest
+  const firstChar = username.charAt(0);
+  const maskedRest = "x".repeat(username.length - 1);
+
+  return firstChar + maskedRest;
+}


### PR DESCRIPTION
# 変更の概要
- ポスターマップの履歴にマスクされたユーザーネームを表示するようにした
　- 「ユーザー」→「ユxxx」

# 変更の背景
- 悪意を持って未貼り付けに戻しているユーザーがいる可能性があるため、同一人物化の判定を容易にしたい
- 一方でユーザー側の匿名性は保ちたい

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました