### PR TITLE
同じTikTokアカウントを複数のユーザーが連携できないように

### DIFF
--- a/supabase/migrations/20260124143245_add_unique_constraint_tiktok_open_id.sql
+++ b/supabase/migrations/20260124143245_add_unique_constraint_tiktok_open_id.sql
@@ -1,0 +1,4 @@
+-- tiktok_open_idにユニーク制約を追加
+-- 同じTikTokアカウントを複数のユーザーが連携できないようにする
+ALTER TABLE tiktok_user_connections
+ADD CONSTRAINT tiktok_user_connections_tiktok_open_id_unique UNIQUE (tiktok_open_id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- TikTokアカウント連携時の重複チェック機能を追加しました。同じTikTokアカウントが複数のユーザーアカウントに連携されることがなくなります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->