### PR TITLE
本番のメモリをTerraformで指定

### DIFF
--- a/terraform/nextjs-app.tf
+++ b/terraform/nextjs-app.tf
@@ -8,6 +8,7 @@ module "nextjs_app" {
   environment          = var.environment
   min_instance_count   = var.min_instance_count
   max_instance_count   = var.max_instance_count
+  cloud_run_memory     = var.environment == "production" ? "2Gi" : "512Mi"
   github_repository_id = google_cloudbuildv2_repository.github_repository.id
   repository_name      = google_artifact_registry_repository.app.repository_id
   trigger_branch       = var.trigger_branch

--- a/terraform/nextjs-app/main.tf
+++ b/terraform/nextjs-app/main.tf
@@ -40,7 +40,7 @@ resource "google_cloud_run_v2_service" "default" {
       resources {
         limits = {
           cpu    = "1000m"
-          memory = "512Mi"
+          memory = var.cloud_run_memory
         }
       }
 

--- a/terraform/nextjs-app/variables.tf
+++ b/terraform/nextjs-app/variables.tf
@@ -25,6 +25,12 @@ variable "max_instance_count" {
   default     = 2
 }
 
+variable "cloud_run_memory" {
+  description = "Memory limit for Cloud Run container"
+  type        = string
+  default     = "512Mi"
+}
+
 variable "github_repository_id" {
   description = "GitHub repository ID"
   type        = string


### PR DESCRIPTION
https://app.terraform.io/app/gamification/workspaces/action-board-production/runs/run-gkML2r9krygqPFVH によって、Cloud Runのメモリが2GB→512MBになってしまっていた。

おそらく過去にGUI上でメモリを変更してしまっていたのが原因。
Terraformで本番は2GBになるように変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 環境に応じてサービスのメモリ割り当てを可変化（本番: 2Gi、その他: 512Mi）。設定は既存の挙動を維持しつつ拡張可能に。

* **Performance**
  * 本番環境での安定性・スループットの向上が期待できます。
  * 検証/開発環境では必要十分なメモリに抑えることでリソース効率を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->