### PR TITLE
ポスター都道府県enumに京都府を追加, load-csv警告log追加

### DIFF
--- a/poster_data/load-csv.ts
+++ b/poster_data/load-csv.ts
@@ -262,6 +262,9 @@ async function main() {
             );
             await db.query(`RELEASE SAVEPOINT ${savepoint}`);
           } catch (error2) {
+            console.warn(
+              `9-column format failed for ${file}. Error: ${error2 instanceof Error ? error2.message : error2}`,
+            );
             // Try legacy 7-column format (no district, no note)
             await db.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
             console.log("  Retrying with legacy 7-column format...");

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -1959,7 +1959,8 @@ export type Database = {
         | "大阪府"
         | "兵庫県"
         | "愛媛県"
-        | "福岡県";
+        | "福岡県"
+        | "京都府";
       posting_shape_status: "planned" | "completed" | "unavailable" | "other";
     };
     CompositeTypes: {
@@ -2117,6 +2118,7 @@ export const Constants = {
         "兵庫県",
         "愛媛県",
         "福岡県",
+        "京都府",
       ],
       posting_shape_status: ["planned", "completed", "unavailable", "other"],
     },

--- a/supabase/migrations/20260124065813_add_kyoto_to_prefecture_enum.sql
+++ b/supabase/migrations/20260124065813_add_kyoto_to_prefecture_enum.sql
@@ -1,0 +1,2 @@
+-- poster_prefecture_enum に 京都府 を追加
+ALTER TYPE poster_prefecture_enum ADD VALUE '京都府';


### PR DESCRIPTION
# 変更の概要
- poster_prefecture_enumに京都府を追加
- load-csv log追加

# 変更の背景
- 衆議院選挙2026において、新たに京都府が選挙区の対象となった。
- load-csv実行時例外の警告ログに不足部分があった。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 京都府が都道府県の選択肢として追加されました。ポスターデータの登録時に京都府を選択できるようになります。

* **改善**
  * データ読み込み処理のエラーログを強化し、トラブルシューティングがより効率的になりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->