### PR TITLE
Fix/mission scroll right button

### DIFF
--- a/src/features/missions/components/horizontal-scroll-container.tsx
+++ b/src/features/missions/components/horizontal-scroll-container.tsx
@@ -137,12 +137,13 @@ export function HorizontalScrollContainer({
     handleDragEnd();
   }, [handleDragEnd, isDesktop]);
 
-  const button_style = (side: "left-2" | "right-2") =>
+  const button_style = (side: "left" | "right") =>
     cn(
-      side,
-      "absolute top-1/2 -translate-y-1/2 z-10",
-      "flex items-center justify-center w-12 h-12 rounded-full",
-      "bg-white shadow-lg border-2 hover:bg-gray-50 transition-colors",
+      `absolute top-1/2 -translate-y-1/2 z-10
+      flex items-center justify-center
+      w-12 h-12 rounded-full bg-white shadow-lg border-2
+      hover:bg-gray-50 transition-colors`,
+      side === "left" ? "left-2" : "right-2",
     );
 
   return (
@@ -151,7 +152,7 @@ export function HorizontalScrollContainer({
         <button
           type="button"
           onClick={scrollLeftButton}
-          className={button_style("left-2")}
+          className={button_style("left")}
           aria-label="前のミッションを表示"
         >
           <ChevronLeft />
@@ -185,7 +186,7 @@ export function HorizontalScrollContainer({
         <button
           type="button"
           onClick={scrollRight}
-          className={button_style("right-2")}
+          className={button_style("right")}
           aria-label="次のミッションを表示"
         >
           <ChevronRight />


### PR DESCRIPTION
問題の本質は {side}-2 という文字列処理で left-2 right-2 を使用していたが、 tailwind の仕組み上、これだとコンパイル済みの css に left-2, right-2 が含まれない。