### PR TITLE
fix: BadgeItemのclickableプロパティを明示的にfalseに設定しnested-a-tagエラーを回避する

### DIFF
--- a/src/features/user-badges/components/user-top-badge.tsx
+++ b/src/features/user-badges/components/user-top-badge.tsx
@@ -16,5 +16,5 @@ export async function UserTopBadge({ userId, seasonId }: UserTopBadgeProps) {
     return null;
   }
 
-  return <BadgeItem badge={topBadge} className="w-fit" />;
+  return <BadgeItem badge={topBadge} className="w-fit" clickable={false} />;
 }


### PR DESCRIPTION
# 変更の概要
- ホームのユーザーのカードのBadgeItemのclickableをfalseに設定する

# 変更の背景
- ホームのマイページへ移動するカードの中でaタグがネストされているためにエラーが出るので、出ないようにする。


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました