### PR TITLE
#1189: 累計ポイント数の表示

### DIFF
--- a/components/levels.tsx
+++ b/components/levels.tsx
@@ -47,6 +47,11 @@ export default async function Levels({
               {profile.address_prefecture}
             </div>
           </div>
+          <div className="flex items-center mt-2 text-sm text-gray-600">
+            <div>
+              {userLevel ? userLevel.xp.toLocaleString() : "0"} ポイント
+            </div>
+          </div>
         </div>
       </div>
       {showBadge && (

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -246,9 +246,11 @@ jest.mock("react-dom", () => ({
 jest.mock("@/lib/services/userLevel", () => ({
   getUserLevel: jest.fn(() =>
     Promise.resolve({
+      user_id: "test-user-id",
       level: 2,
-      current_xp: 100,
-      xp_to_next_level: 200,
+      xp: 100,
+      last_notified_level: 1,
+      updated_at: "2023-01-01T00:00:00Z",
     }),
   ),
 }));

--- a/tests/e2e/user-mission.spec.ts
+++ b/tests/e2e/user-mission.spec.ts
@@ -11,7 +11,7 @@ test.describe('アクションボード（Web版）のe2eテスト', () => {
     await assertAuthState(signedInPage, true);
 
     // 自身のステータス表示を確認
-    await expect(signedInPage.locator('section').getByText('テストユーザーLV.1東京都次のレベルまで40ポイント')).toBeVisible({ timeout: 10000 });
+    await expect(signedInPage.locator('section').getByText('テストユーザーLV.1東京都0 ポイント次のレベルまで40ポイント')).toBeVisible({ timeout: 10000 });
     await expect(signedInPage.getByRole('link', { name: 'テストユーザーさんのプロフィールへ' })).toBeVisible();
 
     // 活動状況の表示を確認
@@ -138,7 +138,7 @@ test.describe('アクションボード（Web版）のe2eテスト', () => {
     await signedInPage.goto('/');
     await expect(signedInPage.getByRole('dialog', { name: 'サポーターレベルが アップしました！' })).toBeVisible();
     await signedInPage.getByRole('button', { name: 'Close' }).click();
-    await expect(signedInPage.locator('section').getByText('テストユーザーLV.9東京都次のレベルまで100ポイント')).toBeVisible({ timeout: 10000 });
+    await expect(signedInPage.locator('section').getByText('テストユーザーLV.9東京都800 ポイント次のレベルまで100ポイント')).toBeVisible({ timeout: 10000 });
 
     await signedInPage.goto('/ranking');
     await signedInPage.getByRole('button', { name: '全期間' }).click();
@@ -159,7 +159,7 @@ test.describe('アクションボード（Web版）のe2eテスト', () => {
     await signedInPage.waitForTimeout(2000);
 
     await signedInPage.goto('/');
-    await expect(signedInPage.locator('section').getByText('テストユーザーLV.1東京都次のレベルまで40ポイント')).toBeVisible({ timeout: 10000 });
+    await expect(signedInPage.locator('section').getByText('テストユーザーLV.1東京都0 ポイント次のレベルまで40ポイント')).toBeVisible({ timeout: 10000 });
   });
 
   test('TOP100ランキング - 全タブ遷移が正常に動作する', async ({


### PR DESCRIPTION
# 変更の概要
- ホーム`/`およびマイページ`/users/user.id` に累計ポイント数を表示します
<img src="https://github.com/user-attachments/assets/a450bada-2f3b-4ec0-bf8d-3d6735960bc7" alt="スクリーンショット 2025-07-18 22 56 58" width="700px">
<img src="https://github.com/user-attachments/assets/671885f4-eb4d-4c51-92fe-66291546e044" alt="スクリーンショット 2025-07-18 22 57 14" width="500px">
<img src="https://github.com/user-attachments/assets/b3a35095-1884-408b-a6b2-6ef6ed2e2ef3" alt="スクリーンショット 2025-07-18 22 57 33" width="700px">


# 変更の背景
- 累計ポイントはラインキングのページで全期間にすることで確認できるものの、気軽に確認できない
- closes #1189 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新機能**
  * ユーザープロフィールカードに、ユーザーの経験値（XP）を「〇〇 ポイント」として表示する要素を追加しました。データがない場合は「0 ポイント」と表示されます。
  * アクションボードページのユーザーステータス表示に現在のポイント数を明示的に含めるように更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->