### PR TITLE
fix: 右のスクロールボタンの位置が左端になってしまっていたのを修正

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -78,6 +78,20 @@ jest.mock("lucide-react", () => ({
       className,
     });
   },
+  ChevronLeft: ({ className }) => {
+    const mockReact = require("react");
+    return mockReact.createElement("div", {
+      "data-testid": "chevron-left-icon",
+      className,
+    });
+  },
+  ChevronRight: ({ className }) => {
+    const mockReact = require("react");
+    return mockReact.createElement("div", {
+      "data-testid": "chevron-right-icon",
+      className,
+    });
+  },
 }));
 
 const createMockSupabaseQuery = () => {

--- a/src/features/missions/components/horizontal-scroll-container.test.tsx
+++ b/src/features/missions/components/horizontal-scroll-container.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { HorizontalScrollContainer } from "./horizontal-scroll-container";
+
+describe("HorizontalScrollContainer コンポーネント - 追加テスト", () => {
+  beforeEach(() => {
+    // ResizeObserver をモック
+    class MockResizeObserver {
+      observe() {}
+      disconnect() {}
+    }
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      value: MockResizeObserver,
+    });
+  });
+
+  it("ドラッグ操作でスクロール位置とカーソル/選択状態が切り替わる", () => {
+    const { container } = render(
+      <HorizontalScrollContainer>
+        <div />
+      </HorizontalScrollContainer>,
+    );
+
+    const scroller = container.querySelector(
+      ".custom-scrollbar",
+    ) as HTMLDivElement;
+    expect(scroller).toBeTruthy();
+
+    // 横スクロール可能な状態にセット + 初期スクロール位置
+    Object.defineProperty(scroller, "scrollLeft", {
+      value: 100,
+      writable: true,
+      configurable: true,
+    });
+
+    // 初期はドラッグ前: cursor-grab, userSelect は auto（inline style の空文字）
+    expect(scroller.className).toContain("cursor-grab");
+    expect(
+      scroller.style.userSelect === "" || scroller.style.userSelect === "auto",
+    ).toBeTruthy();
+
+    // ドラッグ開始（clientX=200）
+    fireEvent.mouseDown(scroller, { clientX: 200 });
+    // ドラッグ中は cursor-grabbing, userSelect=none
+    expect(scroller.className).toContain("cursor-grabbing");
+    expect(scroller.style.userSelect).toBe("none");
+
+    // 右方向に 50px ドラッグ（clientX: 250） => scrollLeft は 100 - (250-200) = 50
+    fireEvent.mouseMove(scroller, { clientX: 250 });
+    expect(scroller.scrollLeft).toBe(50);
+
+    // ドラッグ終了
+    fireEvent.mouseUp(scroller);
+    expect(scroller.className).toContain("cursor-grab");
+    expect(
+      scroller.style.userSelect === "" || scroller.style.userSelect === "auto",
+    ).toBeTruthy();
+  });
+
+  it("リサイズでボタンの表示とカーソル状態が切り替わる", async () => {
+    const { container } = render(
+      <HorizontalScrollContainer>
+        <div />
+      </HorizontalScrollContainer>,
+    );
+
+    const scroller = container.querySelector(
+      ".custom-scrollbar",
+    ) as HTMLDivElement;
+    Object.defineProperty(scroller, "scrollWidth", {
+      value: 1000,
+      configurable: true,
+    });
+
+    // デスクトップ時は右ボタンが表示され、カーソルは grab
+    expect(
+      await screen.findByRole("button", { name: "次のミッションを表示" }),
+    ).toBeInTheDocument();
+    expect(scroller.className).toContain("cursor-grab");
+
+    // モバイル幅に変更
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 600,
+    });
+    window.dispatchEvent(new Event("resize"));
+
+    // ボタン非表示、カーソル状態もドラッグ向けクラスが外れる
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "次のミッションを表示" }),
+      ).toBeNull();
+    });
+    expect(scroller.className).not.toContain("cursor-grab");
+    expect(scroller.className).not.toContain("cursor-grabbing");
+
+    // 再びデスクトップに戻す
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+    });
+    window.dispatchEvent(new Event("resize"));
+
+    // 条件を満たせば右ボタンが再表示
+    expect(
+      await screen.findByRole("button", { name: "次のミッションを表示" }),
+    ).toBeInTheDocument();
+  });
+
+  it("className がマージされ、ドラッグ中も保持される", () => {
+    const { container } = render(
+      <HorizontalScrollContainer className="my-custom">
+        <div />
+      </HorizontalScrollContainer>,
+    );
+
+    const scroller = container.querySelector(
+      ".custom-scrollbar",
+    ) as HTMLDivElement;
+    expect(scroller).toBeTruthy();
+
+    // マージ確認（custom-scrollbar と my-custom が共存）
+    expect(scroller.className).toContain("custom-scrollbar");
+    expect(scroller.className).toContain("my-custom");
+
+    // ドラッグで状態が変わっても my-custom は保持される
+    fireEvent.mouseDown(scroller, { clientX: 10 });
+    expect(scroller.className).toContain("cursor-grabbing");
+    expect(scroller.className).toContain("my-custom");
+    fireEvent.mouseUp(scroller);
+    expect(scroller.className).toContain("cursor-grab");
+    expect(scroller.className).toContain("my-custom");
+  });
+});

--- a/src/features/missions/components/horizontal-scroll-container.tsx
+++ b/src/features/missions/components/horizontal-scroll-container.tsx
@@ -137,13 +137,13 @@ export function HorizontalScrollContainer({
     handleDragEnd();
   }, [handleDragEnd, isDesktop]);
 
-  const button_style = (
-    side: "left" | "right",
-  ) => `absolute top-1/2 -translate-y-1/2 z-10
-      flex items-center justify-center
-      w-12 h-12 rounded-full bg-white shadow-lg border-2
-      hover:bg-gray-50 transition-colors
-      ${side}-2`;
+  const button_style = (side: "left-2" | "right-2") =>
+    cn(
+      side,
+      "absolute top-1/2 -translate-y-1/2 z-10",
+      "flex items-center justify-center w-12 h-12 rounded-full",
+      "bg-white shadow-lg border-2 hover:bg-gray-50 transition-colors",
+    );
 
   return (
     <div className="relative">
@@ -151,7 +151,7 @@ export function HorizontalScrollContainer({
         <button
           type="button"
           onClick={scrollLeftButton}
-          className={button_style("left")}
+          className={button_style("left-2")}
           aria-label="前のミッションを表示"
         >
           <ChevronLeft />
@@ -185,7 +185,7 @@ export function HorizontalScrollContainer({
         <button
           type="button"
           onClick={scrollRight}
-          className={button_style("right")}
+          className={button_style("right-2")}
           aria-label="次のミッションを表示"
         >
           <ChevronRight />


### PR DESCRIPTION
# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ミッションの右スクロールボタンが左側に寄ってしまっていたため
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

||変更前|変更後|
|-|-|-|
|ミッションがすべて表示される場合|<img width="1100" height="872" alt="image" src="https://github.com/user-attachments/assets/fd0581d8-208d-4589-ac02-f0ac36b96f70" />|<img width="1100" height="872" alt="image" src="https://github.com/user-attachments/assets/c0950203-1dbd-4a62-b0dd-8fdd789f5c39" />|
|右ボタンのみ|<img width="1100" height="872" alt="image" src="https://github.com/user-attachments/assets/33069d4b-23c9-41f2-9215-5f789168378e" />|<img width="1100" height="872" alt="image" src="https://github.com/user-attachments/assets/eebc3524-8b9c-4abe-a8d7-411a11465b57" />|
|左ボタンのみ|<img width="1100" height="872" alt="image" src="https://github.com/user-attachments/assets/812fa683-9586-4d6a-a226-b47b87b057db" />|<img width="1100" height="872" alt="image" src="https://github.com/user-attachments/assets/cca9c514-031f-4ade-ba23-c1266d976fc4" />|
|両方|<img width="1100" height="872" alt="image" src="https://github.com/user-attachments/assets/cf1cb039-e668-4a73-b3ae-bcfa09e3f859" />|<img width="1100" height="872" alt="image" src="https://github.com/user-attachments/assets/957e3d53-b7fc-4a6f-80af-0cecece5ed01" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

このプルリクエストはユーザー向けの新機能やバグ修正を含まず、内部コードの保守性向上を目的とした改善のみとなっています。ユーザーへの影響はございません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->