### PR TITLE
feat: メールアドレスをアカウント設定ページに表示する

### DIFF
--- a/src/app/(protected)/settings/profile/page.tsx
+++ b/src/app/(protected)/settings/profile/page.tsx
@@ -51,7 +51,7 @@ export default async function ProfileSettingsPage({
         }}
         initialPrivateUser={privateUser}
         partyMembership={partyMembership}
-        email={user.email || ""}
+        email={user.email || null}
       />
 
       {partyMembership && (

--- a/src/features/user-settings/components/profile-form.tsx
+++ b/src/features/user-settings/components/profile-form.tsx
@@ -55,7 +55,7 @@ interface ProfileFormProps {
     postcode?: string;
   } | null;
   partyMembership: PartyMembership | null;
-  email?: string;
+  email: string | null;
 }
 
 export default function ProfileForm({
@@ -275,9 +275,9 @@ export default function ProfileForm({
           {!isNew && (
             <div className="space-y-2">
               <Label htmlFor="email">メールアドレス</Label>
-              {email?.endsWith("@line.local") ? (
+              {!email || email?.endsWith("@line.local") ? (
                 <p className="text-sm text-gray-500">
-                  LINEにメールアドレスが登録されていなかったため、表示できません
+                  メールアドレスが登録されていないため、表示できません
                 </p>
               ) : (
                 <>
@@ -288,7 +288,7 @@ export default function ProfileForm({
                     // フォーム送信時に値が送信されないようにname属性は含めない
                     id="email"
                     type="email"
-                    value={email || ""}
+                    value={email}
                     disabled
                     className="bg-gray-50 cursor-not-allowed"
                   />


### PR DESCRIPTION
# 変更の概要

- アカウント設定画面に、自身のメールアドレスを表示しました
- 編集時のみで、新規作成時は除きます。
- メールアドレスが登録されていない場合は、その旨をメッセージ表示しました
  - アカウント登録時に、LINEからメールアドレスが取得できなかった場合は、内部的なメール文字列が設定される。
  - https://github.com/team-mirai-volunteer/action-board/blob/ca83f6aed78bc58d5c2b9279e4c6157452191e32/src/app/actions.ts#L569

## スクショ
### メールアドレスが登録されている場合
<img width="478" alt="image" src="https://github.com/user-attachments/assets/13973409-6a9e-4e27-8505-0c9019ba7b6a" />


### メールアドレスが登録されていない場合
<img width="478"  alt="image" src="https://github.com/user-attachments/assets/98fd5497-05fb-4ec2-aa95-1ab50318f9ed" />



# やらないこと
- メールアドレスの変更機能


# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #1548 


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * プロフィール設定でメール情報の表示が追加・改善されました。
    * 新規プロフィール以外でメール欄を表示。
    * メール未登録や特定の内部ドメインの場合は「未登録」旨を表示。
    * 登録済みメールは編集不可で非公開である旨の注記を表示。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->