### PR TITLE
README に載せている workflows のバッジのリンク切れ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Check code with Biome](https://github.com/team-mirai/action-board/actions/workflows/check_biome.yaml/badge.svg)](https://github.com/team-mirai/action-board/actions/workflows/check_biome.yaml)
-[![Build & Test E2E/RLS](https://github.com/team-mirai/action-board/actions/workflows/build_test.yaml/badge.svg)](https://github.com/team-mirai/action-board/actions/workflows/build_test.yaml)
-
 # アクションボード
+
+[![Check code with Biome and tsc](https://github.com/team-mirai/action-board/actions/workflows/check_code.yaml/badge.svg)](https://github.com/team-mirai/action-board/actions/workflows/check_code.yaml)
+[![Build & Test E2E/RLS](https://github.com/team-mirai/action-board/actions/workflows/e2e_test.yaml/badge.svg)](https://github.com/team-mirai/action-board/actions/workflows/e2e_test.yaml)
 
 ## コントリビュートについて
 


### PR DESCRIPTION
# 変更の概要
- README に載せている workflows のバッジのリンク切れ修正

# 変更の背景
- check_biome.yaml → check_code.yaml に、build_test.yaml → e2e_test.yaml に変わった関係でバッジのリンクが切れているのを見つけたため対応

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * CI/CDワークフローバッジを更新しました。リポジトリの自動テストおよびコード品質チェック（BiomeおよびTypeScript）の状態をより正確に反映するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->