### PR TITLE
#1276: 登録済みのメールアドレスで新規登録しようとしたときに登録済みである旨のエラーを追加

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -100,10 +100,33 @@ export const signUpActionWithState = async (
       emailRedirectTo: `${origin}/auth/callback`,
     },
   });
+
+  if (error) {
+    // メールアドレスが既に使用されている場合
+    if (
+      error.message.includes("already registered") ||
+      error.message.includes("already exists")
+    ) {
+      return {
+        error:
+          "このメールアドレスは既に登録されています。ログインページからログインしてください。",
+        formData: currentFormData,
+      };
+    }
+    return {
+      error: "ユーザー登録に失敗しました",
+      formData: currentFormData,
+    };
+  }
+
   //サインアップ完了後にuserIdを取得
   const userId = data?.user?.id;
   if (!userId) {
-    return { error: "ユーザー登録に失敗しました", formData: currentFormData };
+    return {
+      error:
+        "アカウント作成処理でエラーが発生しました。しばらく時間をおいて再度お試しください。",
+      formData: currentFormData,
+    };
   }
 
   //紹介URLから遷移した場合のみ以下を実行


### PR DESCRIPTION
# 変更の概要
- 既に登録されているメールアドレスの場合に表示するメッセージを変更した
<img src="https://github.com/user-attachments/assets/07687286-35f5-4a46-af2a-9fa5c103f81c" alt="スクリーンショット 2025-07-19 9 57 15" width="700px">
<img src="https://github.com/user-attachments/assets/88361891-409b-46f3-b799-3f15892e1f2b" alt="スクリーンショット 2025-07-19 9 57 31" width="300px">

# 変更の背景
- 既に登録済みであるメールアドレスであることがわからない
- closes #1276

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * サインアップ時のエラー表示がより分かりやすくなりました。既に登録済みのメールアドレスの場合は、ログインを促すメッセージが表示されます。
  * その他のエラー時にも、より具体的なエラーメッセージが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->