### PR TITLE
Revert "同じTikTokアカウントを複数のユーザーが連携できないように (#1726)"

### DIFF
--- a/src/features/tiktok/actions/tiktok-auth-actions.ts
+++ b/src/features/tiktok/actions/tiktok-auth-actions.ts
@@ -43,24 +43,9 @@ export async function handleTikTokLinkAction(
     // TikTokユーザー情報を取得
     const tiktokUser = await fetchUserInfo(tokens.access_token);
 
+    // tiktok_user_connectionsテーブルに保存（upsert）
+    // NOTE: テーブルがSupabase型定義に存在しないため、マイグレーション適用後に npm run types で型を更新する
     const adminClient = await createAdminClient();
-
-    // 同じTikTokアカウントが他のユーザーに連携されていないかチェック
-    const { data: existingConnection } = await adminClient
-      .from("tiktok_user_connections")
-      .select("user_id")
-      .eq("tiktok_open_id", tiktokUser.open_id)
-      .maybeSingle();
-
-    if (existingConnection && existingConnection.user_id !== user.id) {
-      return {
-        success: false,
-        error:
-          "このTikTokアカウントは既に別のユーザーに連携されています。別のTikTokアカウントをお試しください。",
-      };
-    }
-
-    // tiktok_user_connectionsテーブルに保存
     const { error: upsertError } = await adminClient
       .from("tiktok_user_connections")
       .upsert(

--- a/supabase/migrations/20260124143245_add_unique_constraint_tiktok_open_id.sql
+++ b/supabase/migrations/20260124143245_add_unique_constraint_tiktok_open_id.sql
@@ -1,4 +1,0 @@
--- tiktok_open_idにユニーク制約を追加
--- 同じTikTokアカウントを複数のユーザーが連携できないようにする
-ALTER TABLE tiktok_user_connections
-ADD CONSTRAINT tiktok_user_connections_tiktok_open_id_unique UNIQUE (tiktok_open_id);


### PR DESCRIPTION
This reverts commit 0281dc23191fe8df9063bb46a56cef50285784b6.
- migration error のため

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * TikTok認証フローを簡素化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->