### PR TITLE
#1262: 期日前投票ミッションの説明文に選挙区候補者を記入する

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -595,7 +595,7 @@ missions:
   - slug: early-vote
     title: 期日前投票をしよう！
     icon_url: /img/mission-icons/actionboard_icon_work_20250713_ol_early-vote.svg
-    content: 予定が合わない方も安心！「期日前投票」は、選挙日の前でも投票できる便利な制度です。<br>忙しい方や当日行けない方も、あなたの大切な一票を無理なく投じることができます。<br>みんなで投票率アップを目指そう！
+    content: 予定が合わない方も安心！「期日前投票」は、選挙日の前でも投票できる便利な制度です。<br>忙しい方や当日行けない方も、あなたの大切な一票を無理なく投じることができます。<br>みんなで投票率アップを目指そう！<br><br>■選挙区候補者<br>北海道　：稲原 むねよし<br>宮城県　：角野 なすか<br>長野県　：山田 ゆうじ<br>埼玉県　：武藤 かずこ<br>千葉県　：小林 しゅうへい<br>東京都　：みねしま 侑也<br>神奈川県：河合 みちお<br>愛知県　：山根 ゆきや<br>大阪府　：平 りさこ<br>兵庫県　：前田 みさ<br>愛媛県　：川端 ゆうすけ<br>福岡県　：古川 あおい<br><br>■比例代表候補者<br>安野 たかひろ<br>高山 さとし<br>須田 えいたろう
     difficulty: 5
     required_artifact_type: NONE
     max_achievement_count: 1


### PR DESCRIPTION
# 変更の概要
- ミッションの説明文に選挙区候補者を追加
- 比例の3人も追加
- 候補者の一覧は以下ページ参照しました
  - https://team-mirai.notion.site/7-19-231f6f56bae180cba059c38f7c9e7567#231f6f56bae180b8923ee162c0588405

<img src="https://github.com/user-attachments/assets/2520e571-9530-4964-a25f-aefe78825e3d" width="500px" alt="スクリーンショット 2025-07-19 13 32 25">
<img src="https://github.com/user-attachments/assets/2052a0d9-cbb5-44dc-ae7b-985945d738bc" width="500px" alt="スクリーンショット 2025-07-19 13 32 43">

# 変更の背景
- `愛知県で投票したいのに、チームみらいの立候補者がいない。`というご意見箱意見あり
- closes #1262

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 「期日前投票」ミッションの説明文に、選挙区ごとの候補者一覧と比例代表候補者リストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->