### PR TITLE
refactor:onboarding配下の型定義を集約

### DIFF
--- a/src/features/onboarding/components/onboarding-button.tsx
+++ b/src/features/onboarding/components/onboarding-button.tsx
@@ -1,16 +1,10 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import type { OnboardingButtonProps } from "@/features/onboarding/types/types";
 import { Sparkles } from "lucide-react";
-import type { ReactNode } from "react";
 import { useState } from "react";
 import { OnboardingModal } from "./onboarding-modal";
-
-interface OnboardingButtonProps {
-  children?: ReactNode;
-  variant?: "default" | "outline" | "link";
-  className?: string;
-}
 
 export function OnboardingButton({
   children = "使い方を見る",

--- a/src/features/onboarding/components/onboarding-character.tsx
+++ b/src/features/onboarding/components/onboarding-character.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import type { OnboardingCharacterProps } from "@/features/onboarding/types/types";
 import { motion } from "framer-motion";
 import { ChevronDown } from "lucide-react";
 import Image from "next/image";
@@ -9,13 +10,6 @@ import {
 } from "../constants/constants";
 import { onboardingDialogues } from "../constants/onboarding-texts";
 import { getButtonText, isFinalScreen, sanitizeHtml } from "../utils/utils";
-
-interface OnboardingCharacterProps {
-  currentDialogue: number;
-  isAnimating: boolean;
-  onNext: () => void;
-  onScrollDown: () => void;
-}
 
 /**
  * オンボーディングキャラクターコンポーネント（期日前投票専用）

--- a/src/features/onboarding/components/onboarding-mission-card.tsx
+++ b/src/features/onboarding/components/onboarding-mission-card.tsx
@@ -4,19 +4,11 @@ import MissionAchievementStatus from "@/components/mission/mission-achievement-s
 import { Button } from "@/components/ui/button";
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { MissionIcon } from "@/components/ui/mission-icon";
+import type { OnboardingMissionCardProps } from "@/features/onboarding/types/types";
 import { calculateMissionXp } from "@/features/user-level/utils/level-calculator";
-import type { Tables } from "@/lib/types/supabase";
 import clsx from "clsx";
 import { motion } from "framer-motion";
 import { UsersRound } from "lucide-react";
-
-interface OnboardingMissionCardProps {
-  mission: Omit<Tables<"missions">, "slug">;
-  achieved: boolean;
-  achievementsCount?: number;
-  userAchievementCount?: number;
-  onCardClick?: () => void;
-}
 
 export default function OnboardingMissionCard({
   mission,

--- a/src/features/onboarding/components/onboarding-mission-details.tsx
+++ b/src/features/onboarding/components/onboarding-mission-details.tsx
@@ -2,15 +2,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DifficultyBadge } from "@/components/ui/difficulty-badge";
 import { MissionIcon } from "@/components/ui/mission-icon";
+import type { OnboardingMissionDetailsProps } from "@/features/onboarding/types/types";
 import { BUTTON_TEXT, STYLE_CLASSES } from "../constants/constants";
-import type { MockMission } from "../types/types";
 import { sanitizeHtml } from "../utils/utils";
-
-interface OnboardingMissionDetailsProps {
-  mission: MockMission;
-  isSubmissionCompleted: boolean;
-  onSubmit: () => void;
-}
 
 /**
  * オンボーディングミッション詳細コンポーネント

--- a/src/features/onboarding/components/onboarding-modal.tsx
+++ b/src/features/onboarding/components/onboarding-modal.tsx
@@ -8,9 +8,9 @@ import { X } from "lucide-react";
 import Image from "next/image";
 import { onboardingDialogues } from "../constants/onboarding-texts";
 
+import type { OnboardingModalProps } from "@/features/onboarding/types/types";
 import { MOCK_MISSION } from "../constants/constants";
 import { useOnboardingState } from "../hooks/use-onboarding-state";
-import type { OnboardingModalProps } from "../types/types";
 import { OnboardingCharacter } from "./onboarding-character";
 import { OnboardingMissionDetails } from "./onboarding-mission-details";
 import { OnboardingWelcome } from "./onboarding-welcome";

--- a/src/features/onboarding/constants/onboarding-texts.ts
+++ b/src/features/onboarding/constants/onboarding-texts.ts
@@ -1,10 +1,4 @@
-export interface OnboardingDialogue {
-  id: number;
-  text: string;
-  isWelcome: boolean;
-  showMissionCard?: boolean;
-  showMissionDetails?: boolean;
-}
+import type { OnboardingDialogue } from "@/features/onboarding/types/types";
 
 export const onboardingDialogues: OnboardingDialogue[] = [
   {

--- a/src/features/onboarding/hooks/use-onboarding-state.ts
+++ b/src/features/onboarding/hooks/use-onboarding-state.ts
@@ -1,11 +1,11 @@
+import type {
+  UseOnboardingActions,
+  UseOnboardingState,
+} from "@/features/onboarding/types/types";
 import { useEffect, useRef, useState } from "react";
 import { ANIMATION_DURATION } from "../constants/constants";
 import { onboardingDialogues } from "../constants/onboarding-texts";
-import type { UseOnboardingActions, UseOnboardingState } from "../types/types";
-import {
-  calculateDefaultScrollPosition,
-  calculateScrollPosition,
-} from "../utils/utils";
+import { calculateDefaultScrollPosition } from "../utils/utils";
 
 /**
  * オンボーディング状態管理フック（期日前投票専用）

--- a/src/features/onboarding/types/types.ts
+++ b/src/features/onboarding/types/types.ts
@@ -1,3 +1,6 @@
+import type { Tables } from "@/lib/types/supabase";
+import type { ReactNode } from "react";
+
 /**
  * オンボーディング機能で使用する型定義（期日前投票専用）
  */
@@ -26,6 +29,37 @@ export interface OnboardingModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
+// オンボーディングボタンのProps
+export interface OnboardingButtonProps {
+  children?: ReactNode;
+  variant?: "default" | "outline" | "link";
+  className?: string;
+}
+
+// オンボーディングキャラクターのProps
+export interface OnboardingCharacterProps {
+  currentDialogue: number;
+  isAnimating: boolean;
+  onNext: () => void;
+  onScrollDown: () => void;
+}
+
+// オンボーディングミッションカードのProps
+export interface OnboardingMissionCardProps {
+  mission: Omit<Tables<"missions">, "slug">;
+  achieved: boolean;
+  achievementsCount?: number;
+  userAchievementCount?: number;
+  onCardClick?: () => void;
+}
+
+// オンボーディングミッション詳細のProps
+export interface OnboardingMissionDetailsProps {
+  mission: MockMission;
+  isSubmissionCompleted: boolean;
+  onSubmit: () => void;
+}
+
 // フック型
 export interface UseOnboardingState {
   currentDialogue: number;
@@ -39,4 +73,13 @@ export interface UseOnboardingActions {
   handleSubmit: () => void;
   handleScrollDown: () => void;
   handleOpenChange: (open: boolean) => void;
+}
+
+// オンボーディングダイアログの型
+export interface OnboardingDialogue {
+  id: number;
+  text: string;
+  isWelcome: boolean;
+  showMissionCard?: boolean;
+  showMissionDetails?: boolean;
 }


### PR DESCRIPTION
# 変更の概要
### 主な変更
- **型定義の統一**: 各コンポーネントファイルで個別に定義されていたインターフェースを types.ts に集約
- **import文の修正**: 統一された型定義ファイルから型をインポートするよう変更

### 移動された型定義
1. `OnboardingButtonProps` - onboarding-button.tsx から移動
2. `OnboardingCharacterProps` - onboarding-character.tsx から移動  
3. `OnboardingMissionCardProps` - onboarding-mission-card.tsx から移動
4. `OnboardingMissionDetailsProps` - onboarding-mission-details.tsx から移動
5. `OnboardingDialogue` - onboarding-texts.ts から移動

### 効果
- 型定義の重複を削減
- 保守性の向上（型定義の一元管理）
- インポート文の簡潔化
# 変更の背景
Next.jsアーキテクチャリファクタリング：サーバー・クライアント実行環境の明確化 https://github.com/team-mirai-volunteer/action-board/issues/1375
closes #1432
# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- リファクタリング
  - オンボーディング関連コンポーネントのプロップ型を共通化し、参照先を統一。ダイアログ定義も共通タイプへ移行し、インポート経路を整理。挙動・UIの変更はありません。

- 雑務
  - 未使用のユーティリティ／型インポートを削除し、型専用インポートへ統一。ビルドの一貫性・保守性を向上。機能追加やパフォーマンス影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->