### PR TITLE
マイク納めミッションの最終更新日時表示を削除

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -670,8 +670,7 @@ missions:
       【愛媛】19:00- @松山市大街頭商店街入り口（川端ゆうすけ）
       【福岡】19:30- @天神ワンビル（ワン・フクオカ・ビルディング）前（古川あおい）
 
-      2025/07/17 23:34 現在の情報です。<br>
-      現地の状況によっては、場所・時間が変更になる可能性があります。最新情報は、候補者のXアカウント、または<a href="https://team-mirai.notion.site/7-19-231f6f56bae180cba059c38f7c9e7567" target="_blank" rel="noopener noreferrer">こちらのページ</a>をご確認ください。
+      現地の状況によって、場所・時間が変更になる可能性があります。最新情報は、候補者のXアカウント、または<a href="https://team-mirai.notion.site/7-19-231f6f56bae180cba059c38f7c9e7567" target="_blank" rel="noopener noreferrer">こちらのページ</a>をご確認ください。
 
       ▼公認候補者・SNSアカウント一覧
       https://team-mir.ai/#member


### PR DESCRIPTION
# 変更の概要
- マイク納めミッションに表示されている「2025/07/17 23:34 現在の情報です。」という最終更新日時を削除
- 文言を「現地の状況によっては」から「現地の状況によって」に統一

# 変更の背景
- 更新時刻を更新し忘れやすい
- デプロイのタイミングなど考慮することが多い
- Notionへの誘導があるので、最終更新日時の表示は不要
- closes #1294

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（\"- [ ]\" を \"- [x]\" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました