### PR TITLE
#1222: ミッション「Xでチームみらいの投稿をリポストしよう」に「6月15日（日）開催」と記載されている

### DIFF
--- a/supabase/migrations/20250719025501_fix_x-repost_event_date.sql
+++ b/supabase/migrations/20250719025501_fix_x-repost_event_date.sql
@@ -1,0 +1,6 @@
+UPDATE "public"."missions"
+SET 
+    "event_date" = null,
+    "updated_at" = NOW()
+WHERE 
+    "slug" = 'x-repost';


### PR DESCRIPTION
# 変更の概要
- evant_date を null にしました
<table>
    <thead>
        <tr>
            <th class="after">修正後 (After)</th>
            <th class="before">修正前 (Before)</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td class="after">
                <img src="https://github.com/user-attachments/assets/d742d981-58e0-41d0-86a9-48d485959ab4" alt="修正後スクリーンショット 1">
            </td>
            <td class="before">
                <img src="https://github.com/user-attachments/assets/65258315-d01b-4010-98ed-d2a2ff9b7a55" alt="修正前スクリーンショット 1">
            </td>
        </tr>
        <tr>
            <td class="after">
                <img src="https://github.com/user-attachments/assets/1cfb97c2-87c9-4580-b8a8-ca6ad913592d" alt="修正後スクリーンショット 2">
            </td>
            <td class="before">
                <img src="https://github.com/user-attachments/assets/483a3e15-4bed-40e4-8661-90443d36c87e" alt="修正前スクリーンショット 2">
            </td>
        </tr>
    </tbody>
</table>

# 変更の背景
- 表示が不要である
- closes #1222

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 「x-repost」ミッションのイベント日付がリセットされ、最新の更新日時が反映されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->