### PR TITLE
ミッション詳細ページにおける達成履歴をはじめは少なく表示

### DIFF
--- a/app/missions/[id]/_components/SubmissionHistory.tsx
+++ b/app/missions/[id]/_components/SubmissionHistory.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type React from "react";
+import { useState } from "react";
 import CancelSubmissionDialog from "./CancelSubmissionDialog";
 import SubmissionItem from "./SubmissionItem";
 import type { Submission } from "./types";
@@ -38,11 +39,18 @@ const SubmissionHistory: React.FC<SubmissionHistoryProps> = ({
       new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   );
 
+  // 5件ずつ表示するためのstate
+  const [showAll, setShowAll] = useState(false);
+
+  const displayedSubmissions = showAll
+    ? sortedSubmissions
+    : sortedSubmissions.slice(0, 5);
+
   return (
     <div className="mt-8">
       <h2 className="text-xl font-semibold mb-4">あなたの達成履歴</h2>
       <ul className="space-y-4">
-        {sortedSubmissions.map((submission, index) => (
+        {displayedSubmissions.map((submission, index) => (
           <SubmissionItem
             key={submission.id}
             submission={submission}
@@ -52,6 +60,19 @@ const SubmissionHistory: React.FC<SubmissionHistoryProps> = ({
           />
         ))}
       </ul>
+
+      {!showAll && sortedSubmissions.length > 5 && (
+        <div className="flex justify-center mt-4">
+          <button
+            className="px-4 py-2 rounded bg-gray-100 hover:bg-gray-200"
+            onClick={() => setShowAll(true)}
+            type="button"
+            data-testid="show-all-achievement"
+          >
+            すべて見る
+          </button>
+        </div>
+      )}
 
       <CancelSubmissionDialog
         isOpen={isDialogOpen}


### PR DESCRIPTION
# 変更の概要
- ミッション詳細ページにおいて、「あなたの達成履歴」をデフォルトでは5件のみ表示
- 「すべて見る」ボタンを追加し、それを押した場合に達成履歴をすべて表示する
- これによりその下のランキング情報までたくさんスクロールする必要がなくなりました

# 変更の背景
- closes #1274

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクリーンショット
<img width="692" height="868" alt="スクリーンショット 2025-07-19 16 52 14" src="https://github.com/user-attachments/assets/b861e7eb-842d-4c7b-b1d9-0fc229d32c38" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 提出履歴が5件まで表示され、ボタン「すべて見る」を押すと全件を表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->