### PR TITLE
#1036: ユーザーページの「ミッション達成状況」から各ミッションにリンクさせる

### DIFF
--- a/components/user-mission-achievements/index.tsx
+++ b/components/user-mission-achievements/index.tsx
@@ -21,6 +21,7 @@ export function UserMissionAchievements({
         {achievements.map((achievement) => (
           <MissionAchievementCard
             key={achievement.mission_id}
+            missionId={achievement.mission_id}
             title={achievement.mission_title}
             count={achievement.achievement_count}
           />

--- a/components/user-mission-achievements/mission-card.tsx
+++ b/components/user-mission-achievements/mission-card.tsx
@@ -1,25 +1,30 @@
 import { Card } from "@/components/ui/card";
+import Link from "next/link";
 
 interface MissionAchievementCardProps {
+  missionId: string;
   title: string;
   count: number;
 }
 
 export function MissionAchievementCard({
+  missionId,
   title,
   count,
 }: MissionAchievementCardProps) {
   return (
-    <Card className="p-4">
-      <div className="flex justify-between items-center">
-        <div className="text-sm font-bold text-gray-700 flex-1 min-w-0 truncate">
-          {title}
+    <Link href={`/missions/${missionId}`}>
+      <Card className="p-4 cursor-pointer hover:shadow-md transition-shadow">
+        <div className="flex justify-between items-center">
+          <div className="text-sm font-bold text-gray-700 flex-1 min-w-0 truncate">
+            {title}
+          </div>
+          <div className="flex items-baseline gap-2 ml-4">
+            <span className="text-2xl font-bold text-teal-600">{count}</span>
+            <span className="text-base font-bold text-gray-700">回</span>
+          </div>
         </div>
-        <div className="flex items-baseline gap-2 ml-4">
-          <span className="text-2xl font-bold text-teal-600">{count}</span>
-          <span className="text-base font-bold text-gray-700">回</span>
-        </div>
-      </div>
-    </Card>
+      </Card>
+    </Link>
   );
 }


### PR DESCRIPTION
# 変更の概要
- ユーザーページの「ミッション達成状況」から各ミッションに遷移できるようにしました
（ホバー時）
<img src="https://github.com/user-attachments/assets/9234d4a2-7db9-429a-ab98-30cc04f2f09d" alt="スクリーンショット 2025-07-19 10 31 15" width="500px">

# 変更の背景
- 複数回実施できるミッションにユーザーページから遷移できると便利
- closes #1036

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ミッション達成カードがクリック可能になり、各カードをクリックすると対応するミッション詳細ページ（/missions/{missionId}）へ移動できるようになりました。
  * カードにホバー時の視覚効果が追加され、インタラクティブ性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->