### PR TITLE
youtubeチャンネルリンクを差し替え

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -127,7 +127,7 @@ missions:
   - slug: youtube-subscribe
     title: 公式YouTubeチャンネルを登録しよう
     icon_url: /img/mission-icons/actionboard_icon_work_20250713_ol_youtube-subscribe.svg
-    content: AIや政治の話をもっとわかりやすく。<a href="https://www.youtube.com/channel/UCiMwbmcCSMORJ-85XWhStBw" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>を登録して、政策解説、候補者のトーク、生配信アーカイブなど、多彩な動画をチェックしよう！難しそうな話題もわかりやすく解説しています。
+    content: AIや政治の話をもっとわかりやすく。<a href="https://youtube.com/channel/UC72A_x2FKHkJ8Nc2eIzqj8Q?si=iVd31cFccDfsEvL0" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>を登録して、政策解説、候補者のトーク、生配信アーカイブなど、多彩な動画をチェックしよう！難しそうな話題もわかりやすく解説しています。
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1
@@ -324,7 +324,7 @@ missions:
   - slug: youtube-watch
     title: YouTube動画を視聴しよう
     icon_url: /img/mission-icons/actionboard_icon_work_20250713_ol_youtube-watch.svg
-    content: <a href="https://www.youtube.com/channel/UCiMwbmcCSMORJ-85XWhStBw" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>でチームみらいの活動や政策解説、候補者のトーク、生配信アーカイブを視聴しよう！政治のことをわかりやすく解説してお届けしています。日本の政治を考えるヒントがきっと見つかるはず。まずは気になる動画から、ぜひご覧ください。動画の内容が気に入ったら高評価をお願いします！
+    content: <a href="https://youtube.com/channel/UC72A_x2FKHkJ8Nc2eIzqj8Q?si=iVd31cFccDfsEvL0" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>でチームみらいの活動や政策解説、候補者のトーク、生配信アーカイブを視聴しよう！政治のことをわかりやすく解説してお届けしています。日本の政治を考えるヒントがきっと見つかるはず。まずは気になる動画から、ぜひご覧ください。動画の内容が気に入ったら高評価をお願いします！
     difficulty: 1
     required_artifact_type: LINK
     max_achievement_count: null
@@ -629,7 +629,7 @@ missions:
   - slug: youtube-comment
     title: YouTube動画にコメントしよう
     icon_url: /img/mission-icons/actionboard_icon_work_20250713_ol_youtube-watch.svg
-    content: <a href="https://www.youtube.com/channel/UCiMwbmcCSMORJ-85XWhStBw" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>やチームみらい関連の動画を視聴して、ぜひコメントを残してみてください！あなたの感想や意見が、次の動画制作の参考になります。動画の内容が気に入ったら高評価もお願いします！<br><br><a href="https://www.youtube.com/results?search_query=%E3%83%81%E3%83%BC%E3%83%A0%E3%81%BF%E3%82%89%E3%81%84" target="_blank" rel="noopener noreferrer">「チームみらい」で検索</a>
+    content: <a href="https://youtube.com/channel/UC72A_x2FKHkJ8Nc2eIzqj8Q?si=iVd31cFccDfsEvL0" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>やチームみらい関連の動画を視聴して、ぜひコメントを残してみてください！あなたの感想や意見が、次の動画制作の参考になります。動画の内容が気に入ったら高評価もお願いします！<br><br><a href="https://www.youtube.com/results?search_query=%E3%83%81%E3%83%BC%E3%83%A0%E3%81%BF%E3%82%89%E3%81%84" target="_blank" rel="noopener noreferrer">「チームみらい」で検索</a>
     difficulty: 2
     required_artifact_type: LINK
     max_achievement_count: null
@@ -640,7 +640,7 @@ missions:
   - slug: youtube-comment-reaction
     title: YouTube動画のコメントにリアクションしよう
     icon_url: /img/mission-icons/actionboard_icon_work_20250713_ol_youtube-watch.svg
-    content: <a href="https://www.youtube.com/channel/UCiMwbmcCSMORJ-85XWhStBw" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>やチームみらい関連の動画で他の視聴者のコメントに「いいね」や「返信」をして、コミュニケーションを楽しもう！あなたのリアクションが、動画コミュニティをより活性化させます。<br><br><a href="https://www.youtube.com/results?search_query=%E3%83%81%E3%83%BC%E3%83%A0%E3%81%BF%E3%82%89%E3%81%84" target="_blank" rel="noopener noreferrer">「チームみらい」で検索</a>
+    content: <a href="https://youtube.com/channel/UC72A_x2FKHkJ8Nc2eIzqj8Q?si=iVd31cFccDfsEvL0" target="_blank" rel="noopener noreferrer">チームみらいの公式YouTubeチャンネル</a>やチームみらい関連の動画で他の視聴者のコメントに「いいね」や「返信」をして、コミュニケーションを楽しもう！あなたのリアクションが、動画コミュニティをより活性化させます。<br><br><a href="https://www.youtube.com/results?search_query=%E3%83%81%E3%83%BC%E3%83%A0%E3%81%BF%E3%82%89%E3%81%84" target="_blank" rel="noopener noreferrer">「チームみらい」で検索</a>
     difficulty: 1
     required_artifact_type: LINK
     max_achievement_count: null

--- a/src/components/mission/MissionDetails.tsx
+++ b/src/components/mission/MissionDetails.tsx
@@ -52,7 +52,7 @@ export function MissionDetails({
         />
 
         {/* YouTubeチャンネル登録ミッションの場合のみ、YouTube登録ボタンを表示 */}
-        {mission.id === YOUTUBE_MISSION_CONFIG.MISSION_ID && (
+        {mission.slug === YOUTUBE_MISSION_CONFIG.SLUG && (
           <div className="flex justify-center mt-6">
             <YouTubeSubscribeButton
               channelId={YOUTUBE_MISSION_CONFIG.CHANNEL_ID}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,10 +6,10 @@ export const POSTER_POINTS_PER_UNIT = 400;
 
 // YouTubeチャンネル登録ミッションの設定
 export const YOUTUBE_MISSION_CONFIG = {
-  // YouTubeチャンネル登録ミッションID
-  MISSION_ID: "9071a1eb-e272-43be-9c6b-e08b258a41c3",
+  // YouTubeチャンネル登録ミッションslug
+  SLUG: "youtube-subscribe",
   // 安野たかひろYouTubeチャンネルID
-  CHANNEL_ID: "UCiMwbmcCSMORJ-85XWhStBw",
+  CHANNEL_ID: "UC72A_x2FKHkJ8Nc2eIzqj8Q",
 } as const;
 
 // ポスティングミッションでの最大枚数

--- a/src/lib/links/index.ts
+++ b/src/lib/links/index.ts
@@ -17,8 +17,7 @@ export const EXTERNAL_LINKS = {
   // SNSアカウント
   x_team_mirai: "https://x.com/team_mirai_jp",
   x_anno_takahiro: "https://x.com/takahiroanno",
-  youtube_team_mirai:
-    "https://www.youtube.com/channel/UCiMwbmcCSMORJ-85XWhStBw",
+  youtube_team_mirai: "https://youtube.com/channel/UC72A_x2FKHkJ8Nc2eIzqj8Q",
   line_team_mirai:
     "https://line.me/R/ti/p/@465hhyop?oat_content=url&ts=05062204",
   note_anno_takahiro: "https://note.com/annotakahiro24",


### PR DESCRIPTION
安野さん個人チャンネルから公式チャンネルに変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - ミッションの入力ラベルを修正（YouTubeアカウント名、コメントした/リアクションした動画のURL などの表記を統一）

- 雑務
  - 公式YouTubeチャンネルのリンクを新URLに更新（複数ミッションおよび外部リンクで反映）

- リファクタ
  - YouTube購読ボタンの判定をIDからスラッグ基準に変更
  - 設定値をスラッグ＋チャンネルID構成に更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->