### PR TITLE
ArtifactForm.test.tsx を修正

### DIFF
--- a/components/mission/ArtifactForm.test.tsx
+++ b/components/mission/ArtifactForm.test.tsx
@@ -127,7 +127,7 @@ describe("ArtifactForm", () => {
       />,
     );
 
-    expect(screen.getByText("ポスティング")).toBeInTheDocument();
+    expect(screen.getByText("ポスティング・配布枚数")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("例：50")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("例：1540017")).toBeInTheDocument();
   });


### PR DESCRIPTION
# 変更の概要
- fail しているテストを修正
<details>

<summary>ログ</summary>

```
FAIL components/mission/ArtifactForm.test.tsx
  ● ArtifactForm › POSTINGタイプの場合はポスティング入力フォームが表示される

    TestingLibraryElementError: Unable to find an element with the text: ポスティング. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.

    Ignored nodes: comments, script, style
    <body>
      <div>
        <div
          class="rounded-lg border bg-card text-card-foreground shadow-sm"
        >
          <div
            class="flex flex-col space-y-1.5 p-6"
          >
            <div
              class="font-semibold tracking-tight text-lg text-center"
            >
              ミッション完了を記録しよう
            </div>
            <p
              class="text-sm text-muted-foreground"
                <label
                  class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                  for="locationText"
                >
                  ポスティング・配布場所の郵便番号（ハイフンなし）
                </label>
                <input
                  class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                  id="locationText"
                  maxlength="100"
                  name="locationText"
                  placeholder="例：1540017"
                  type="text"
                />
                <p
                  class="text-xs text-gray-500"
                >
                  対象エリアの郵便番号をご入力ください
                </p>
              </div>
            </div>
            <div
              class="space-y-2"
            >
              <label
                class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                for="artifactDescription"
              >
                補足説明 (任意)
              </label>
              <textarea
                class="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                id="artifactDescription"
                name="artifactDescription"
                placeholder="達成内容に関して補足説明があれば入力してください"
                rows="3"
              />
            </div>
          </div>
        </div>
      </div>
    </body>

      128 |     );
      129 |
    > 130 |     expect(screen.getByText("ポスティング")).toBeInTheDocument();
          |                   ^
      131 |     expect(screen.getByPlaceholderText("例：50")).toBeInTheDocument();
      132 |     expect(screen.getByPlaceholderText("例：1540017")).toBeInTheDocument();
      133 |   });

      at Object.getElementError (node_modules/@testing-library/dom/dist/config.js:37:19)
      at node_modules/@testing-library/dom/dist/query-helpers.js:76:38
      at node_modules/@testing-library/dom/dist/query-helpers.js:52:17
      at node_modules/@testing-library/dom/dist/query-helpers.js:95:19
      at Object.getByText (components/mission/ArtifactForm.test.tsx:130:19)


Test Suites: 1 failed, 64 passed, 65 total
Tests:       1 failed, 651 passed, 652 total
Snapshots:   0 total
Time:        18.355 s
Ran all test suites.
Error: Process completed with exit code 1.
```
</details>
# 変更の背景
- テストがfailしている
- closes なし

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました