### PR TITLE
バッジ通知でバッジが大量にあった場合閉じれない問題を修正

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -579,7 +579,7 @@ missions:
     max_achievement_count: null
     is_featured: false
     is_hidden: false
-    artifact_label: 一番応援したくなった投稿のURL
+    artifact_label: 投稿のURL
     ogp_image_url: null
   - slug: design-create
     title: 'チームみらいのデザインクリエイティブをお手伝いしよう'

--- a/src/features/user-badges-notification/components/badge-notification-dialog.tsx
+++ b/src/features/user-badges-notification/components/badge-notification-dialog.tsx
@@ -26,7 +26,7 @@ export function BadgeNotificationDialog({
 }: BadgeNotificationDialogProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md max-h-[80vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Award className="h-5 w-5 text-emerald-600" />
@@ -38,12 +38,16 @@ export function BadgeNotificationDialog({
             ランキングで上位に入り、新しいバッジを獲得しました。
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-3 py-4">
-          {badges.map((item) => (
-            <BadgeItem key={item.id} badge={item} className="w-fit" />
+        <div className="flex flex-col gap-3 py-4 overflow-y-auto flex-1 max-h-[40vh]">
+          {badges.map((item, index) => (
+            <BadgeItem
+              key={`${item.id}-${index}`}
+              badge={item}
+              className="w-fit"
+            />
           ))}
         </div>
-        <DialogFooter>
+        <DialogFooter className="flex-shrink-0">
           <Button onClick={onClose} className="w-full">
             確認しました
           </Button>


### PR DESCRIPTION
ダイアログの最大高さを画面高さの80%とし、バッジが大量にある場合はスクロールできるようにしました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - バッジ通知ダイアログのレイアウトを最適化。リストをスクロール可能にし、コンテンツの最大高さを設定。ヘッダー/フッターの高さが安定し、長い一覧でも快適に閲覧可能に。

- スタイル
  - ミッション「tiktok-like」の成果物ラベル文言を「投稿のURL」に変更し、表記を簡潔に。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->