### PR TITLE
YouTubeダッシュボードをデフォルトで今年の分を表示

### DIFF
--- a/src/app/youtube_stats/page.tsx
+++ b/src/app/youtube_stats/page.tsx
@@ -41,7 +41,7 @@ export default async function YouTubeStatsPage({ searchParams }: PageProps) {
   const resolvedSearchParams = await searchParams;
   const sort = resolvedSearchParams.sort || "published_at";
   const page = Math.max(1, Number(resolvedSearchParams.page) || 1);
-  const period = resolvedSearchParams.period || "all";
+  const period = resolvedSearchParams.period || "this_year";
   const customStartDate = resolvedSearchParams.startDate;
   const customEndDate = resolvedSearchParams.endDate;
   const offset = (page - 1) * PAGE_SIZE;

--- a/src/features/metrics/components/metrics-index.tsx
+++ b/src/features/metrics/components/metrics-index.tsx
@@ -31,7 +31,9 @@ export async function Metrics() {
     };
   }
 
-  // YouTube統計を取得
+  // YouTube統計を取得（今年の1月1日以降のデータのみ）
+  const thisYear = new Date().getFullYear();
+  const startOfYear = new Date(`${thisYear}-01-01`);
   let youtubeStats = {
     totalVideos: 0,
     totalViews: 0,
@@ -39,7 +41,7 @@ export async function Metrics() {
     dailyVideosIncrease: 0,
   };
   try {
-    const stats = await getYouTubeStatsSummary();
+    const stats = await getYouTubeStatsSummary(startOfYear);
     youtubeStats = {
       totalVideos: stats.totalVideos,
       totalViews: stats.totalViews,
@@ -77,6 +79,7 @@ export async function Metrics() {
         totalVideos={youtubeStats.totalVideos}
         dailyViewsIncrease={youtubeStats.dailyViewsIncrease}
         dailyVideosIncrease={youtubeStats.dailyVideosIncrease}
+        startDate={startOfYear}
       />
     </MetricsLayout>
   );

--- a/src/features/metrics/components/youtube-metric.tsx
+++ b/src/features/metrics/components/youtube-metric.tsx
@@ -6,6 +6,17 @@ interface YouTubeMetricProps {
   totalVideos: number;
   dailyViewsIncrease?: number;
   dailyVideosIncrease?: number;
+  startDate?: Date;
+}
+
+/**
+ * 日付を YYYY.MM.DD 形式でフォーマット
+ */
+function formatDateLabel(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}.${month}.${day}`;
 }
 
 /**
@@ -16,13 +27,16 @@ export function YouTubeMetric({
   totalVideos,
   dailyViewsIncrease = 0,
   dailyVideosIncrease = 0,
+  startDate,
 }: YouTubeMetricProps) {
+  const dateLabel = startDate ? `${formatDateLabel(startDate)}-` : "";
   return (
     <div className="py-3">
       {/* 再生回数 */}
       <div className="flex justify-between">
         <div>
           <p className="text-base text-black mt-1">YouTube再生回数</p>
+          {dateLabel && <p className="text-xs text-gray-500">{dateLabel}</p>}
         </div>
         <div className="text-right">
           <p className="text-2xl font-black text-gray-800">
@@ -42,6 +56,7 @@ export function YouTubeMetric({
       <div className="flex justify-between mt-4">
         <div>
           <p className="text-base text-black mt-1">YouTube動画本数</p>
+          {dateLabel && <p className="text-xs text-gray-500">{dateLabel}</p>}
         </div>
         <div className="text-right">
           <p className="text-2xl font-black text-gray-800">

--- a/src/features/youtube-stats/components/youtube-period-filter.tsx
+++ b/src/features/youtube-stats/components/youtube-period-filter.tsx
@@ -27,7 +27,7 @@ interface YouTubePeriodFilterProps {
 }
 
 export function YouTubePeriodFilter({
-  defaultPeriod = "all",
+  defaultPeriod = "this_year",
   defaultStartDate,
   defaultEndDate,
 }: YouTubePeriodFilterProps) {

--- a/src/features/youtube-stats/services/youtube-stats-service.ts
+++ b/src/features/youtube-stats/services/youtube-stats-service.ts
@@ -319,7 +319,7 @@ export async function getOverallStatsHistory(
 
 /**
  * 日別の動画投稿数を取得する
- * @param startDate - 開始日（オプション、デフォルトは2025年5月1日）
+ * @param startDate - 開始日（オプション、デフォルトは2026年1月1日）
  * @param endDate - 終了日（オプション、デフォルトは今日）
  * @returns 日別の動画投稿数
  */
@@ -329,7 +329,7 @@ export async function getVideoCountByDate(
 ): Promise<VideoCountByDateItem[]> {
   const supabase = createClient();
 
-  const effectiveStartDate = startDate || new Date("2025-05-01");
+  const effectiveStartDate = startDate || new Date("2026-01-01");
   const effectiveEndDate = endDate || new Date();
 
   let query = supabase

--- a/src/features/youtube-stats/types/index.ts
+++ b/src/features/youtube-stats/types/index.ts
@@ -44,14 +44,22 @@ export const SORT_OPTIONS: { value: SortType; label: string }[] = [
   { value: "like_count", label: "いいね順" },
 ];
 
-export type PeriodType = "30" | "90" | "180" | "365" | "all" | "custom";
+export type PeriodType =
+  | "30"
+  | "90"
+  | "180"
+  | "365"
+  | "this_year"
+  | "all_time"
+  | "custom";
 
 export const PERIOD_OPTIONS: { value: PeriodType; label: string }[] = [
   { value: "30", label: "過去30日" },
   { value: "90", label: "過去90日" },
   { value: "180", label: "過去6ヶ月" },
   { value: "365", label: "過去1年" },
-  { value: "all", label: "全期間" },
+  { value: "this_year", label: "今年" },
+  { value: "all_time", label: "全期間" },
   { value: "custom", label: "カスタム" },
 ];
 
@@ -62,11 +70,18 @@ export function getPeriodStartDate(
   if (period === "custom" && customStart) {
     return new Date(customStart);
   }
-  if (period === "all") {
-    return new Date("2025-05-01");
+  if (period === "this_year") {
+    // 今年の1月1日
+    const year = new Date().getFullYear();
+    return new Date(`${year}-01-01`);
+  }
+  if (period === "all_time") {
+    return null; // 全期間は開始日なし
   }
   if (period === "custom") {
-    return new Date("2025-05-01");
+    // カスタムで開始日未指定の場合は今年の1月1日
+    const year = new Date().getFullYear();
+    return new Date(`${year}-01-01`);
   }
   const days = Number.parseInt(period, 10);
   const date = new Date();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * YouTube統計の期間フィルターに「今年」と「全期間」の新しいオプションを追加しました
  * 統計データに開始日付ラベルを表示するようにしました

* **Changes**
  * デフォルトの統計期間を「今年」に変更しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->