### PR TITLE
サービス終了の注意書きを追加

### DIFF
--- a/app/oldHome.tsx
+++ b/app/oldHome.tsx
@@ -1,3 +1,4 @@
+import NoticeBoardAlert from "@/components/NoticeBoardAlert";
 import Activities from "@/components/activities";
 import { BadgeNotificationCheck } from "@/components/badge-notification-check";
 import Hero from "@/components/hero";
@@ -68,6 +69,9 @@ export default async function Home({
 
   return (
     <div className="flex flex-col min-h-screen">
+      {/* 注意書き */}
+      <NoticeBoardAlert />
+
       {/* レベルアップ通知 */}
       {levelUpNotification && (
         <LevelUpCheck levelUpData={levelUpNotification} />

--- a/components/NoticeBoardAlert.tsx
+++ b/components/NoticeBoardAlert.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+export default function NoticeBoardAlert() {
+  return (
+    <div className="flex justify-center w-full mt-8">
+      <div
+        className="w-full max-w-xl bg-yellow-50 text-yellow-900 p-4 mb-8 flex items-center gap-3"
+        role="alert"
+      >
+        <svg
+          className="w-6 h-6 text-yellow-500 flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+          role="img"
+          aria-label="お知らせ"
+        >
+          <title>お知らせ</title>
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="2"
+            fill="white"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 8v4m0 4h.01"
+          />
+        </svg>
+        <div className="flex-1 min-w-0">
+          <span className="break-words">
+            アクションボードは{" "}
+            <span className="font-semibold">7/19(土) 23:59</span>{" "}
+            をもってサービスを終了します。
+            <br className="hidden sm:block" />
+            ミッション達成報告はお早めに！
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 変更の概要
- アクションボードは 7/19(土) 23:59 をもってサービスを終了する旨の注意書きを追加しました

# 変更の背景
- サービスが終了するため

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# スクリーンショット
<img width="899" height="525" alt="スクリーンショット 2025-07-19 23 01 22" src="https://github.com/user-attachments/assets/eee1f5ef-58f1-474e-8c11-e79853793dee" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 「Action Board」サービス終了のお知らせを表示するアラートをホーム画面上部に追加しました。サービスは7月19日23:59に終了します。お早めのミッション完了報告を推奨しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->