### PR TITLE
Cloud Buildでビルド時にSUPABASE_SERVICE_ROLE_KEYを指定

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -70,9 +70,11 @@ steps:
           --build-arg NEXT_PUBLIC_LINE_CLIENT_ID=${_NEXT_PUBLIC_LINE_CLIENT_ID} \
           --build-arg SENTRY_RELEASE=${COMMIT_SHA} \
           --build-arg SENTRY_AUTH_TOKEN="$$SENTRY_AUTH_TOKEN" \
+          --build-arg SUPABASE_SERVICE_ROLE_KEY="$$SUPABASE_SERVICE_ROLE_KEY" \
           .
     secretEnv:
       - SENTRY_AUTH_TOKEN
+      - SUPABASE_SERVICE_ROLE_KEY
 
   # Artifact Registryへのプッシュ
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
ビルド時に Error: Missing SUPABASE_SERVICE_ROLE_KEY environment variable が発生するようになったので。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - ビルド手順にSUPABASE_SERVICE_ROLE_KEYをビルド引数として追加し、シークレットから供給。
  - ビルド中に同キーを環境変数として参照可能に設定。
  - シークレット管理との連携を拡張し、ビルド引数および環境変数へ安全に反映。
  - 画像の発行やデプロイなど他のワークフローは変更なし。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->