### PR TITLE
fix: poster-auto-load dir for shugin-2026

### DIFF
--- a/poster_data/auto-load-from-drive.ts
+++ b/poster_data/auto-load-from-drive.ts
@@ -13,7 +13,7 @@ import { basename, join } from "node:path";
 
 const SOURCE_PATH =
   "~/Google Drive/Shared drives/チームみらい(外部共有)/ポスター・ポスティングロジ/ポスター・ポスティング作業用/ポスター/ポスター掲示場CSV化/自治体";
-const SUCCESS_DATA_DIR = "poster_data/data";
+const SUCCESS_DATA_DIR = "poster_data/data/shugin-2026";
 const BROKEN_DATA_DIR = "poster_data/broken_data";
 const TEMP_DIR = "poster_data/temp";
 const CHOICE_LOG_FILE = "poster_data/choice.md";


### PR DESCRIPTION
# 変更の概要
- poster:auto-loadのディレクトリパスを2026衆院選用に修正

# 変更の背景
- closes #1745

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データ処理完了時の出力先ディレクトリのパスを更新しました。これに伴い、正常に処理されたデータの保存先が変更されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->