### PR TITLE
fix fetch poster by district (#1711)

### DIFF
--- a/src/features/map-poster/actions/poster-boards.ts
+++ b/src/features/map-poster/actions/poster-boards.ts
@@ -267,6 +267,7 @@ export async function getUserEditedBoardIdsByDistrictAction(
       .from("poster_board_latest_editors")
       .select("board_id")
       .eq("district", district)
+      .eq("archived", false)
       .eq("last_editor_id", userId);
 
     if (error) {

--- a/supabase/migrations/20260124085138_add_columns_to_latest_editors_view.sql
+++ b/supabase/migrations/20260124085138_add_columns_to_latest_editors_view.sql
@@ -1,4 +1,4 @@
--- ビューposter_board_latest_editorsに district カラムを追加します。
+-- ビューposter_board_latest_editorsに district, archived カラムを追加します。
 -- 1. ビューに依存している関数を先に削除します
 DROP FUNCTION get_user_edited_boards_by_prefecture(poster_prefecture_enum, uuid);
 DROP FUNCTION get_user_edited_boards_with_details(poster_prefecture_enum, uuid);
@@ -21,7 +21,8 @@ WITH latest_history AS (
 SELECT 
   pb.id AS board_id,
   pb.prefecture,
-  pb.district, -- ★ここに追加
+  pb.district, -- 追加
+  pb.archived, -- 追加
   pb.lat,
   pb.long,
   pb.status,


### PR DESCRIPTION
# 変更の概要
- ビューposter_board_latest_editorsにdistrict, archivedを追加するため再作成(DROP→CREATE)する。依存する関数も再作成の必要がある。

# 変更の背景
- closes #1711

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * データベースのクエリ構造を最適化し、ユーザーが編集したボードの取得処理を効率化しました。

* **メンテナンス**
  * データベーススキーマを更新し、システムの安定性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->