### PR TITLE
活動タイムラインを上部に表示するように

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -27,6 +27,13 @@ jest.mock("next/link", () => {
 });
 
 jest.mock("lucide-react", () => ({
+  ChevronRight: ({ className }) => {
+    const mockReact = require("react");
+    return mockReact.createElement("div", {
+      "data-testid": "chevron-right-icon",
+      className,
+    });
+  },
   CheckIcon: ({ size, className }) => {
     const mockReact = require("react");
     return mockReact.createElement("div", {

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,0 +1,45 @@
+import { Card } from "@/components/ui/card";
+import GlobalActivities from "@/features/user-activity/components/global-activities";
+import {
+  getGlobalActivityTimeline,
+  getGlobalActivityTimelineCount,
+} from "@/features/user-activity/services/timeline";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "活動タイムライン | アクションボード",
+  description: "リアルタイムで更新される活動記録",
+};
+
+const PAGE_SIZE = 50;
+
+export default async function ActivitiesPage() {
+  const [timeline, totalCount] = await Promise.all([
+    getGlobalActivityTimeline(PAGE_SIZE),
+    getGlobalActivityTimelineCount(),
+  ]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-6xl mx-auto px-4">
+        <div className="flex flex-col gap-6">
+          <div className="text-center">
+            <h1 className="text-2xl md:text-4xl text-gray-900 mb-2">
+              ⏰ 活動タイムライン
+            </h1>
+            <p className="text-sm text-gray-600 mt-1">
+              リアルタイムで更新される活動記録
+            </p>
+          </div>
+          <Card className="border-2 border-gray-200 rounded-2xl shadow-lg p-8 bg-white">
+            <GlobalActivities
+              initialTimeline={timeline}
+              totalCount={totalCount}
+              pageSize={PAGE_SIZE}
+            />
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -88,8 +88,13 @@ export default async function Home({
         {/* メトリクスセクション */}
         <MetricsWithSuspense />
 
-        {/* ランキングセクション */}
+        {/* アクティビティセクション */}
         <section className="py-12 md:py-16 bg-white">
+          <Activities />
+        </section>
+
+        {/* ランキングセクション */}
+        <section className="md:py-16 bg-white">
           <RankingSection />
         </section>
 
@@ -108,11 +113,6 @@ export default async function Home({
           showAchievedMissions={true}
           id="missions"
         />
-      </section>
-
-      {/* アクティビティセクション */}
-      <section className="py-12 md:py-16 bg-white">
-        <Activities />
       </section>
     </div>
   );

--- a/src/features/metrics/components/metrics-layout.tsx
+++ b/src/features/metrics/components/metrics-layout.tsx
@@ -22,7 +22,7 @@ export function MetricsLayout({
       <div className="w-full max-w-xl bg-white rounded-md shadow-custom p-6 py-8">
         {/* ヘッダー部分：タイトルと最終更新日時 */}
         <div className="text-center mb-6">
-          <h2 className="text-xl font-bold text-black mb-1">{title}</h2>
+          <h2 className="text-2xl font-bold text-black mb-1">{title}</h2>
           <p className="text-xs text-black">{lastUpdated} 更新</p>
         </div>
 

--- a/src/features/metrics/components/metrics-with-suspense.tsx
+++ b/src/features/metrics/components/metrics-with-suspense.tsx
@@ -8,7 +8,7 @@ function MetricsSkeleton() {
     <section className="bg-gradient-hero flex justify-center py-6 px-4">
       <div className="w-full max-w-xl bg-white rounded-md shadow-custom p-6">
         <div className="text-center mb-6">
-          <h2 className="text-xl font-bold text-black mb-1">
+          <h2 className="text-2xl font-bold text-black mb-1">
             チームみらいの活動状況🚀
           </h2>
           <output aria-live="polite">

--- a/src/features/missions/components/mission-list.tsx
+++ b/src/features/missions/components/mission-list.tsx
@@ -80,7 +80,7 @@ export default async function Missions({
 
   return (
     <div className="flex flex-col gap-6 px-4 md:px-0">
-      <h2 id={id} className="text-center text-2xl md:text-4xl">
+      <h2 id={id} className="text-center text-2xl md:text-3xl">
         {title}
       </h2>
 

--- a/src/features/missions/components/missions-by-category.tsx
+++ b/src/features/missions/components/missions-by-category.tsx
@@ -122,7 +122,7 @@ export default async function MissionsByCategory({
 
   return (
     <div className="flex flex-col gap-11">
-      <h2 className="text-center text-2xl md:text-4xl my-5">📈 ミッション</h2>
+      <h2 className="text-center text-2xl md:text-3xl my-5">📈 ミッション</h2>
 
       {Object.values(grouped).map((missionsInCategory) => {
         const category = missionsInCategory[0];

--- a/src/features/ranking/components/base-ranking.tsx
+++ b/src/features/ranking/components/base-ranking.tsx
@@ -21,7 +21,7 @@ export const BaseRanking: React.FC<BaseRankingProps> = ({
   return (
     <div className="flex flex-col gap-6">
       <Card className="border-2 border-gray-200 rounded-2xl transition-all duration-300 p-8">
-        <h2 className="text-xl md:text-2xl text-gray-900 mb-6 text-center">
+        <h2 className="text-xl md:text-2xl text-gray-900 mb-4 text-center">
           {title}
         </h2>
         {children.length > 0 ? (

--- a/src/features/ranking/components/ranking-section.tsx
+++ b/src/features/ranking/components/ranking-section.tsx
@@ -12,16 +12,16 @@ import Link from "next/link";
 export default async function RankingSection() {
   return (
     <div className="max-w-6xl mx-auto">
-      <h2 className="text-2xl md:text-4xl text-gray-900 mb-8 text-center">
+      <h2 className="text-2xl md:text-3xl text-gray-900 mb-6 text-center">
         🏅アクションリーダー
       </h2>
       <Carousel className="max-w-[100vw] px-4">
         <CarouselContent className="mb-4 lg:-ml-6">
           <CarouselItem className="pl-0 lg:basis-1/2 lg:pl-6">
-            <RankingTop limit={5} period="daily" title="今日のトップ5" />
+            <RankingTop limit={3} period="daily" title="今日のトップ3" />
           </CarouselItem>
           <CarouselItem className="pl-0 lg:basis-1/2 lg:pl-6">
-            <RankingTop limit={5} title="全期間トップ5" />
+            <RankingTop limit={3} title="全期間トップ3" />
           </CarouselItem>
         </CarouselContent>
         <div className="flex gap-4 justify-center">

--- a/src/features/user-activity/actions/timeline-actions.ts
+++ b/src/features/user-activity/actions/timeline-actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { getGlobalActivityTimeline } from "@/features/user-activity/services/timeline";
+
+export async function fetchMoreGlobalActivities(limit: number, offset: number) {
+  return await getGlobalActivityTimeline(limit, offset);
+}

--- a/src/features/user-activity/components/activities.tsx
+++ b/src/features/user-activity/components/activities.tsx
@@ -1,52 +1,39 @@
 import { Card } from "@/components/ui/card";
-import { getPartyMembershipMap } from "@/features/party-membership/services/memberships";
 import { ActivityTimeline } from "@/features/user-activity/components/activity-timeline";
-import { createClient } from "@/lib/supabase/client";
+import { getGlobalActivityTimeline } from "@/features/user-activity/services/timeline";
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
 
 export default async function Activities() {
-  const supabase = createClient();
-
-  const { data: activityTimelines } = await supabase
-    .from("activity_timeline_view")
-    .select()
-    .order("created_at", { ascending: false })
-    .limit(10);
-
-  const membershipMap = await getPartyMembershipMap(
-    (activityTimelines ?? [])
-      .map((item) => item.user_id)
-      .filter((id): id is string => typeof id === "string" && id.length > 0),
-  );
-
-  const timelineWithMembership = (activityTimelines ?? []).map((item) => ({
-    ...item,
-    party_membership:
-      item.user_id && membershipMap[item.user_id]
-        ? membershipMap[item.user_id]
-        : null,
-  }));
+  const timeline = await getGlobalActivityTimeline(3);
 
   return (
-    <div className="max-w-6xl mx-auto px-4">
+    <div className="max-w-3xl mx-auto px-4">
       <div className="flex flex-col gap-6">
         <div className="text-center">
-          <h2 className="text-2xl md:text-4xl text-gray-900 mb-2">
+          <h2 className="text-2xl md:text-3xl text-gray-900 mb-1">
             ⏰ 活動タイムライン
           </h2>
-          <p className="text-sm text-gray-600 mt-1">
+          <p className="text-xs text-gray-600">
             リアルタイムで更新される活動記録
           </p>
         </div>
-        <Card className="border-2 border-gray-200 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 bg-white">
+        <Card className="rounded-2xl shadow-sm transition-all duration-300 p-8 bg-white">
           <div className="flex flex-col gap-6">
             <div className="flex flex-col gap-2">
-              <ActivityTimeline
-                timeline={timelineWithMembership}
-                hasNext={false}
-              />
+              <ActivityTimeline timeline={timeline} hasNext={false} />
             </div>
           </div>
         </Card>
+        <div className="flex justify-center">
+          <Link
+            href="/activities"
+            className="flex items-center text-teal-600 hover:text-teal-700"
+          >
+            もっと見る
+            <ChevronRight className="w-4 h-4 ml-1" />
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/features/user-activity/components/global-activities.tsx
+++ b/src/features/user-activity/components/global-activities.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { fetchMoreGlobalActivities } from "@/features/user-activity/actions/timeline-actions";
+import { ActivityTimeline } from "@/features/user-activity/components/activity-timeline";
+import type { ActivityTimelineItem } from "@/features/user-activity/types/activity-types";
+import { useState } from "react";
+
+interface GlobalActivitiesProps {
+  initialTimeline: ActivityTimelineItem[];
+  totalCount: number;
+  pageSize: number;
+}
+
+export default function GlobalActivities({
+  initialTimeline,
+  totalCount,
+  pageSize,
+}: GlobalActivitiesProps) {
+  const [timeline, setTimeline] =
+    useState<ActivityTimelineItem[]>(initialTimeline);
+  const [hasNext, setHasNext] = useState(totalCount > initialTimeline.length);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLoadMore = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+
+    try {
+      const newTimeline = await fetchMoreGlobalActivities(
+        pageSize,
+        timeline.length,
+      );
+
+      if (newTimeline.length > 0) {
+        const updatedTimeline = [...timeline, ...newTimeline];
+        setTimeline(updatedTimeline);
+        setHasNext(updatedTimeline.length < totalCount);
+      } else {
+        setHasNext(false);
+      }
+    } catch (error) {
+      console.error("Failed to load more activities:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <ActivityTimeline
+        timeline={timeline}
+        hasNext={hasNext && !isLoading}
+        onLoadMore={handleLoadMore}
+      />
+      {isLoading && (
+        <div className="text-center text-sm text-gray-500 mt-2">
+          読み込み中...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/user-activity/services/timeline.ts
+++ b/src/features/user-activity/services/timeline.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { getPartyMembershipMap } from "@/features/party-membership/services/memberships";
 import { getPartyMembership } from "@/features/party-membership/services/memberships";
 import type { ActivityTimelineItem } from "@/features/user-activity/types/activity-types";
 import { createClient } from "@/lib/supabase/client";
@@ -134,4 +135,59 @@ export async function getUserActivityTimelineCount(
   ]);
 
   return (achievementsCount.count || 0) + (activitiesCount.count || 0);
+}
+
+/**
+ * 全体の活動タイムラインを取得する（全ユーザー対象）
+ * @param limit - 取得する最大件数
+ * @param offset - 取得開始位置（デフォルト: 0）
+ * @returns パーティメンバーシップ付きの活動タイムラインアイテムの配列
+ */
+export async function getGlobalActivityTimeline(
+  limit: number,
+  offset = 0,
+): Promise<ActivityTimelineItem[]> {
+  const supabase = createClient();
+
+  const { data: activityTimelines } = await supabase
+    .from("activity_timeline_view")
+    .select()
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  const membershipMap = await getPartyMembershipMap(
+    (activityTimelines ?? [])
+      .map((item) => item.user_id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
+  );
+
+  return (activityTimelines ?? []).map((item) => ({
+    id: item.id ?? "",
+    user_id: item.user_id ?? "",
+    name: item.name ?? "",
+    address_prefecture: item.address_prefecture,
+    avatar_url: item.avatar_url,
+    title: item.title ?? "",
+    mission_id: item.mission_id,
+    created_at: item.created_at ?? "",
+    activity_type: item.activity_type ?? "",
+    party_membership:
+      item.user_id && membershipMap[item.user_id]
+        ? membershipMap[item.user_id]
+        : null,
+  }));
+}
+
+/**
+ * 全体の活動タイムラインの総数を取得する
+ * @returns 活動タイムラインの総数
+ */
+export async function getGlobalActivityTimelineCount(): Promise<number> {
+  const supabase = createClient();
+
+  const { count } = await supabase
+    .from("activity_timeline_view")
+    .select("*", { count: "exact", head: true });
+
+  return count || 0;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * グローバルアクティビティタイムラインを表示する新しいアクティビティページを追加しました
  * アクティビティセクションに「詳細を見る」リンクを追加し、追加のアクティビティを読み込めるようにしました

* **スタイル**
  * ホームページのセクション順序を変更し、アクティビティセクションをメトリクスセクションの直後に移動しました
  * ページ全体の見出しサイズと間隔を調整しました
  * アクティビティセクションのカード表示をリフレッシュしました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->