### PR TITLE
fix: restore poster_boards write policy

### DIFF
--- a/supabase/migrations/20260125013142_restore_poster_boards_write_policy.sql
+++ b/supabase/migrations/20260125013142_restore_poster_boards_write_policy.sql
@@ -1,0 +1,5 @@
+-- 削除されたUPDATEポリシーを復活させる。
+CREATE POLICY "poster_boards_update_policy" ON poster_boards
+  FOR UPDATE
+  USING (auth.uid() IS NOT NULL)
+  WITH CHECK (auth.uid() IS NOT NULL);


### PR DESCRIPTION
# 変更の概要
- poster_boardsのUPDATEポリシーを復活させる。

# 変更の背景
- closes #1730

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 認証ユーザーがポスターボードを更新できる機能を復元しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->