### PR TITLE
fix: poster-info copy toast

### DIFF
--- a/src/features/map-poster/components/detailed-poster-map-client.tsx
+++ b/src/features/map-poster/components/detailed-poster-map-client.tsx
@@ -199,11 +199,11 @@ export default function DetailedPosterMapClient({
     }
   }, [isUpdateDialogOpen, selectedBoard, userId]);
 
-  // 住所をクリップボードにコピー
-  const copyToClipboard = async (text: string) => {
+  // クリップボードにコピー
+  const copyToClipboard = async (text: string, label = "内容") => {
     try {
       await navigator.clipboard.writeText(text);
-      toast.success("住所をコピーしました");
+      toast.success(`${label}をコピーしました`);
     } catch (error) {
       toast.error("コピーに失敗しました");
     }
@@ -568,9 +568,9 @@ export default function DetailedPosterMapClient({
                   selectedBoard?.name ||
                   selectedBoard?.address ||
                   selectedBoard?.number;
-                if (text) copyToClipboard(text);
+                if (text) copyToClipboard(text, "名称");
               }}
-              title="名前/住所をコピー"
+              title="名称をコピー"
             >
               <Copy className="h-3 w-3" />
             </Button>
@@ -589,7 +589,7 @@ export default function DetailedPosterMapClient({
                     className="h-6 w-6 p-0"
                     onClick={() => {
                       const address = `${selectedBoard.city} ${selectedBoard.address}`;
-                      copyToClipboard(address);
+                      copyToClipboard(address, "住所");
                     }}
                     title="住所をコピー"
                   >
@@ -689,7 +689,7 @@ export default function DetailedPosterMapClient({
                     variant="ghost"
                     size="sm"
                     className="h-5 w-5 p-0"
-                    onClick={() => copyToClipboard(selectedBoard.id)}
+                    onClick={() => copyToClipboard(selectedBoard.id, "ID")}
                     title="IDをコピー"
                   >
                     <Copy className="h-3 w-3" />


### PR DESCRIPTION
# 変更の概要
- ポスター掲示場情報コピーボタン（名称、ID）押下時のtoast文言の修正

# 変更の背景
- closes #1748

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* コピー機能の確認メッセージを最適化しました。名称、住所、ボードIDなど、コピーした情報の種類に応じた詳細なメッセージが表示されるようになり、ユーザーが正確に何をコピーしたかを確認できるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->