### PR TITLE
不要な要素、冗長なcssの指定、共通化できる処理の共通化をする　追加PR

### DIFF
--- a/src/features/missions/components/mission-card.test.tsx
+++ b/src/features/missions/components/mission-card.test.tsx
@@ -145,7 +145,6 @@ describe("Mission", () => {
     render(
       <Mission
         mission={mockMission}
-        achieved={false}
         achievementsCount={10}
         userAchievementCount={0}
       />,
@@ -160,7 +159,6 @@ describe("Mission", () => {
     render(
       <Mission
         mission={mockMission}
-        achieved={false}
         achievementsCount={5}
         userAchievementCount={0}
       />,
@@ -173,7 +171,6 @@ describe("Mission", () => {
     render(
       <Mission
         mission={mockMission}
-        achieved={true}
         achievementsCount={15}
         userAchievementCount={3}
       />,
@@ -188,7 +185,6 @@ describe("Mission", () => {
     render(
       <Mission
         mission={missionWithoutLimit}
-        achieved={false}
         achievementsCount={20}
         userAchievementCount={5}
       />,
@@ -203,7 +199,6 @@ describe("Mission", () => {
     render(
       <Mission
         mission={missionWithoutIcon}
-        achieved={false}
         achievementsCount={0}
         userAchievementCount={0}
       />,
@@ -217,8 +212,7 @@ describe("Mission", () => {
     render(
       <Mission
         mission={mockMission}
-        achieved={false}
-        achievementsCount={undefined}
+        achievementsCount={0}
         userAchievementCount={0}
       />,
     );
@@ -232,7 +226,6 @@ describe("Mission", () => {
     render(
       <Mission
         mission={missionWithoutDate}
-        achieved={false}
         achievementsCount={5}
         userAchievementCount={0}
       />,

--- a/src/features/missions/components/mission-card.tsx
+++ b/src/features/missions/components/mission-card.tsx
@@ -13,15 +13,14 @@ import MissionAchievementStatus from "./mission-achievement-status";
 
 interface MissionProps {
   mission: Omit<Tables<"missions">, "slug">;
-  achieved: boolean;
-  achievementsCount?: number;
-  userAchievementCount?: number;
+  achievementsCount: number;
+  userAchievementCount: number;
 }
 
 export default function Mission({
   mission,
   achievementsCount,
-  userAchievementCount = 0,
+  userAchievementCount,
 }: MissionProps) {
   // 最大達成回数が設定されている場合、ユーザーの達成回数が最大に達しているかどうかを確認
   const hasReachedMaxAchievements =
@@ -68,9 +67,7 @@ export default function Mission({
           <div className="flex items-center">
             <UsersRound className="size-4 mr-2" />
             <span className="text-sm font-medium text-gray-700">
-              {achievementsCount !== undefined
-                ? `みんなで${achievementsCount.toLocaleString()}回達成`
-                : "みんなで0回達成"}
+              みんなで{achievementsCount.toLocaleString()}回達成
             </span>
           </div>
           <div className="flex items-center">

--- a/src/features/missions/components/mission-list.tsx
+++ b/src/features/missions/components/mission-list.tsx
@@ -90,7 +90,6 @@ export default async function Missions({
             <Mission
               key={mission.id}
               mission={mission}
-              achieved={achievedMissionIds.includes(mission.id)}
               achievementsCount={achievement_count_map.get(mission.id) ?? 0}
               userAchievementCount={
                 userAchievementCountMap.get(mission.id) ?? 0

--- a/src/features/missions/components/missions-by-category.tsx
+++ b/src/features/missions/components/missions-by-category.tsx
@@ -175,7 +175,6 @@ export default async function MissionsByCategory({
                       <div key={missionId} className="flex-shrink-0 w-[300px]">
                         <Mission
                           mission={missionForComponent}
-                          achieved={achievedMissionIds.includes(missionId)}
                           achievementsCount={
                             achievementCountMap.get(missionId) ?? 0
                           }


### PR DESCRIPTION
# 変更の概要
- Props整理: Mission コンポーネントから achieved を削除。achievementsCount/userAchievementCount を必須の number に統一。
- 呼び出し元対応: mission-list.tsx/missions-by-category.tsx から achieved 引数を除去し、集計値は必ず数値を渡すように変更。
- 表示ロジック簡素化: 合計達成回数は常に「みんなで{N}回達成」を表示（undefined 分岐を廃止、0 なら 0 を表示）。
- スタイル微調整: カテゴリ一覧の余白・パディング・見出し（gap-11, my-5, px-4 pb-2 pt-4 など）を調整。
- テスト更新: mission-card.test.tsx を新しい Props に追従（achieved 削除、achievementsCount の undefined ケースを 0 に
修正）。

# 変更の背景
- https://github.com/team-mirai-volunteer/action-board/pull/1500 で修正漏れした部分を追加で修正したPR
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

||変更前|変更後|
|-|-|-|
|重要ミッション|<img width="1137" height="1252" alt="image" src="https://github.com/user-attachments/assets/4f94e843-8a78-4170-9b7a-e146a89c93a5" />|<img width="1127" height="1245" alt="image" src="https://github.com/user-attachments/assets/c49db004-d283-4a74-8ce1-28442adf8a4b" />|
|ミッション|<img width="1141" height="1251" alt="image" src="https://github.com/user-attachments/assets/7c4c6dec-1724-4c16-840b-78d09ef80d86" />|<img width="1135" height="1254" alt="image" src="https://github.com/user-attachments/assets/c7c40be6-461a-4ab3-bfd9-6b591925b5af" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- UI/スタイル
  - ミッション一覧/カテゴリ表示の余白とパディングを調整し、カード間の間隔を最適化。
  - ミッションカードの文言を統一し、常に「みんなでX回達成」を表示。
- リファクタリング
  - 達成状態の判定をカウント値に集約してプロップを簡素化。
- テスト
  - 新しい判定ロジックに合わせてテストケースを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->