### PR TITLE
refactor: uuid ライブラリの代わりに標準のcryptoモジュールを用いる

### DIFF
--- a/mission_data/src/sync.ts
+++ b/mission_data/src/sync.ts
@@ -58,7 +58,7 @@ async function syncCategories(categories: Category[], dryRun: boolean) {
         .single();
 
       const categoryData = {
-        id: existing?.id || uuidv4(),
+        id: existing?.id || crypto.randomUUID(),
         slug: category.slug,
         category_title: category.title,
         sort_no: category.sort_no,
@@ -98,7 +98,7 @@ async function syncMissions(missions: Mission[], dryRun: boolean) {
         .single();
 
       const missionData = {
-        id: existing?.id || uuidv4(),
+        id: existing?.id || crypto.randomUUID(),
         slug: mission.slug,
         title: mission.title,
         icon_url: mission.icon_url,
@@ -340,7 +340,7 @@ async function syncMissionQuizLinks(
       );
     } else {
       const { error } = await supabase.from("mission_quiz_links").insert({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         mission_id: missionId,
         link: link.link,
         remark: link.remark,

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "sonner": "^2.0.4",
         "tsparticles-engine": "^2.12.0",
         "tsparticles-preset-fireworks": "^2.12.0",
-        "uuid": "^9.0.1",
         "zod": "^3.25.23"
       },
       "devDependencies": {
@@ -80,7 +79,6 @@
         "@types/pg-copy-streams": "^1.2.5",
         "@types/react": "^19.0.2",
         "@types/react-dom": "^19.1.5",
-        "@types/uuid": "^9.0.7",
         "@vitest/browser": "^3.1.4",
         "@vitest/coverage-v8": "^3.1.4",
         "dotenv": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "sonner": "^2.0.4",
     "tsparticles-engine": "^2.12.0",
     "tsparticles-preset-fireworks": "^2.12.0",
-    "uuid": "^9.0.1",
     "zod": "^3.25.23"
   },
   "devDependencies": {
@@ -104,7 +103,6 @@
     "@types/pg-copy-streams": "^1.2.5",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.1.5",
-    "@types/uuid": "^9.0.7",
     "@vitest/browser": "^3.1.4",
     "@vitest/coverage-v8": "^3.1.4",
     "dotenv": "^16.5.0",


### PR DESCRIPTION
# 変更の概要
- uuid ライブラリの代わりに標準のcryptoモジュールを用いてuuid生成を行う
- uuid, @types/uuidライブラリの直接インストールの削除


uuid, @types/uuid はそれぞれ以下のライブラリから依存されており、間接インストールは残っています。

```
% npm ls uuid      
action-board@0.1.0 /action-board
├─┬ @sentry/nextjs@9.39.0
│ └─┬ @sentry/webpack-plugin@3.6.0
│   └── uuid@9.0.1
├─┬ @storybook/addon-essentials@8.6.14
│ └─┬ @storybook/addon-actions@8.6.14
│   └── uuid@9.0.1 deduped
└─┬ jest-junit@16.0.0
  └── uuid@8.3.2
```

```
% npm ls @types/uuid       
action-board@0.1.0 /action-board
└─┬ @storybook/addon-essentials@8.6.14
  └─┬ @storybook/addon-actions@8.6.14
    └── @types/uuid@9.0.8
```

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #966 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました