### PR TITLE
ポスターマップにおいて総数と登録数の表示を入れ替え、用語も変更する

### DIFF
--- a/app/map/poster/PosterMapPageClientOptimized.tsx
+++ b/app/map/poster/PosterMapPageClientOptimized.tsx
@@ -119,15 +119,15 @@ export default function PosterMapPageClientOptimized({
         <CardContent>
           <div className="grid grid-cols-3 gap-4 text-center">
             <div>
-              <div className="text-2xl font-bold">
-                {totalStats.actualTotal.toLocaleString()}
-              </div>
-              <div className="text-sm text-muted-foreground">総掲示板数</div>
               {totalStats.actualTotal > 0 && (
-                <div className="text-xs text-muted-foreground">
-                  (登録済: {totalStats.registeredTotal.toLocaleString()})
+                <div className="text-2xl font-bold">
+                  {totalStats.registeredTotal.toLocaleString()}
                 </div>
               )}
+              <div className="text-sm text-muted-foreground">総掲示板数</div>
+              <div className="text-xs text-muted-foreground">
+                (選管公表数: {totalStats.actualTotal.toLocaleString()})
+              </div>
             </div>
             <div>
               <div className="text-2xl font-bold text-green-600">
@@ -226,15 +226,12 @@ export default function PosterMapPageClientOptimized({
                       <div className="space-y-3">
                         <div className="flex items-center justify-between text-sm">
                           <span className="text-muted-foreground">
-                            掲示板数:{" "}
-                            {actualTotalInPrefecture > 0
-                              ? actualTotalInPrefecture.toLocaleString()
-                              : registeredInPrefecture.toLocaleString()}
+                            掲示板数: {registeredInPrefecture.toLocaleString()}
                             {actualTotalInPrefecture > 0 && (
                               <span className="text-xs">
                                 {" "}
-                                (登録: {registeredInPrefecture.toLocaleString()}
-                                )
+                                (選管公表数:{" "}
+                                {actualTotalInPrefecture.toLocaleString()})
                               </span>
                             )}
                           </span>

--- a/app/map/poster/PosterMapPageClientOptimized.tsx
+++ b/app/map/poster/PosterMapPageClientOptimized.tsx
@@ -126,7 +126,7 @@ export default function PosterMapPageClientOptimized({
               )}
               <div className="text-sm text-muted-foreground">総掲示板数</div>
               <div className="text-xs text-muted-foreground">
-                (選管公表数: {totalStats.actualTotal.toLocaleString()})
+                (公表数: {totalStats.actualTotal.toLocaleString()})
               </div>
             </div>
             <div>
@@ -230,7 +230,7 @@ export default function PosterMapPageClientOptimized({
                             {actualTotalInPrefecture > 0 && (
                               <span className="text-xs">
                                 {" "}
-                                (選管公表数:{" "}
+                                (公表数:{" "}
                                 {actualTotalInPrefecture.toLocaleString()})
                               </span>
                             )}

--- a/app/map/poster/PosterMapPageClientOptimized.tsx
+++ b/app/map/poster/PosterMapPageClientOptimized.tsx
@@ -126,7 +126,7 @@ export default function PosterMapPageClientOptimized({
               )}
               <div className="text-sm text-muted-foreground">総掲示板数</div>
               <div className="text-xs text-muted-foreground">
-                (公表数: {totalStats.actualTotal.toLocaleString()})
+                (公表: {totalStats.actualTotal.toLocaleString()})
               </div>
             </div>
             <div>
@@ -230,7 +230,7 @@ export default function PosterMapPageClientOptimized({
                             {actualTotalInPrefecture > 0 && (
                               <span className="text-xs">
                                 {" "}
-                                (公表数:{" "}
+                                (公表:{" "}
                                 {actualTotalInPrefecture.toLocaleString()})
                               </span>
                             )}

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -446,13 +446,13 @@ export default function PrefecturePosterMapClient({
           {/* 主要統計 */}
           <div className="flex items-baseline gap-4">
             <div className="flex items-baseline gap-1">
-              <span className="text-2xl font-bold">{totalCount}</span>
-              <span className="text-xs text-muted-foreground">総数</span>
               {actualTotalCount > 0 && (
-                <span className="text-xs text-muted-foreground">
-                  (登録: {registeredCount})
-                </span>
+                <span className="text-2xl font-bold">{registeredCount}</span>
               )}
+              <span className="text-xs text-muted-foreground">総数</span>
+              <span className="text-xs text-muted-foreground">
+                (選管公表数: {totalCount})
+              </span>
             </div>
             <div className="flex items-baseline gap-1">
               <span className="text-2xl font-bold text-green-600">

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -451,7 +451,7 @@ export default function PrefecturePosterMapClient({
               )}
               <span className="text-xs text-muted-foreground">総数</span>
               <span className="text-xs text-muted-foreground">
-                (公表数: {totalCount})
+                (公表: {totalCount})
               </span>
             </div>
             <div className="flex items-baseline gap-1">

--- a/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
+++ b/app/map/poster/[prefecture]/PrefecturePosterMapClient.tsx
@@ -451,7 +451,7 @@ export default function PrefecturePosterMapClient({
               )}
               <span className="text-xs text-muted-foreground">総数</span>
               <span className="text-xs text-muted-foreground">
-                (選管公表数: {totalCount})
+                (公表数: {totalCount})
               </span>
             </div>
             <div className="flex items-baseline gap-1">


### PR DESCRIPTION
# 変更の概要
- ポスターマップにおける「総数（総掲示板数、掲示板数）」に表示する目立つ値を、現状の登録数（達成率の分母に使われている数）に変更し、もともと総数として表示されていた値を「公表」として小さく表示させるようにしました。
  - これにより、達成率の計算に用いられている分子と分母の値がそれぞれ目立ち、また総数を完了数が超えることを防げます。

# 変更の背景
- https://team-mirai-volunteer.slack.com/archives/C08UN1G2YCE/p1752795216163339

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクリーンショット
### 適用前
<img width="857" height="841" alt="スクリーンショット 2025-07-18 19 58 42" src="https://github.com/user-attachments/assets/dd8ca0fc-bff9-4e56-bd39-41b4a2e98fb3" />
<img width="845" height="653" alt="スクリーンショット 2025-07-18 19 59 37" src="https://github.com/user-attachments/assets/01ccc905-f8be-4deb-b1ec-d1956ddc1251" />

### 適用後
<img width="836" height="846" alt="スクリーンショット 2025-07-19 0 45 22" src="https://github.com/user-attachments/assets/e2101ddc-036b-42d3-89c3-46f9930232cc" />
<img width="844" height="654" alt="スクリーンショット 2025-07-19 0 45 32" src="https://github.com/user-attachments/assets/c55e4a30-87a5-4c24-94c6-74e0f1ffc640" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UIの改善**
  * 掲示板数の表示とラベルを調整し、登録総数をより目立つ形で表示するようになりました。
  * 実際の総数（選管公表数）は小さめの文字で補足的に表示されます。
  * 都道府県リストや統計カードでも同様のラベル・表示順の変更が適用されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->