### PR TITLE
docs: テスト実行関連の記載更新および整形

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
    - WSL2のインストール `wsl --version` で確認
       - `cmd wsl --install` または `PowerShell wsl --install`
       - いずれも管理者権限が必要
+      - 詳細: [公式ドキュメント](https://learn.microsoft.com/ja-jp/windows/wsl/install)
 
    - Hyper-Vの有効化
       1. コントロールパネル > プログラムと機能 > Windowsの機能の有効化または無効化 > Windows ハイパーバイザープラットフォーム > チェックが入っているか確認 (デフォルトでは有効化)
@@ -133,7 +134,7 @@
    npm run mission:sync
    ```
 
-   `mission_data/README.md`を参照ください。
+   詳しくは [ミッションデータ README](mission_data/README.md) を参照ください。
 
 8. Next.js のローカル開発サーバーを起動:
 
@@ -208,7 +209,7 @@ supabase migration up
 
 migrationファイルの追加や編集で、テーブルの追加や更新を行った場合は、型定義を生成してください。
 
-```
+```bash
 npx supabase gen types typescript --local > lib/types/supabase.ts
 ```
 
@@ -238,12 +239,27 @@ npx supabase gen types typescript --local > lib/types/supabase.ts
 
 このプロジェクトでは、Playwrightを使用したE2Eテストを実装しています。テストは`tests/e2e`ディレクトリに配置されています。
 
+### テスト実行準備
+
+Playwright 実行に必要なソフトウェア・ツールをインストールする必要があります
+※ 環境によってはすでにインストールされている場合もあります
+
+テスト実行時、ブラウザや依存パッケージに関するエラーが出た場合は下記コマンドでインストールを行ってください
+
+```bash
+# テスト用ブラウザのインストール
+npx playwright install
+# 依存パッケージのインストール
+npx playwright install-deps
+```
+
 ### テストの実行方法
 
 1. テスト実行前に、ローカル開発環境が起動していることを確認してください:
 
    ```bash
    supabase start
+   npm run dev
    ```
 
 2. 以下のコマンドですべてのテストを実行できます:
@@ -406,9 +422,9 @@ HUBSPOT_CONTACT_LIST_ID=123456
 アクションボードのユーザー情報は以下のようにHubSpotのコンタクトプロパティにマッピングされます：
 
 | アプリケーション項目 | HubSpotプロパティ | HubSpot表示名 | データ型 | ステータス |
-|-------------|-----------------|--------------|----------|----------|
-| メールアドレス | `email` | Email | Email | ✅ 実装済み |
-| メールアドレス | `firstname` | 名 | Text | ✅ 実装済み |
+| -------------------- | ----------------- | ------------- | -------- | ---------- |
+| メールアドレス       | `email`           | Email         | Email    | ✅ 実装済み |
+| メールアドレス       | `firstname`       | 名            | Text     | ✅ 実装済み |
 
 ### 連携タイミング
 
@@ -471,15 +487,15 @@ HUBSPOT_CONTACT_LIST_ID=123456
 ### ミッション登録フロー変更のお知らせ
 
 #### 背景
-- **ISSUE（#398） の対応により、`missions` テーブルへ新規ミッションを登録する際、  
-  同時に `mission_category_link` テーブルへの登録が必須になりました。  
+- **ISSUE（#398） の対応により、`missions` テーブルへ新規ミッションを登録する際、
+  同時に `mission_category_link` テーブルへの登録が必須になりました。
   - もし `mission_category_link` への登録を忘れると、トップページにミッションが表示されません。
 
 #### 対応内容
-1. **新規ミッション登録**  
-   - `missions` テーブルへのデータ登録  
+1. **新規ミッション登録**
+   - `missions` テーブルへのデータ登録
    - **必ず** `mission_category_link` テーブルへカテゴリー紐づけデータを登録
-2. **カテゴリーの選定**  
+2. **カテゴリーの選定**
    - 登録するミッションを **どのカテゴリー** に紐づけるかは、PM（プロダクトマネージャー）と相談して決定してください。
    - カテゴリ管理は以下の Notion ページで一元管理しています。
 


### PR DESCRIPTION
## 変更の概要

- [README.md](README.md) の E2E テストに関する記載の更新
  - Playwright 依存ソフトウェア・ツールのインストール方法追記
  - 実行前確認内容としてサーバ起動確認を追加
- 整形および軽微な修正

## 変更の背景
- ここに変更が必要となった背景を記載してください
  - E2E テストの準備について説明が不足していたため

## CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- ドキュメント
  - WSL インストール手順を追記（公式ドキュメントへのリンク付き）
  - mission_data/README 参照をハイパーリンク化（2箇所）し表現を改善
  - supabase/migration 用の typegen スニペットを bash 表記に統一
  - E2E「テスト実行準備」節を新設（Playwright のインストール、install/install-deps、依存インストール、テスト前に npm run dev 起動を明記）
  - HubSpot データマッピング表の体裁を調整
  - 「ミッション登録フロー変更のお知らせ」に Notion 管理ページへのリンク追加・文言・改行・番号整形
  - CodeRabbit の PR レビュー通知バッジ見出しを追加
  - 軽微な語彙・書式統一を実施
<!-- end of auto-generated comment: release notes by coderabbit.ai -->