### PR TITLE
Fix Threads mission

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -184,9 +184,9 @@ missions:
     artifact_label: あなたのnoteアカウント名
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//1_follow_note.png
   - slug: follow-anno-threads
-    title: 安野たかひろスタッフのThreadsをフォローしよう
+    title: 公式Threadsをフォローしよう
     icon_url: /img/mission-icons/actionboard_icon_work_20250713_ol_follow-anno-threads.svg
-    content: <a href="https://www.threads.com/@annotakahiro2024" target="_blank" rel="noopener noreferrer">安野たかひろスタッフのThreads</a>をフォローして、チームみらいの最新情報をチェック！街頭演説のお知らせや、日々の活動レポートなど、リアルタイムな情報をお届けしています。
+    content: <a href="https://www.threads.com/@team_mirai_jp" target="_blank" rel="noopener noreferrer">公式Threads</a>をフォローして、チームみらいの最新情報をチェック！街頭演説のお知らせや、日々の活動レポートなど、リアルタイムな情報をお届けしています。
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1


### PR DESCRIPTION
アカウント名が変わってリンクが無効になっていたので修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Updates**
  * Threadsフォローミッションを更新しました。スタッフアカウントから公式チャネルへのフォロー対象が変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->