### PR TITLE
fix: ミッション別ランキングのポイント表示を回数表示に変更（#1475）

### DIFF
--- a/src/features/ranking/components/current-user-card-mission.test.tsx
+++ b/src/features/ranking/components/current-user-card-mission.test.tsx
@@ -2,40 +2,6 @@ import { render, screen } from "@testing-library/react";
 import type React from "react";
 import { CurrentUserCardMission } from "./current-user-card-mission";
 
-type UserMissionRanking = {
-  user_id: string;
-  name: string;
-  address_prefecture: string;
-  rank: number | null;
-  total_points: number | null;
-  user_achievement_count?: number;
-  level?: number;
-  updated_at?: string;
-  xp?: number;
-};
-
-type Mission = {
-  id: string;
-  title: string;
-  description: string;
-  artifact_label?: string | null;
-  content?: string | null;
-  created_at?: string;
-  difficulty?: number;
-  event_date?: string | null;
-  icon_url?: string | null;
-  is_featured?: boolean;
-  is_posting_mission?: boolean;
-  location?: string | null;
-  max_participants?: number | null;
-  name?: string;
-  updated_at?: string;
-  is_hidden?: boolean;
-  max_achievement_count?: number | null;
-  ogp_image_url?: string | null;
-  required_artifact_type?: string | null;
-};
-
 jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
@@ -88,7 +54,6 @@ const mockUser = {
   name: "テストユーザー",
   address_prefecture: "東京都",
   rank: 3,
-  total_points: 1500,
   user_achievement_count: 5,
   level: 10,
   updated_at: "2024-01-01T00:00:00Z",
@@ -115,8 +80,8 @@ describe("CurrentUserCardMission", () => {
 
       expect(screen.getByText("テストユーザー")).toBeInTheDocument();
       expect(screen.getByText("東京都")).toBeInTheDocument();
-      expect(screen.getByText("1,500pt")).toBeInTheDocument();
-      expect(screen.getByText("3")).toBeInTheDocument();
+      expect(screen.getByText("Lv.10")).toBeInTheDocument();
+      expect(screen.getByText("5回達成")).toBeInTheDocument();
     });
 
     it("タイトルが正しく表示される", () => {
@@ -172,8 +137,8 @@ describe("CurrentUserCardMission", () => {
       expect(screen.getByText("0")).toBeInTheDocument();
     });
 
-    it("total_pointsがnullの場合は0ptが表示される", () => {
-      const user = { ...mockUser, total_points: null };
+    it("レベルがnullの場合はLv.0が表示される", () => {
+      const user = { ...mockUser, level: null };
       render(
         <CurrentUserCardMission
           currentUser={user}
@@ -182,7 +147,7 @@ describe("CurrentUserCardMission", () => {
         />,
       );
 
-      expect(screen.getByText("0pt")).toBeInTheDocument();
+      expect(screen.getByText("Lv.0")).toBeInTheDocument();
     });
   });
 
@@ -199,34 +164,6 @@ describe("CurrentUserCardMission", () => {
       expect(screen.getByTestId("card-header")).toBeInTheDocument();
       expect(screen.getByTestId("card-content")).toBeInTheDocument();
       expect(screen.getByTestId("card-title")).toBeInTheDocument();
-    });
-  });
-
-  describe("データフォーマット", () => {
-    it("ポイントが正しくフォーマットされる", () => {
-      const user = { ...mockUser, total_points: 123456 };
-      render(
-        <CurrentUserCardMission
-          currentUser={user}
-          mission={mockMission}
-          badgeText="5回達成"
-        />,
-      );
-
-      expect(screen.getByText("123,456pt")).toBeInTheDocument();
-    });
-
-    it("大きな数値も正しくフォーマットされる", () => {
-      const user = { ...mockUser, total_points: 1000000 };
-      render(
-        <CurrentUserCardMission
-          currentUser={user}
-          mission={mockMission}
-          badgeText="100回達成"
-        />,
-      );
-
-      expect(screen.getByText("1,000,000pt")).toBeInTheDocument();
     });
   });
 
@@ -255,34 +192,6 @@ describe("CurrentUserCardMission", () => {
       );
 
       expect(screen.getByText("未設定")).toBeInTheDocument();
-    });
-
-    it("空のバッジテキストが処理される", () => {
-      render(
-        <CurrentUserCardMission
-          currentUser={mockUser}
-          mission={mockMission}
-          badgeText=""
-        />,
-      );
-
-      const badge = screen.getByTestId("badge");
-      expect(badge).toHaveTextContent("");
-    });
-  });
-
-  describe("displayUserの変換", () => {
-    it("displayUserが正しく変換される", () => {
-      const user = { ...mockUser, rank: null };
-      render(
-        <CurrentUserCardMission
-          currentUser={user}
-          mission={mockMission}
-          badgeText="5回達成"
-        />,
-      );
-
-      expect(screen.getByText("0")).toBeInTheDocument();
     });
   });
 });

--- a/src/features/ranking/components/current-user-card-mission.tsx
+++ b/src/features/ranking/components/current-user-card-mission.tsx
@@ -1,7 +1,7 @@
-import { Badge } from "@/components/ui/badge";
 import type { Tables } from "@/lib/types/supabase";
 import type { UserMissionRanking } from "../types/ranking-types";
 import { BaseCurrentUserCard } from "./base-current-user-card";
+import { LevelBadge } from "./ranking-level-badge";
 
 interface CurrentUserCardProps {
   currentUser: UserMissionRanking | null;
@@ -18,6 +18,12 @@ export const CurrentUserCardMission: React.FC<CurrentUserCardProps> = ({
     return null;
   }
 
+  const displayUser = {
+    ...currentUser,
+    level: currentUser.level || 0,
+    xp: currentUser.xp || 0,
+  };
+
   const userForCard = {
     user_id: currentUser.user_id,
     name: currentUser.name,
@@ -28,14 +34,8 @@ export const CurrentUserCardMission: React.FC<CurrentUserCardProps> = ({
   return (
     <BaseCurrentUserCard currentUser={userForCard}>
       <div className="flex items-center gap-3">
-        <Badge
-          className={"bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"}
-        >
-          {badgeText}
-        </Badge>
-        <span className="font-bold text-lg">
-          {(currentUser.total_points ?? 0).toLocaleString()}pt
-        </span>
+        <LevelBadge level={displayUser.level} />
+        <div className="text-lg font-bold">{badgeText}</div>
       </div>
     </BaseCurrentUserCard>
   );

--- a/src/features/ranking/components/ranking-item.test.tsx
+++ b/src/features/ranking/components/ranking-item.test.tsx
@@ -21,7 +21,6 @@ type UserMissionRanking = {
   xp: number | null;
   updated_at: string | null;
   user_achievement_count: number | null;
-  total_points: number | null;
 };
 
 jest.mock("next/link", () => {
@@ -72,7 +71,6 @@ const mockUserMissionRanking: UserMissionRanking = {
   xp: null,
   updated_at: null,
   user_achievement_count: null,
-  total_points: 2500,
 };
 
 describe("RankingItem", () => {
@@ -137,7 +135,7 @@ describe("RankingItem", () => {
       name: "テストミッション",
     };
 
-    it("ミッション別ランキングの場合はポイントが表示される", () => {
+    it("ミッション別ランキングの場合は達成回数が表示される", () => {
       render(
         <RankingItem
           user={mockUserRanking}
@@ -147,24 +145,11 @@ describe("RankingItem", () => {
         />,
       );
 
-      expect(screen.getByText("2,500pt")).toBeInTheDocument();
+      expect(screen.getByText("Lv.15")).toBeInTheDocument();
       expect(screen.getByText("5回達成")).toBeInTheDocument();
     });
 
-    it("ミッション別ランキングの場合はレベル表示されない", () => {
-      render(
-        <RankingItem
-          user={mockUserRanking}
-          userWithMission={mockUserMissionRanking}
-          mission={mission}
-          badgeText="3回達成"
-        />,
-      );
-
-      expect(screen.queryByText("Lv.15")).not.toBeInTheDocument();
-    });
-
-    it("userWithMissionがnullの場合は0ptが表示される", () => {
+    it("ミッション別ランキングの場合はポイントが表示されない", () => {
       render(
         <RankingItem
           user={mockUserRanking}
@@ -174,7 +159,7 @@ describe("RankingItem", () => {
         />,
       );
 
-      expect(screen.getByText("0pt")).toBeInTheDocument();
+      expect(screen.queryByText("1,500pt")).not.toBeInTheDocument();
     });
   });
 

--- a/src/features/ranking/components/ranking-item.tsx
+++ b/src/features/ranking/components/ranking-item.tsx
@@ -27,7 +27,6 @@ function getLevelBadgeColor(level: number | null) {
 
 export function RankingItem({
   user,
-  userWithMission,
   showDetailedInfo = false,
   mission,
   badgeText,
@@ -48,19 +47,15 @@ export function RankingItem({
         </div>
       </div>
       <div className="flex items-center gap-3">
-        {/* ミッション別ランキングの場合はポイントと達成回数を表示 */}
+        {/* ミッション別ランキングの場合は達成回数を表示 */}
         {mission ? (
           <>
             <Badge
-              className={
-                "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full"
-              }
+              className={`${getLevelBadgeColor(user.level)} px-3 py-1 rounded-full`}
             >
-              {badgeText}
+              Lv.{user.level}
             </Badge>
-            <span className="font-bold text-lg">
-              {(userWithMission?.total_points ?? 0).toLocaleString()}pt
-            </span>
+            <span className="font-bold text-lg">{badgeText ?? 0}</span>
           </>
         ) : (
           <>

--- a/src/features/ranking/components/ranking-mission.test.tsx
+++ b/src/features/ranking/components/ranking-mission.test.tsx
@@ -7,7 +7,6 @@ type UserMissionRanking = {
   name: string;
   address_prefecture: string;
   rank: number | null;
-  total_points: number | null;
   user_achievement_count?: number;
 };
 
@@ -69,14 +68,12 @@ const mockRankings: UserMissionRanking[] = [
     name: "ユーザー1",
     address_prefecture: "東京都",
     rank: 1,
-    total_points: 1000,
   },
   {
     user_id: "user-2",
     name: "ユーザー2",
     address_prefecture: "大阪府",
     rank: 2,
-    total_points: 800,
   },
 ];
 
@@ -90,7 +87,6 @@ const mockCurrentUser: UserMissionRanking = {
   name: "現在のユーザー",
   address_prefecture: "愛知県",
   rank: 5,
-  total_points: 500,
 };
 
 describe("RankingMission", () => {

--- a/src/features/ranking/services/get-missions-ranking.test.ts
+++ b/src/features/ranking/services/get-missions-ranking.test.ts
@@ -45,7 +45,6 @@ describe("missionsRanking service", () => {
             xp: 1000,
             updated_at: "2024-01-01T00:00:00Z",
             user_achievement_count: 5,
-            total_points: 500,
             rank: 1,
           },
           {
@@ -56,7 +55,6 @@ describe("missionsRanking service", () => {
             xp: 800,
             updated_at: "2024-01-01T00:00:00Z",
             user_achievement_count: 3,
-            total_points: 300,
             rank: 2,
           },
         ];
@@ -82,7 +80,6 @@ describe("missionsRanking service", () => {
           user_id: "user1",
           name: "テストユーザー1",
           user_achievement_count: 5,
-          total_points: 500,
         });
       });
 
@@ -115,7 +112,6 @@ describe("missionsRanking service", () => {
             user_name: "テストユーザー1",
             address_prefecture: "東京都",
             user_achievement_count: 2,
-            total_points: 100,
             rank: 1,
           },
         ];
@@ -142,7 +138,6 @@ describe("missionsRanking service", () => {
           user_achievement_count: 2,
           level: null,
           xp: null,
-          total_points: 100,
         });
       });
 
@@ -202,7 +197,6 @@ describe("missionsRanking service", () => {
             xp: 1000,
             updated_at: "2024-01-01T00:00:00Z",
             user_achievement_count: 5,
-            total_points: 500,
             rank: 3,
           },
         ];
@@ -241,7 +235,6 @@ describe("missionsRanking service", () => {
             user_name: "テストユーザー",
             address_prefecture: "東京都",
             user_achievement_count: 2,
-            total_points: 50,
             rank: 5,
             level: null,
             xp: null,
@@ -276,7 +269,6 @@ describe("missionsRanking service", () => {
           rank: 5,
           level: null,
           xp: null,
-          total_points: 50,
         });
       });
     });

--- a/src/features/ranking/services/get-missions-ranking.ts
+++ b/src/features/ranking/services/get-missions-ranking.ts
@@ -69,7 +69,6 @@ export async function getMissionRanking(
             xp: ranking.xp,
             updated_at: ranking.updated_at,
             user_achievement_count: ranking.user_achievement_count,
-            total_points: ranking.total_points,
           }) as UserMissionRanking,
       );
     }
@@ -85,7 +84,6 @@ export async function getMissionRanking(
           xp: null, // 期間別では取得しない
           updated_at: null,
           user_achievement_count: ranking.user_achievement_count,
-          total_points: ranking.total_points,
         }) as UserMissionRanking,
     );
   } catch (error) {
@@ -156,7 +154,6 @@ export async function getUserMissionRanking(
       xp: ranking.xp,
       updated_at: ranking.updated_at,
       user_achievement_count: ranking.user_achievement_count,
-      total_points: ranking.total_points,
     } as UserMissionRanking;
   } catch (error) {
     console.error("User mission ranking service error:", error);

--- a/src/features/ranking/types/ranking-types.ts
+++ b/src/features/ranking/types/ranking-types.ts
@@ -16,7 +16,6 @@ export interface UserRanking {
 
 export interface UserMissionRanking extends UserRanking {
   user_achievement_count: number | null;
-  total_points: number | null;
 }
 
 export interface PrefectureRanking {


### PR DESCRIPTION
# 変更の概要
**UI表示の変更:**
- **変更前**: `[5回達成] 1,500pt`
- **変更後**: `[Lv.10] 5回達成`

**実装変更:**
- `current-user-card-mission.tsx`: ポイント表示を削除し、レベルバッジ + 達成回数表示に変更
- `ranking-item.tsx`: ミッション別ランキングでポイント表示を廃止、レベルと達成回数のみ表示

issueに記載していた合計ポイントの集計方法を変更する対応（#1475）について、以下の課題があった：
案1の課題： 今後ポイント変更が発生した場合、既存データとの整合性が取れなくなるリスクがある。
案2の課題： DBのカラム変更や既存データへのマイグレーションが必要となり、変更による影響範囲が大きい。

そこで、ミッション別ランキングでは固定ポイント×達成回数という仕組みのため、ポイント数を表示する意義が薄いと判断し、合計ポイント表示から達成回数表示に変更することで対応しました。


## 変更前
<img width="1066" height="484" alt="image" src="https://github.com/user-attachments/assets/d4689e93-c42e-485b-944c-69c590ee9b79" />


## 変更後
<img width="1071" height="487" alt="image" src="https://github.com/user-attachments/assets/879322eb-1551-479c-afd5-465aa299dcd9" />


# 変更の背景
- 獲得ポイント数が正確に表示されないバグが発生していたため
- closes #1475

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ミッションランキングの表示をポイント表示から「レベル（Lv.）」と「達成回数」中心に切替
  - レベル表示を用いたバッジ表示を導入（レベルに応じた色付け）

- 改善
  - ユーザーカード（ミッション）で欠損のレベル/XPを0で補完し安定表示
  - バッジ表示を統一し視認性・一貫性を向上

- テスト
  - 期待値をレベル／達成回数基準に更新し、旧ポイント表示に関するテストを整理・簡素化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->