### PR TITLE
Fix manifest link

### DIFF
--- a/mission_data/mission_main_links.yaml
+++ b/mission_data/mission_main_links.yaml
@@ -4,4 +4,4 @@ mission_main_links:
     link: https://team-mir.ai
   - mission_slug: read-manifest
     label: チームみらいのマニフェスト(要約版)を読む
-    link: https://speakerdeck.com/teammirai/timumiraimanihuesuto-yao-yue-ban-v0-dot-2
+    link: https://team-mir.ai/pdf-viewer?url=https%3A%2F%2Ftibsocpjqvxxipszbwui.supabase.co%2Fstorage%2Fv1%2Fobject%2Fpublic%2Fassets%2Fmanifestos%2Fteammirai_manifest_summary_v1.0.pdf


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- ドキュメント
  - 「read-manifest」のリンクを内蔵PDFビューアーのURLに更新し、アプリ内で直接PDFを閲覧可能にしました。
  - 外部サイトへの遷移を削減し、表示の安定性とアクセス性を改善しました。
  - 他の項目や内容に変更はなく、既存の動作・設定への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->