### PR TITLE
#1285: 複数回記録できることをわかりやすくする

### DIFF
--- a/app/missions/[id]/_components/MissionFormWrapper.tsx
+++ b/app/missions/[id]/_components/MissionFormWrapper.tsx
@@ -302,7 +302,9 @@ export function MissionFormWrapper({
           mission.max_achievement_count === null)) && (
         <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center">
           <p className="text-sm font-medium text-gray-800">
-            このミッションは達成済みです。
+            {mission.max_achievement_count === null
+              ? "このミッションは何度でもチャレンジできます。"
+              : "このミッションはすでに達成済みです。"}
           </p>
           <div className="flex flex-col gap-2 mt-2">
             <Button

--- a/app/missions/[id]/_components/MissionFormWrapper.tsx
+++ b/app/missions/[id]/_components/MissionFormWrapper.tsx
@@ -304,7 +304,7 @@ export function MissionFormWrapper({
           <p className="text-sm font-medium text-gray-800">
             {mission.max_achievement_count === null
               ? "このミッションは何度でもチャレンジできます。"
-              : "このミッションはすでに達成済みです。"}
+              : "このミッションは達成済みです。"}
           </p>
           <div className="flex flex-col gap-2 mt-2">
             <Button


### PR DESCRIPTION
# 変更の概要
- 複数回可能なミッションでは `このミッションはすでに達成済みです。` ではなく　`このミッションは何度でもチャレンジできます。` と表示するようにしました

複数回可能なミッションの場合
![スクリーンショット 2025-07-19 14 34 25](https://github.com/user-attachments/assets/f693f9fc-d80a-489c-8de5-a42493faa2e7)
1度のみの場合（変更なし）
![スクリーンショット 2025-07-19 14 38 12](https://github.com/user-attachments/assets/2f049bfe-95b0-4dcb-9a2d-27e80582e9e3)

# 変更の背景
- 複数回可能なミッションで複数回行ってよいことがわかりづらい
- closes #1285 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新機能**
  * ミッションの達成状況に応じて表示されるメッセージが動的になりました。達成回数が無制限の場合は「このミッションは何度でもチャレンジできます。」、それ以外は「このミッションはすでに達成済みです。」と表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->