### PR TITLE
postingのメモ機能

### DIFF
--- a/src/features/map-posting/components/shape-status-dialog.tsx
+++ b/src/features/map-posting/components/shape-status-dialog.tsx
@@ -18,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -58,11 +59,13 @@ export function ShapeStatusDialog({
   const [completedPostingCount, setCompletedPostingCount] = useState<
     number | null
   >(null);
+  const [memo, setMemo] = useState<string>("");
 
   // ダイアログ開時にミッション達成状況を取得
   useEffect(() => {
     if (shape?.id && isOpen) {
       setSelectedStatus(shape.status || "planned");
+      setMemo(shape.memo || "");
       setPostingCount(null);
       setIsLoading(true);
 
@@ -95,8 +98,8 @@ export function ShapeStatusDialog({
 
     setIsUpdating(true);
     try {
-      // 1. ステータスを更新
-      await updateShapeStatus(shape.id, selectedStatus);
+      // 1. ステータスとメモを更新
+      await updateShapeStatus(shape.id, selectedStatus, memo || null);
 
       // 2. 配布完了 & 未達成の場合、ミッション達成処理
       if (
@@ -183,6 +186,18 @@ export function ShapeStatusDialog({
                   )}
                 </SelectContent>
               </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="memo">メモ</Label>
+              <Textarea
+                id="memo"
+                value={memo}
+                onChange={(e) => setMemo(e.target.value)}
+                placeholder="地域の特性などを記録"
+                rows={3}
+                disabled={!isOwner}
+              />
             </div>
 
             {selectedStatus === "completed" && !isMissionCompleted && (

--- a/src/features/map-posting/services/posting-shapes.ts
+++ b/src/features/map-posting/services/posting-shapes.ts
@@ -119,11 +119,13 @@ export async function updateShape(id: string, data: Partial<MapShape>) {
 export async function updateShapeStatus(
   id: string,
   status: PostingShapeStatus,
+  memo?: string | null,
 ) {
   const { data, error } = await supabase
     .from("posting_shapes")
     .update({
       status,
+      memo,
       updated_at: new Date().toISOString(),
     })
     .eq("id", id)

--- a/src/features/map-posting/types/posting-types.ts
+++ b/src/features/map-posting/types/posting-types.ts
@@ -9,6 +9,7 @@ export interface MapShape {
   coordinates: Json;
   properties?: Json;
   status?: PostingShapeStatus;
+  memo?: string | null;
   user_id?: string;
   user_display_name?: string;
   event_id?: string;

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -835,6 +835,7 @@ export type Database = {
           created_at: string | null;
           event_id: string;
           id: string;
+          memo: string | null;
           properties: Json | null;
           status: Database["public"]["Enums"]["posting_shape_status"];
           type: string;
@@ -846,6 +847,7 @@ export type Database = {
           created_at?: string | null;
           event_id: string;
           id?: string;
+          memo?: string | null;
           properties?: Json | null;
           status?: Database["public"]["Enums"]["posting_shape_status"];
           type: string;
@@ -857,6 +859,7 @@ export type Database = {
           created_at?: string | null;
           event_id?: string;
           id?: string;
+          memo?: string | null;
           properties?: Json | null;
           status?: Database["public"]["Enums"]["posting_shape_status"];
           type?: string;

--- a/supabase/migrations/20260115095209_add_posting_shapes_memo.sql
+++ b/supabase/migrations/20260115095209_add_posting_shapes_memo.sql
@@ -1,0 +1,9 @@
+-- Add memo column to posting_shapes table
+-- Issue #1605: ポスティングマップのモーダルにメモ機能を追加
+
+-- Add memo column (optional text field for user notes about shapes)
+ALTER TABLE public.posting_shapes
+ADD COLUMN memo TEXT;
+
+-- Add comment for documentation
+COMMENT ON COLUMN public.posting_shapes.memo IS 'User notes for shapes (optional input)';


### PR DESCRIPTION
- posting_shapesテーブルにmemoカラムを追加するマイグレーションを作成
- MapShapeインターフェースにmemoフィールドを追加
- updateShapeStatus関数にmemoパラメータを追加
- ShapeStatusDialogにメモ入力用のTextareaコンポーネントを追加
  - 配布ステータスの下にメモ欄を配置
  - プレースホルダーに「地域の特性などを記録」と表示
  - 3行のTextareaで任意入力として実装
  - オーナー以外はdisabledに

Resolves #1605

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました