### PR TITLE
表示するポスティングイベントを切り替えられるように

### DIFF
--- a/posting_data/posting_events.yaml
+++ b/posting_data/posting_events.yaml
@@ -1,7 +1,7 @@
 posting_events:
   - slug: default
-    title: デフォルトイベント
-    description: 初期イベント
+    title: 2025年6月~
+    description: 2025年6月からのポスティングイベント
     is_active: false
   - slug: 2026-01
     title: 2026年1月~

--- a/src/features/map-posting/components/posting-page.tsx
+++ b/src/features/map-posting/components/posting-page.tsx
@@ -916,6 +916,7 @@ export default function PostingPageClient({
       />
 
       <PostingControlPanel
+        eventId={eventId}
         eventTitle={eventTitle}
         totalPostingCount={totalPostingCount}
         showOnlyMine={showOnlyMine}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ポスティングイベント選択ドロップダウンを追加しました。複数のイベント間をシームレスに切り替えられます。

* **改善**
  * イベント情報の表示形式を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->