### PR TITLE
管理者が全てのシェイプを管理できるようにする機能を追加

### DIFF
--- a/src/app/map/posting/[slug]/page.tsx
+++ b/src/app/map/posting/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import PostingPageClient from "@/features/map-posting/components/posting-page";
 import { getEventBySlug } from "@/features/map-posting/services/posting-events.server";
 import { getUser } from "@/features/user-profile/services/profile";
+import { isAdmin } from "@/lib/utils/admin";
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 
@@ -47,6 +48,7 @@ export default async function PostingEventPage({
       userId={user.id}
       eventId={event.id}
       eventTitle={event.title}
+      isAdmin={isAdmin(user)}
     />
   );
 }

--- a/src/features/map-posting/components/posting-page.tsx
+++ b/src/features/map-posting/components/posting-page.tsx
@@ -33,6 +33,7 @@ export default function PostingPageClient({
   userId,
   eventId,
   eventTitle,
+  isAdmin,
 }: PostingPageClientProps) {
   const [mapInstance, setMapInstance] = useState<LeafletMap | null>(null);
   const [showText, setShowText] = useState(true);
@@ -771,6 +772,7 @@ export default function PostingPageClient({
         onOpenChange={setIsStatusDialogOpen}
         shape={selectedShape}
         currentUserId={userId}
+        isAdmin={isAdmin}
         onStatusUpdated={handleStatusUpdated}
         onDelete={async (id) => {
           await handleDeleteShape(id, { removeFromMap: true });

--- a/src/features/map-posting/components/shape-status-dialog.tsx
+++ b/src/features/map-posting/components/shape-status-dialog.tsx
@@ -38,6 +38,7 @@ interface ShapeStatusDialogProps {
   onOpenChange: (open: boolean) => void;
   shape: MapShape | null;
   currentUserId: string;
+  isAdmin: boolean;
   onStatusUpdated: (
     id: string,
     newStatus: PostingShapeStatus,
@@ -51,11 +52,14 @@ export function ShapeStatusDialog({
   onOpenChange,
   shape,
   currentUserId,
+  isAdmin,
   onStatusUpdated,
   onDelete,
 }: ShapeStatusDialogProps) {
   // Check if the current user owns this shape
   const isOwner = shape?.user_id === currentUserId || !shape?.user_id;
+  // Allow edit if user is owner or admin
+  const canEdit = isOwner || isAdmin;
   const [selectedStatus, setSelectedStatus] =
     useState<PostingShapeStatus>("planned");
   const [postingCount, setPostingCount] = useState<number | null>(null);
@@ -163,9 +167,9 @@ export function ShapeStatusDialog({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>配布ステータス{isOwner ? "の変更" : ""}</DialogTitle>
+          <DialogTitle>配布ステータス{canEdit ? "の変更" : ""}</DialogTitle>
           <DialogDescription>
-            {isOwner
+            {canEdit
               ? "選択した図形の配布ステータスを変更します"
               : "この図形は他のユーザーが作成したため、変更できません"}
             {isMissionCompleted && (
@@ -194,7 +198,7 @@ export function ShapeStatusDialog({
                 onValueChange={(value) =>
                   setSelectedStatus(value as PostingShapeStatus)
                 }
-                disabled={!isOwner}
+                disabled={!canEdit}
               >
                 <SelectTrigger id="status">
                   <SelectValue />
@@ -232,7 +236,7 @@ export function ShapeStatusDialog({
                     )
                   }
                   placeholder="配布した枚数を入力"
-                  disabled={!isOwner}
+                  disabled={!canEdit}
                 />
                 <p className="text-muted-foreground text-sm">
                   配布完了を保存すると、ミッションが自動で達成されます
@@ -254,13 +258,13 @@ export function ShapeStatusDialog({
                 onChange={(e) => setMemo(e.target.value)}
                 placeholder="地域の特性などを記録"
                 rows={3}
-                disabled={!isOwner}
+                disabled={!canEdit}
               />
             </div>
           </div>
         )}
         <DialogFooter className="flex-row justify-between sm:justify-between">
-          {isOwner && onDelete ? (
+          {canEdit && onDelete ? (
             <Button
               variant="link"
               onClick={handleDelete}
@@ -278,9 +282,9 @@ export function ShapeStatusDialog({
               onClick={() => onOpenChange(false)}
               disabled={isUpdating || isDeleting}
             >
-              {isOwner ? "キャンセル" : "閉じる"}
+              {canEdit ? "キャンセル" : "閉じる"}
             </Button>
-            {isOwner && (
+            {canEdit && (
               <Button
                 onClick={handleStatusUpdate}
                 disabled={isUpdating || isDeleting || isLoading || !canSubmit}

--- a/src/features/map-posting/types/posting-types.ts
+++ b/src/features/map-posting/types/posting-types.ts
@@ -61,6 +61,7 @@ export interface PostingPageClientProps {
   userId: string;
   eventId: string;
   eventTitle: string;
+  isAdmin: boolean;
 }
 
 // === Leaflet and Geoman Types ===

--- a/src/lib/utils/admin.ts
+++ b/src/lib/utils/admin.ts
@@ -1,0 +1,16 @@
+import type { User } from "@supabase/supabase-js";
+
+/**
+ * ユーザーが管理者かどうかをチェックする
+ * raw_app_meta_data.roles に "admin" が含まれているかを確認
+ * @param user Supabase User オブジェクト
+ * @returns 管理者の場合 true
+ */
+export function isAdmin(user: User | null): boolean {
+  if (!user) return false;
+
+  const roles = user.app_metadata?.roles;
+  if (!Array.isArray(roles)) return false;
+
+  return roles.includes("admin");
+}

--- a/supabase/migrations/20260116000000_add_admin_posting_shapes_rls.sql
+++ b/supabase/migrations/20260116000000_add_admin_posting_shapes_rls.sql
@@ -1,0 +1,33 @@
+-- 管理者ユーザー向け posting_shapes RLS ポリシー追加
+-- Issue #1619: 管理者が全てのシェイプを管理できるようにする
+
+-- ヘルパー関数: ユーザーが管理者かどうかをチェック
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT COALESCE(
+    (
+      SELECT (auth.jwt() -> 'app_metadata' -> 'roles')::jsonb ? 'admin'
+    ),
+    false
+  );
+$$;
+
+-- 既存のポリシーを削除
+DROP POLICY IF EXISTS "Users can update own posting shapes" ON public.posting_shapes;
+DROP POLICY IF EXISTS "Users can delete own posting shapes" ON public.posting_shapes;
+
+-- 更新ポリシー: 作成者または管理者が更新可能
+CREATE POLICY "Users can update own posting shapes or admin"
+  ON public.posting_shapes
+  FOR UPDATE
+  USING (auth.uid() = user_id OR user_id IS NULL OR public.is_admin());
+
+-- 削除ポリシー: 作成者または管理者が削除可能
+CREATE POLICY "Users can delete own posting shapes or admin"
+  ON public.posting_shapes
+  FOR DELETE
+  USING (auth.uid() = user_id OR user_id IS NULL OR public.is_admin());

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -6,6 +6,12 @@ VALUES
 ON CONFLICT (slug) DO NOTHING;
 
 -- auth.usersテーブルにユーザーを追加（外部キー制約のため）
+-- 管理者ユーザー（admin@example.com / admin123456）
+INSERT INTO auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, last_sign_in_at, raw_app_meta_data, raw_user_meta_data, email_change, email_change_token_new, recovery_token, confirmation_token, confirmation_sent_at, created_at, updated_at)
+VALUES
+  ('00000000-0000-0000-0000-000000000000', 'a0000000-0000-0000-0000-000000000001', 'authenticated', 'authenticated', 'admin@example.com', crypt('admin123456', gen_salt('bf')), now(), now(), '{"provider": "email", "providers": ["email"], "roles": ["admin"]}', '{"email_verified": true}', '', '', '', '', now(), now(), now())
+ON CONFLICT (id) DO NOTHING;
+
 INSERT INTO auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, last_sign_in_at, raw_app_meta_data, raw_user_meta_data, email_change, email_change_token_new, recovery_token, confirmation_token, confirmation_sent_at, created_at, updated_at)
 VALUES
   ('00000000-0000-0000-0000-000000000000', '622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'authenticated', 'authenticated', 'takahiroanno@example.com', crypt('password123', gen_salt('bf')), now(), now(), '{"provider": "email", "providers": ["email"]}', '{"email_verified": true}', '', '', '', '', now(), now(), now()),
@@ -22,6 +28,12 @@ VALUES
   ('00000000-0000-0000-0000-000000000000', '6ba7b818-9dad-11d1-80b4-00c04fd430c8', 'authenticated', 'authenticated', 'matsumoto.kana@example.com', crypt('password123', gen_salt('bf')), now(), now(), '{"provider": "email", "providers": ["email"]}', '{"email_verified": true}', '', '', '', '', now(), now(), now());
 
 -- private usersテーブルにデータを追加
+-- 管理者ユーザー
+INSERT INTO private_users (id, date_of_birth, postcode)
+VALUES
+  ('a0000000-0000-0000-0000-000000000001', '1985-01-01', '1000000')
+ON CONFLICT (id) DO NOTHING;
+
 INSERT INTO private_users (id, date_of_birth, postcode)
 VALUES
   ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', '1990-12-01', '1000001'),
@@ -38,6 +50,12 @@ VALUES
   ('6ba7b818-9dad-11d1-80b4-00c04fd430c8', '1998-01-03', '9000001');
 
 -- public_user_profilesテーブルにデータを追加
+-- 管理者ユーザー
+INSERT INTO public_user_profiles (id, name, address_prefecture, x_username, github_username)
+VALUES
+  ('a0000000-0000-0000-0000-000000000001', '管理者', '東京都', NULL, NULL)
+ON CONFLICT (id) DO NOTHING;
+
 INSERT INTO public_user_profiles (id, name, address_prefecture, x_username, github_username)
 VALUES
   ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', '安野たかひろ', '東京都', 'takahiroanno', 'takahiroanno'),


### PR DESCRIPTION
管理者が全てのシェイプを管理できるようにする機能を追加。

- RLSポリシーを修正し、管理者がposting_shapesを更新・削除可能に
- is_admin() PostgreSQL関数でapp_metadataからロールをチェック
- isAdmin() TypeScriptヘルパー関数を追加
- ShapeStatusDialogで管理者もcanEdit可能に変更
- シードデータに管理者ユーザー (admin@example.com / admin123456) を追加

Resolves #1619

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 管理者ロール機能を追加しました。管理者はポスティング情報の編集・削除が可能になります。

* **改善**
  * 権限管理ロジックを更新し、オーナーまたは管理者による操作をサポートしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->