### PR TITLE
バッジのシーズン対応もれを修正

### DIFF
--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -11,6 +11,7 @@ import { getUnnotifiedBadges } from "@/features/user-badges/services/get-unnotif
 import { generateRootMetadata } from "@/lib/metadata";
 import { checkLevelUpNotification } from "@/lib/services/levelUpNotification";
 import { hasFeaturedMissions } from "@/lib/services/missions";
+import { getCurrentSeasonId } from "@/lib/services/seasons";
 import { createClient } from "@/lib/supabase/client";
 import { redirect } from "next/navigation";
 
@@ -44,6 +45,9 @@ export default async function Home({
       redirect("/settings/profile?new=true");
     }
 
+    // 現在のシーズンIDを取得
+    const currentSeasonId = await getCurrentSeasonId();
+
     // レベルアップ通知をチェック
     // 自動ミッション（紹介など）でレベルアップした場合の通知を表示するため有効化
     const levelUpCheck = await checkLevelUpNotification(user.id);
@@ -51,8 +55,11 @@ export default async function Home({
       levelUpNotification = levelUpCheck.levelUp;
     }
 
-    // バッジ通知をチェック
-    const unnotifiedBadges = await getUnnotifiedBadges(user.id);
+    // バッジ通知をチェック（現在のシーズンのみ）
+    const unnotifiedBadges = await getUnnotifiedBadges(
+      user.id,
+      currentSeasonId ?? undefined,
+    );
     if (unnotifiedBadges.length > 0) {
       badgeNotifications = unnotifiedBadges;
     }

--- a/src/features/user-badges-calculation/calculate-badges.ts
+++ b/src/features/user-badges-calculation/calculate-badges.ts
@@ -93,6 +93,7 @@ async function calculateAllRankingBadges(seasonId?: string): Promise<{
         badge_type: "ALL",
         sub_type: null,
         rank: user.rank,
+        season_id: targetSeasonId,
       });
 
       if (result.updated) {
@@ -164,6 +165,7 @@ async function calculateDailyRankingBadges(seasonId?: string): Promise<{
         badge_type: "DAILY",
         sub_type: null,
         rank: user.rank,
+        season_id: targetSeasonId,
       });
 
       if (result.updated) {
@@ -220,6 +222,7 @@ async function calculatePrefectureRankingBadges(seasonId?: string): Promise<{
           badge_type: "PREFECTURE",
           sub_type: prefecture,
           rank: user.rank,
+          season_id: targetSeasonId,
         });
 
         if (result.updated) {
@@ -292,6 +295,7 @@ async function calculateMissionRankingBadges(seasonId?: string): Promise<{
           badge_type: "MISSION",
           sub_type: mission.slug,
           rank: user.rank,
+          season_id: targetSeasonId,
         });
 
         if (result.updated) {
@@ -315,16 +319,21 @@ async function updateBadge({
   badge_type,
   sub_type,
   rank,
-}: BadgeUpdateParams): Promise<{ success: boolean; updated: boolean }> {
+  season_id,
+}: BadgeUpdateParams & { season_id: string }): Promise<{
+  success: boolean;
+  updated: boolean;
+}> {
   const supabaseAdmin = await createAdminClient();
 
   try {
-    // 既存バッジを確認
+    // 既存バッジを確認（シーズンとタイプで検索）
     const query = supabaseAdmin
       .from("user_badges")
       .select("*")
       .eq("user_id", user_id)
-      .eq("badge_type", badge_type);
+      .eq("badge_type", badge_type)
+      .eq("season_id", season_id);
 
     // sub_typeがnullの場合とそうでない場合で処理を分ける
     if (sub_type === null) {
@@ -350,6 +359,7 @@ async function updateBadge({
           badge_type,
           sub_type,
           rank,
+          season_id,
           achieved_at: new Date().toISOString(),
           is_notified: false,
         });

--- a/src/features/user-badges/badge-types.ts
+++ b/src/features/user-badges/badge-types.ts
@@ -6,6 +6,7 @@ export interface UserBadge {
   badge_type: BadgeType;
   sub_type: string | null;
   rank: number;
+  season_id: string;
   achieved_at: string;
   is_notified: boolean;
   created_at: string;

--- a/src/features/user-badges/services/get-unnotified-badges.ts
+++ b/src/features/user-badges/services/get-unnotified-badges.ts
@@ -7,15 +7,22 @@ import { enrichMissionBadges } from "./helpers";
  */
 export async function getUnnotifiedBadges(
   userId: string,
+  seasonId?: string,
 ): Promise<UserBadge[]> {
   const supabaseAdmin = await createAdminClient();
 
-  const { data, error } = await supabaseAdmin
+  let query = supabaseAdmin
     .from("user_badges")
     .select("*")
     .eq("user_id", userId)
-    .eq("is_notified", false)
-    .order("created_at", { ascending: false });
+    .eq("is_notified", false);
+
+  // seasonIdが指定された場合はそのシーズンのバッジのみ取得
+  if (seasonId) {
+    query = query.eq("season_id", seasonId);
+  }
+
+  const { data, error } = await query.order("created_at", { ascending: false });
 
   if (error) {
     console.error("Error fetching unnotified badges:", error);


### PR DESCRIPTION
- バッジ作成時ににシーズンが入らないのを修正
- バッジ通知は現在シーズンのバッジのみに

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  - バッジ通知を現在シーズンに限定し、過去シーズンの未通知分は除外します。
  - ランキング系バッジをシーズン単位で集計・更新し、シーズンごとの実績を明確化します。
  - 現在シーズンはログイン後に自動判定され、対象バッジのみ取得します。
  - 通知一覧の並び順や表示は従来通りで、既存ユーザーの利用フローに影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->