### PR TITLE
`.pnpm-store` を git 管理から除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 /.pnp
 .pnp.*
+.pnpm-store
 .yarn/*
 !.yarn/patches
 !.yarn/plugins


### PR DESCRIPTION

# 変更の概要
`.gitignore` に `.pnpm-store` を追加し、pnpm のストアディレクトリを git 管理から除外しました。

# 変更の背景
- README の沿って Dev Containers で環境構築をすると、`pnpm install` で生成される `.pnpm-store` が git の差分として発生します
- 現状はプロジェクトルートに `.pnpm-store` が作成される設定になっています
  ```sh
  node@b05db0c3d074:/workspaces/action-board$ pnpm store path
  /workspaces/action-board/.pnpm-store/v3
  ```
# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境の構成を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->