### PR TITLE
Remove archived column from poster_boards and add election enum

### DIFF
--- a/src/app/map/poster/archive/[electionTerm]/[prefecture]/page.tsx
+++ b/src/app/map/poster/archive/[electionTerm]/[prefecture]/page.tsx
@@ -4,8 +4,11 @@ import {
   type PosterPrefectureKey,
 } from "@/features/map-poster/constants/poster-prefectures";
 import { getArchivedPosterBoardStats } from "@/features/map-poster/services/poster-boards";
+import type { Database } from "@/lib/types/supabase";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+
+type ElectionType = Database["public"]["Enums"]["election_type"];
 
 // Election term display names
 const ELECTION_TERM_NAMES: Record<string, string> = {
@@ -62,7 +65,10 @@ export default async function ArchivePrefecturePage({
   const prefectureJp = prefectureData.jp;
 
   // Get archived stats for this election term and prefecture
-  const stats = await getArchivedPosterBoardStats(electionTerm, prefectureJp);
+  const stats = await getArchivedPosterBoardStats(
+    electionTerm as ElectionType,
+    prefectureJp,
+  );
 
   return (
     <DetailedPosterMapClient

--- a/src/app/map/poster/archive/[electionTerm]/page.tsx
+++ b/src/app/map/poster/archive/[electionTerm]/page.tsx
@@ -4,6 +4,9 @@ import { statusConfig } from "@/features/map-poster/config/status-config";
 import { JP_TO_EN_PREFECTURE } from "@/features/map-poster/constants/poster-prefectures";
 import { getArchivedPosterBoardSummary } from "@/features/map-poster/services/poster-boards";
 import type { BoardStatus } from "@/features/map-poster/types/poster-types";
+import type { Database } from "@/lib/types/supabase";
+
+type ElectionType = Database["public"]["Enums"]["election_type"];
 import {
   calculateProgressRate,
   getCompletedCount,
@@ -48,7 +51,9 @@ export default async function ArchiveElectionTermPage({
   }
 
   // Get archived summary for this election term
-  const summary = await getArchivedPosterBoardSummary(electionTerm);
+  const summary = await getArchivedPosterBoardSummary(
+    electionTerm as ElectionType,
+  );
 
   // Calculate total stats
   let registeredTotal = 0;

--- a/src/features/map-poster/actions/poster-boards.ts
+++ b/src/features/map-poster/actions/poster-boards.ts
@@ -59,7 +59,7 @@ export async function getPosterBoardStatsAction(
           .select("*", { count: "exact", head: true })
           .eq("prefecture", prefecture)
           .eq("status", status)
-          .eq("archived", false);
+          .eq("election", "shugin-2026");
 
         if (error) {
           console.error(`Error counting ${status}:`, error);
@@ -74,7 +74,7 @@ export async function getPosterBoardStatsAction(
         .from("poster_boards")
         .select("*", { count: "exact", head: true })
         .eq("prefecture", prefecture)
-        .eq("archived", false);
+        .eq("election", "shugin-2026");
 
       // すべてのクエリを並列実行
       const [statusResults, totalResult] = await Promise.all([
@@ -200,7 +200,7 @@ export async function getPosterBoardStatsByDistrictAction(
       .from("poster_boards")
       .select("status")
       .eq("district", district)
-      .eq("archived", false);
+      .eq("election", "shugin-2026");
 
     if (error) {
       console.error("Error fetching district stats:", error);
@@ -269,7 +269,7 @@ export async function getUserEditedBoardIdsByDistrictAction(
       .from("poster_board_latest_editors")
       .select("board_id")
       .eq("district", district)
-      .eq("archived", false)
+      .eq("election", "shugin-2026")
       .eq("last_editor_id", userId);
 
     if (error) {
@@ -280,7 +280,7 @@ export async function getUserEditedBoardIdsByDistrictAction(
         .from("poster_boards")
         .select("id")
         .eq("district", district)
-        .eq("archived", false);
+        .eq("election", "shugin-2026");
 
       if (boardError || !boardData) {
         return [];

--- a/src/features/map-poster/components/detailed-poster-map-client.tsx
+++ b/src/features/map-poster/components/detailed-poster-map-client.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { achieveMissionAction } from "@/features/mission-detail/actions/actions";
+import type { Database } from "@/lib/types/supabase";
 import { Archive, ArrowLeft, Copy, HelpCircle, MapPin } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -54,6 +55,8 @@ import type {
   PosterBoardTotal,
   StatusHistory,
 } from "../types/poster-types";
+
+type ElectionType = Database["public"]["Enums"]["election_type"];
 import {
   calculateProgressRate,
   getCompletedCount,
@@ -226,7 +229,7 @@ export default function DetailedPosterMapClient({
       if (isArchive && archiveElectionTerm) {
         // アーカイブモードの場合
         data = await getArchivedPosterBoardsMinimal(
-          archiveElectionTerm,
+          archiveElectionTerm as ElectionType,
           prefecture,
         );
       } else if (isDistrict) {

--- a/src/features/map-poster/services/poster-boards-stats.ts
+++ b/src/features/map-poster/services/poster-boards-stats.ts
@@ -69,7 +69,7 @@ async function getFallbackStats(): Promise<{
       .select("prefecture, status")
       .not("lat", "is", null)
       .not("long", "is", null)
-      .eq("archived", false)
+      .eq("election", "shugin-2026")
       .range(page * pageSize, (page + 1) * pageSize - 1);
 
     if (error) {

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -700,11 +700,10 @@ export type Database = {
       poster_boards: {
         Row: {
           address: string | null;
-          archived: boolean | null;
           city: string;
           created_at: string;
           district: string | null;
-          election_term: string | null;
+          election: Database["public"]["Enums"]["election_type"] | null;
           file_name: string | null;
           id: string;
           lat: number | null;
@@ -718,11 +717,10 @@ export type Database = {
         };
         Insert: {
           address?: string | null;
-          archived?: boolean | null;
           city: string;
           created_at?: string;
           district?: string | null;
-          election_term?: string | null;
+          election?: Database["public"]["Enums"]["election_type"] | null;
           file_name?: string | null;
           id?: string;
           lat?: number | null;
@@ -736,11 +734,10 @@ export type Database = {
         };
         Update: {
           address?: string | null;
-          archived?: boolean | null;
           city?: string;
           created_at?: string;
           district?: string | null;
-          election_term?: string | null;
+          election?: Database["public"]["Enums"]["election_type"] | null;
           file_name?: string | null;
           id?: string;
           lat?: number | null;
@@ -1112,7 +1109,7 @@ export type Database = {
           city: string;
           created_at: string;
           district: string | null;
-          election_term: string | null;
+          election: Database["public"]["Enums"]["election_type"] | null;
           file_name: string | null;
           id: string | null;
           lat: number | null;
@@ -1129,7 +1126,7 @@ export type Database = {
           city: string;
           created_at?: string;
           district?: string | null;
-          election_term?: string | null;
+          election?: Database["public"]["Enums"]["election_type"] | null;
           file_name?: string | null;
           id?: string | null;
           lat?: number | null;
@@ -1146,7 +1143,7 @@ export type Database = {
           city?: string;
           created_at?: string;
           district?: string | null;
-          election_term?: string | null;
+          election?: Database["public"]["Enums"]["election_type"] | null;
           file_name?: string | null;
           id?: string | null;
           lat?: number | null;
@@ -1752,9 +1749,9 @@ export type Database = {
       };
       poster_board_latest_editors: {
         Row: {
-          archived: boolean | null;
           board_id: string | null;
           district: string | null;
+          election: Database["public"]["Enums"]["election_type"] | null;
           last_edited_at: string | null;
           last_editor_id: string | null;
           lat: number | null;
@@ -1840,7 +1837,7 @@ export type Database = {
         Returns: undefined;
       };
       get_archived_poster_board_stats: {
-        Args: { p_election_term: string };
+        Args: { p_election: Database["public"]["Enums"]["election_type"] };
         Returns: {
           count: number;
           prefecture: string;
@@ -2128,6 +2125,7 @@ export type Database = {
       is_posting_admin: { Args: never; Returns: boolean };
     };
     Enums: {
+      election_type: "sangin-2025" | "shugin-2026";
       poster_board_status:
         | "not_yet"
         | "reserved"
@@ -2285,6 +2283,7 @@ export const Constants = {
   },
   public: {
     Enums: {
+      election_type: ["sangin-2025", "shugin-2026"],
       poster_board_status: [
         "not_yet",
         "reserved",

--- a/supabase/migrations/20260125160000_remove_archived_add_election_enum.sql
+++ b/supabase/migrations/20260125160000_remove_archived_add_election_enum.sql
@@ -1,0 +1,237 @@
+-- Remove archived column and convert election_term to election enum
+-- The archived column is redundant since it's derived from election_term
+
+-- =========================================================================
+-- 1. Create election enum type
+-- =========================================================================
+CREATE TYPE election_type AS ENUM ('sangin-2025', 'shugin-2026');
+
+-- =========================================================================
+-- 2. Drop dependent views and functions that reference 'archived'
+-- =========================================================================
+
+-- Drop functions that depend on the view first
+DROP FUNCTION IF EXISTS get_user_edited_boards_by_prefecture(poster_prefecture_enum, uuid);
+DROP FUNCTION IF EXISTS get_user_edited_boards_with_details(poster_prefecture_enum, uuid);
+
+-- Drop the view
+DROP VIEW IF EXISTS poster_board_latest_editors;
+
+-- Drop the archived stats function
+DROP FUNCTION IF EXISTS get_archived_poster_board_stats(text);
+
+-- Drop functions that filter by archived
+DROP FUNCTION IF EXISTS get_poster_board_stats();
+DROP FUNCTION IF EXISTS get_poster_board_stats_optimized(poster_prefecture_enum);
+
+-- =========================================================================
+-- 3. Drop indexes on archived column
+-- =========================================================================
+DROP INDEX IF EXISTS idx_poster_boards_archived_election_term;
+
+-- =========================================================================
+-- 4. Add election column as enum, migrate data, then drop old columns
+-- =========================================================================
+
+-- Add new election column
+ALTER TABLE poster_boards
+ADD COLUMN election election_type;
+
+-- Migrate data from election_term to election
+UPDATE poster_boards
+SET election = election_term::election_type
+WHERE election_term IS NOT NULL;
+
+-- Add election column to staging table
+ALTER TABLE staging_poster_boards
+ADD COLUMN election election_type;
+
+-- Now drop archived and election_term columns
+ALTER TABLE poster_boards
+DROP COLUMN archived;
+
+ALTER TABLE poster_boards
+DROP COLUMN election_term;
+
+ALTER TABLE staging_poster_boards
+DROP COLUMN election_term;
+
+-- =========================================================================
+-- 5. Create index on election column
+-- =========================================================================
+CREATE INDEX idx_poster_boards_election ON poster_boards(election);
+
+-- =========================================================================
+-- 6. Recreate the view without archived column
+-- =========================================================================
+CREATE VIEW poster_board_latest_editors AS
+WITH latest_history AS (
+  SELECT DISTINCT ON (board_id)
+    board_id,
+    user_id,
+    created_at,
+    new_status,
+    previous_status
+  FROM poster_board_status_history
+  ORDER BY board_id, created_at DESC
+)
+SELECT
+  pb.id AS board_id,
+  pb.prefecture,
+  pb.district,
+  pb.election,
+  pb.lat,
+  pb.long,
+  pb.status,
+  lh.user_id AS last_editor_id,
+  lh.created_at AS last_edited_at,
+  lh.new_status,
+  lh.previous_status
+FROM poster_boards pb
+LEFT JOIN latest_history lh ON pb.id = lh.board_id;
+
+-- Grant permissions on the view
+GRANT SELECT ON poster_board_latest_editors TO authenticated, anon;
+
+-- =========================================================================
+-- 7. Recreate functions using election instead of archived
+-- =========================================================================
+
+-- Function to get poster board stats (active election only)
+CREATE OR REPLACE FUNCTION get_poster_board_stats()
+RETURNS TABLE (
+  prefecture text,
+  status poster_board_status,
+  count bigint
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    prefecture::text,
+    status,
+    COUNT(*)::bigint as count
+  FROM poster_boards
+  WHERE prefecture IS NOT NULL
+    AND lat IS NOT NULL
+    AND long IS NOT NULL
+    AND election = 'shugin-2026'  -- Active election
+  GROUP BY prefecture, status
+  ORDER BY prefecture, status;
+$$;
+
+-- Optimized stats function for a specific prefecture
+CREATE OR REPLACE FUNCTION get_poster_board_stats_optimized(
+  target_prefecture poster_prefecture_enum
+)
+RETURNS TABLE(
+  total_count bigint,
+  status_counts jsonb
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH status_summary AS (
+    SELECT
+      COUNT(*) FILTER (WHERE status = 'not_yet') AS not_yet_count,
+      COUNT(*) FILTER (WHERE status = 'not_yet_dangerous') AS not_yet_dangerous_count,
+      COUNT(*) FILTER (WHERE status = 'reserved') AS reserved_count,
+      COUNT(*) FILTER (WHERE status = 'done') AS done_count,
+      COUNT(*) FILTER (WHERE status = 'error_wrong_place') AS error_wrong_place_count,
+      COUNT(*) FILTER (WHERE status = 'error_damaged') AS error_damaged_count,
+      COUNT(*) FILTER (WHERE status = 'error_wrong_poster') AS error_wrong_poster_count,
+      COUNT(*) FILTER (WHERE status = 'other') AS other_count,
+      COUNT(*) AS total
+    FROM poster_boards
+    WHERE prefecture = target_prefecture
+      AND lat IS NOT NULL
+      AND long IS NOT NULL
+      AND election = 'shugin-2026'  -- Active election
+  )
+  SELECT
+    total,
+    jsonb_build_object(
+      'not_yet', not_yet_count,
+      'not_yet_dangerous', not_yet_dangerous_count,
+      'reserved', reserved_count,
+      'done', done_count,
+      'error_wrong_place', error_wrong_place_count,
+      'error_damaged', error_damaged_count,
+      'error_wrong_poster', error_wrong_poster_count,
+      'other', other_count
+    )
+  FROM status_summary;
+$$;
+
+-- Function to get user edited boards by prefecture
+CREATE OR REPLACE FUNCTION get_user_edited_boards_by_prefecture(
+  target_prefecture poster_prefecture_enum,
+  target_user_id uuid
+)
+RETURNS TABLE(board_id uuid)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT board_id
+  FROM poster_board_latest_editors
+  WHERE prefecture = target_prefecture
+    AND last_editor_id = target_user_id
+    AND election = 'shugin-2026'  -- Active election
+  ORDER BY last_edited_at DESC;
+$$;
+
+-- Function to get user edited boards with details
+CREATE OR REPLACE FUNCTION get_user_edited_boards_with_details(
+  target_prefecture poster_prefecture_enum,
+  target_user_id uuid
+)
+RETURNS TABLE(
+  board_id uuid,
+  lat double precision,
+  long double precision,
+  status poster_board_status,
+  last_edited_at timestamp with time zone
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    board_id,
+    lat,
+    long,
+    status,
+    last_edited_at
+  FROM poster_board_latest_editors
+  WHERE prefecture = target_prefecture
+    AND last_editor_id = target_user_id
+    AND election = 'shugin-2026'  -- Active election
+  ORDER BY last_edited_at DESC;
+$$;
+
+-- Function to get archived (past election) poster board stats
+CREATE OR REPLACE FUNCTION get_archived_poster_board_stats(p_election election_type)
+RETURNS TABLE (
+  prefecture text,
+  status poster_board_status,
+  count bigint
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    prefecture::text,
+    status,
+    COUNT(*)::bigint as count
+  FROM poster_boards
+  WHERE prefecture IS NOT NULL
+    AND election = p_election
+  GROUP BY prefecture, status
+  ORDER BY prefecture, status;
+$$;
+
+-- Grant execute permissions
+GRANT EXECUTE ON FUNCTION get_poster_board_stats() TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION get_poster_board_stats_optimized(poster_prefecture_enum) TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION get_user_edited_boards_by_prefecture(poster_prefecture_enum, uuid) TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION get_user_edited_boards_with_details(poster_prefecture_enum, uuid) TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION get_archived_poster_board_stats(election_type) TO authenticated, anon;


### PR DESCRIPTION
- Create election_type enum with 'sangin-2025' and 'shugin-2026' values
- Drop redundant archived column (was derived from election_term)
- Convert election_term text column to election enum column
- Update all SQL functions to filter by election instead of archived
- Update TypeScript services, actions, and types
- Update archive pages and map component to use election enum type
- Update load-csv script to use election column instead of archived

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 選挙タイプベースのデータ管理システムを導入しました。参院2025と衆院2026の選挙に対応しています。

* **Bug Fixes**
  * アーカイブフラグから選挙フィールドへの移行により、データフィルタリングロジックを改善しました。

* **Refactor**
  * レガシーなアーカイブ機能を廃止し、選挙別フィルタリングに統一しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->