### PR TITLE
fix: ゴミ拾いミッションのロケータを明示的に指定

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -4,9 +4,11 @@ import { cn } from "@/lib/utils/utils";
 
 const Card = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
+  React.HTMLAttributes<HTMLDivElement> & {
+    as?: React.ElementType;
+  }
+>(({ className, as: Component = "div", ...props }, ref) => (
+  <Component
     ref={ref}
     className={cn(
       "rounded-lg border bg-card text-card-foreground shadow-sm",

--- a/src/features/missions/components/mission-card.tsx
+++ b/src/features/missions/components/mission-card.tsx
@@ -36,7 +36,7 @@ export default function Mission({
     : null;
 
   return (
-    <Card className="@container/card">
+    <Card as="article" className="@container/card">
       <CardHeader className="relative">
         <div className="flex items-center gap-4">
           <div className="flex flex-col items-center justify-center">

--- a/tests/e2e/user-mission.spec.ts
+++ b/tests/e2e/user-mission.spec.ts
@@ -156,8 +156,9 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
 
     // ミッションページに遷移（ゴミ拾いミッションをクリック）
     await signedInPage
+      .getByRole("article")
+      .filter({ hasText: "(seed) ゴミ拾いをしよう (成果物不要)" })
       .getByRole("button", { name: "今すぐチャレンジ" })
-      .first()
       .click();
     await expect(signedInPage).toHaveURL(/\/missions\/[^\/]+$/, {
       timeout: 10000,


### PR DESCRIPTION
# 変更の概要
PlaywrightのE2Eテストにおいて、「ゴミ拾いミッション」を正しくクリックできるようにするためのロケータを追加

# 変更の背景
- PlaywrightのE2Eテストの`ミッションページ遷移 → ミッション完了 → ミッション取消が正常に動作する`テストシナリオにおいて、「ミッション完了を記録する」ボタンが存在しないミッションに遷移していた影響でテストが落ちている。
- コメントに`// ミッションページに遷移（ゴミ拾いミッションをクリック）`と記載されていたため、「ゴミ拾いミッション」を正しく選択できるように修正。

| Before | After |
| ----- | ----- |
| <img width="1512" height="857" alt="Screenshot 2025-10-14 at 4 44 40 PM" src="https://github.com/user-attachments/assets/dac51a66-fabb-438c-8eb9-ce435e9415e8" /> | <img width="1512" height="859" alt="Screenshot 2025-10-14 at 4 44 05 PM" src="https://github.com/user-attachments/assets/f7a63f8f-6804-4c4f-b06c-0bb5ccc00250" /> |

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * ミッション完了フローのE2Eを見直し、特定のミッション文言を基にボタンをスコープして検出するように変更。検出の堅牢性とCI安定性を向上。挙動やUIへの影響なし。

* **Refactor**
  * 汎用カードコンポーネントに出力要素を切り替える仕組みを追加。ミッション一覧は意味的にarticle要素で出力されるようになりました（ユーザー視点での見た目は変わりません）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->