### PR TITLE
本番デプロイ 01/27 15:50

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -10,6 +10,7 @@
     "ignore": [
       "**/.next/**",
       "**/node_modules/**",
+      "**/.pnpm-store/**",
       "**/supabase/.temp/**",
       "**/playwright-report/**",
       "**/coverage/**",

--- a/src/app/missions/[id]/page.tsx
+++ b/src/app/missions/[id]/page.tsx
@@ -8,8 +8,10 @@ import {
 } from "@/components/ui/card";
 import { getQuizQuestionsAction } from "@/features/mission-detail/actions/quiz-actions";
 import { MissionWithSubmissionHistory } from "@/features/mission-detail/components/mission-with-submission-history";
+import { RelatedMissions } from "@/features/mission-detail/components/related-missions";
 import { getMissionPageData } from "@/features/mission-detail/services/mission-detail";
 import { MissionDetails } from "@/features/missions/components/mission-details";
+import { getMissionAchievementCounts } from "@/features/missions/services/missions";
 import { CurrentUserCardMission } from "@/features/ranking/components/current-user-card-mission";
 import { RankingMission } from "@/features/ranking/components/ranking-mission";
 import {
@@ -84,8 +86,15 @@ export default async function MissionPage({ params }: Props) {
     return <div className="p-4">ミッションが見つかりません。</div>;
   }
 
-  const { mission, submissions, userAchievementCount, referralCode, mainLink } =
-    pageData;
+  const {
+    mission,
+    submissions,
+    userAchievementCount,
+    userAchievementCountMap,
+    referralCode,
+    mainLink,
+    allCategoryMissions,
+  } = pageData;
 
   // クイズミッションの場合は問題を事前取得
   let quizQuestions = null;
@@ -120,6 +129,9 @@ export default async function MissionPage({ params }: Props) {
       badgeText = `${(userWithMissionRanking.user_achievement_count ?? 0).toLocaleString()}回`;
     }
   }
+
+  // 全体の達成数取得
+  const achievementCountMap = await getMissionAchievementCounts();
 
   return (
     <div className="container mx-auto max-w-4xl p-4">
@@ -192,6 +204,18 @@ export default async function MissionPage({ params }: Props) {
             </CardContent>
           </Card>
         )}
+
+        <div className="mt-8 flex flex-col gap-8">
+          {allCategoryMissions.map((categoryData) => (
+            <RelatedMissions
+              key={categoryData.categoryId}
+              missions={categoryData.missions}
+              categoryTitle={categoryData.categoryTitle}
+              userAchievementCountMap={userAchievementCountMap}
+              achievementCountMap={achievementCountMap}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/features/mission-detail/components/related-missions.tsx
+++ b/src/features/mission-detail/components/related-missions.tsx
@@ -1,0 +1,46 @@
+import { HorizontalScrollContainer } from "@/features/missions/components/horizontal-scroll-container";
+import Mission from "@/features/missions/components/mission-card";
+import type { MissionForComponent } from "@/features/missions/utils/group-missions-by-category";
+
+interface RelatedMissionsProps {
+  missions: MissionForComponent[];
+  categoryTitle: string;
+  userAchievementCountMap: Map<string, number>;
+  achievementCountMap: Map<string, number>;
+}
+
+export async function RelatedMissions({
+  missions,
+  categoryTitle,
+  userAchievementCountMap,
+  achievementCountMap,
+}: RelatedMissionsProps) {
+  if (missions.length === 0) {
+    return null; // ミッションがない場合は何も表示しない
+  }
+
+  return (
+    <section className="relative w-screen ml-[calc(50%-50vw)] md:pl-10 text-center">
+      <h2 className="text-xl font-bold mb-4 pl-4 md:pl-0 text-center">
+        {categoryTitle
+          ? `「${categoryTitle}」の他のミッション`
+          : "関連ミッション"}
+      </h2>
+      <HorizontalScrollContainer centering={true}>
+        <div className="flex w-fit gap-4 pl-4 md:pl-0 pr-4 pb-2 pt-4">
+          {missions.map((mission) => (
+            <div key={mission.id} className="shrink-0 w-[300px]">
+              <Mission
+                mission={mission}
+                achievementsCount={achievementCountMap.get(mission.id) ?? 0}
+                userAchievementCount={
+                  userAchievementCountMap.get(mission.id) ?? 0
+                }
+              />
+            </div>
+          ))}
+        </div>
+      </HorizontalScrollContainer>
+    </section>
+  );
+}

--- a/src/features/mission-detail/services/mission-detail.ts
+++ b/src/features/mission-detail/services/mission-detail.ts
@@ -4,9 +4,39 @@ import type {
   MissionPageData,
   SubmissionData,
 } from "@/features/mission-detail/types/detail-types";
+import { groupMissionsByCategory } from "@/features/missions/utils/group-missions-by-category";
 import { createClient } from "@/lib/supabase/client";
 import type { Tables } from "@/lib/types/supabase";
 import { nanoid } from "nanoid";
+
+/**
+ * ユーザーのミッション達成情報を取得し、ミッションIDごとの達成回数をMapで返す
+ */
+async function getUserMissionAchievements(
+  userId: string,
+): Promise<Map<string, number>> {
+  const supabase = createClient();
+
+  const { data: achievements, error } = await supabase
+    .from("achievements")
+    .select("mission_id")
+    .eq("user_id", userId);
+
+  if (error) {
+    console.error("Error fetching user achievements:", error);
+    return new Map();
+  }
+
+  const achievementMap = new Map<string, number>();
+  for (const achievement of achievements ?? []) {
+    if (achievement.mission_id) {
+      const current = achievementMap.get(achievement.mission_id) ?? 0;
+      achievementMap.set(achievement.mission_id, current + 1);
+    }
+  }
+
+  return achievementMap;
+}
 
 export async function getMissionData(
   missionId: string,
@@ -204,6 +234,50 @@ export async function getMissionMainLink(
   return data;
 }
 
+/**
+ * 対象ミッションが属する全カテゴリのミッションを取得
+ * @param missionId - 対象ミッションID
+ * @returns フラットなミッションデータ（現在のミッションは除外）
+ */
+async function getRelatedCategoryMissionsRaw(
+  missionId: string,
+): Promise<Tables<"mission_category_view">[]> {
+  const supabase = createClient();
+
+  // カテゴリIDを取得
+  const { data: links, error: linksError } = await supabase
+    .from("mission_category_link")
+    .select("category_id")
+    .eq("mission_id", missionId)
+    .eq("del_flg", false)
+    .order("sort_no", { ascending: true });
+
+  if (linksError) {
+    console.error("Mission category link fetch error:", linksError);
+    return [];
+  }
+
+  if (!links || links.length === 0) {
+    return [];
+  }
+
+  const categoryIds = links.map((link) => link.category_id);
+
+  // 全カテゴリのミッションを取得
+  const { data, error } = await supabase
+    .from("mission_category_view")
+    .select("*")
+    .in("category_id", categoryIds)
+    .neq("mission_id", missionId);
+
+  if (error) {
+    console.error("Category missions fetch error:", error);
+    return [];
+  }
+
+  return data || [];
+}
+
 export async function getMissionPageData(
   missionId: string,
   userId?: string,
@@ -217,6 +291,11 @@ export async function getMissionPageData(
   let userAchievementCount = 0;
   let submissions: SubmissionData[] = [];
   let referralCode: string | null = null;
+
+  // ユーザーの各ミッションに対する達成回数のマップ
+  const userAchievementCountMap = userId
+    ? await getUserMissionAchievements(userId)
+    : new Map<string, number>();
 
   if (userId) {
     const { achievements, count } = await getUserAchievements(
@@ -235,14 +314,27 @@ export async function getMissionPageData(
   // メインリンクの取得
   const mainLink = await getMissionMainLink(missionId);
 
+  // 全カテゴリのミッションを取得し、グループ化・ソート・変換
+  const rawMissions = await getRelatedCategoryMissionsRaw(missionId);
+  const allCategoryMissions = groupMissionsByCategory(
+    rawMissions,
+    userAchievementCountMap,
+    {
+      showAchievedMissions: true,
+      achievedMissionIds: Array.from(userAchievementCountMap.keys()),
+    },
+  );
+
   return {
     mission,
     userAchievements,
     submissions,
     userAchievementCount,
+    userAchievementCountMap,
     totalAchievementCount,
     referralCode,
     mainLink,
+    allCategoryMissions,
   };
 }
 

--- a/src/features/mission-detail/types/detail-types.ts
+++ b/src/features/mission-detail/types/detail-types.ts
@@ -1,3 +1,4 @@
+import type { CategoryWithMissions } from "@/features/missions/utils/group-missions-by-category";
 import type { Tables } from "@/lib/types/supabase";
 import type { User } from "@supabase/supabase-js";
 
@@ -26,9 +27,11 @@ export type MissionPageData = {
   userAchievements: Achievement[];
   submissions: SubmissionData[];
   userAchievementCount: number;
+  userAchievementCountMap: Map<string, number>;
   totalAchievementCount: number;
   referralCode: string | null;
   mainLink: Tables<"mission_main_links"> | null;
+  allCategoryMissions: CategoryWithMissions[];
 };
 
 export type ButtonLabelProps = {

--- a/src/features/missions/components/horizontal-scroll-container.tsx
+++ b/src/features/missions/components/horizontal-scroll-container.tsx
@@ -9,12 +9,14 @@ interface HorizontalScrollContainerProps {
   children: React.ReactNode;
   className?: string;
   scrollDistance?: number;
+  centering?: boolean;
 }
 
 export function HorizontalScrollContainer({
   children,
   className,
   scrollDistance = 316,
+  centering = false,
 }: HorizontalScrollContainerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -147,7 +149,7 @@ export function HorizontalScrollContainer({
     );
 
   return (
-    <div className="relative">
+    <div className="relative flex justify-center">
       {isDesktop && canScrollLeft && (
         <button
           type="button"
@@ -162,12 +164,13 @@ export function HorizontalScrollContainer({
       <div
         ref={scrollRef}
         className={cn(
-          "w-full overflow-x-auto custom-scrollbar",
+          "overflow-x-auto custom-scrollbar",
           isDesktop && isDragging
             ? "cursor-grabbing"
             : isDesktop
               ? "cursor-grab"
               : "",
+          centering ? "w-fit" : "w-full",
           className,
         )}
         style={{

--- a/src/features/missions/utils/group-missions-by-category.test.ts
+++ b/src/features/missions/utils/group-missions-by-category.test.ts
@@ -1,0 +1,361 @@
+import { groupMissionsByCategory } from "@/features/missions/utils/group-missions-by-category";
+import type { Database } from "@/lib/types/supabase";
+import { describe, expect, it } from "@jest/globals";
+
+type MissionCategoryView =
+  Database["public"]["Views"]["mission_category_view"]["Row"];
+
+// テスト用のミッションデータを作成するヘルパー関数
+function createMissionCategoryView(
+  overrides: Partial<MissionCategoryView> = {},
+): MissionCategoryView {
+  return {
+    mission_id: "mission-1",
+    category_id: "category-1",
+    category_title: "カテゴリ1",
+    category_kbn: null,
+    title: "ミッション1",
+    content: "コンテンツ",
+    difficulty: 1,
+    icon_url: null,
+    artifact_label: null,
+    max_achievement_count: null,
+    event_date: null,
+    is_featured: false,
+    is_hidden: false,
+    ogp_image_url: null,
+    required_artifact_type: "NONE",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    link_sort_no: 1,
+    category_sort_no: 1,
+    ...overrides,
+  };
+}
+
+describe("groupMissionsByCategory", () => {
+  describe("カテゴリごとのグループ化", () => {
+    it("ミッションをカテゴリごとにグループ化する", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+          category_title: "カテゴリ1",
+        }),
+        createMissionCategoryView({
+          mission_id: "m2",
+          category_id: "c1",
+          category_title: "カテゴリ1",
+        }),
+        createMissionCategoryView({
+          mission_id: "m3",
+          category_id: "c2",
+          category_title: "カテゴリ2",
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.find((c) => c.categoryId === "c1")?.missions).toHaveLength(
+        2,
+      );
+      expect(result.find((c) => c.categoryId === "c2")?.missions).toHaveLength(
+        1,
+      );
+    });
+
+    it("category_idがnullのミッションをスキップする", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+          category_title: "カテゴリ1",
+        }),
+        createMissionCategoryView({
+          mission_id: "m2",
+          category_id: null,
+          category_title: null,
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].missions).toHaveLength(1);
+    });
+
+    it("カテゴリタイトルを正しく設定する", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+          category_title: "テストカテゴリ",
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      expect(result[0].categoryTitle).toBe("テストカテゴリ");
+    });
+  });
+
+  describe("ソート", () => {
+    it("link_sort_noでソートする", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+          link_sort_no: 3,
+        }),
+        createMissionCategoryView({
+          mission_id: "m2",
+          category_id: "c1",
+          link_sort_no: 1,
+        }),
+        createMissionCategoryView({
+          mission_id: "m3",
+          category_id: "c1",
+          link_sort_no: 2,
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      const missionIds = result[0].missions.map((m) => m.id);
+      expect(missionIds).toEqual(["m2", "m3", "m1"]);
+    });
+
+    it("上限まで達成済みのミッションを後ろに移動する", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+          max_achievement_count: 1,
+          link_sort_no: 1,
+        }),
+        createMissionCategoryView({
+          mission_id: "m2",
+          category_id: "c1",
+          max_achievement_count: 1,
+          link_sort_no: 2,
+        }),
+        createMissionCategoryView({
+          mission_id: "m3",
+          category_id: "c1",
+          max_achievement_count: null,
+          link_sort_no: 3,
+        }),
+      ];
+
+      // m1は達成済み（上限到達）
+      const userAchievementCountMap = new Map([["m1", 1]]);
+
+      const result = groupMissionsByCategory(data, userAchievementCountMap, {
+        showAchievedMissions: true,
+        achievedMissionIds: ["m1"],
+      });
+
+      const missionIds = result[0].missions.map((m) => m.id);
+      // m1は上限到達なので後ろに移動
+      expect(missionIds).toEqual(["m2", "m3", "m1"]);
+    });
+
+    it("mission_idがnullの場合はソート順を維持する", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: null,
+          category_id: "c1",
+          link_sort_no: 1,
+        }),
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+          link_sort_no: 2,
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      // mission_idがnullのものはフィルタリングで除外される
+      expect(result[0].missions).toHaveLength(1);
+      expect(result[0].missions[0].id).toBe("m1");
+    });
+  });
+
+  describe("フィルタリング", () => {
+    it("showAchievedMissionsがfalseの場合、達成済みミッションを除外する", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+        }),
+        createMissionCategoryView({
+          mission_id: "m2",
+          category_id: "c1",
+        }),
+        createMissionCategoryView({
+          mission_id: "m3",
+          category_id: "c1",
+        }),
+      ];
+
+      const result = groupMissionsByCategory(
+        data,
+        new Map([
+          ["m1", 1],
+          ["m2", 1],
+        ]),
+        { showAchievedMissions: false, achievedMissionIds: ["m1", "m2"] },
+      );
+
+      expect(result[0].missions).toHaveLength(1);
+      expect(result[0].missions[0].id).toBe("m3");
+    });
+
+    it("showAchievedMissionsがtrueの場合、達成済みミッションも含める", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+        }),
+        createMissionCategoryView({
+          mission_id: "m2",
+          category_id: "c1",
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map([["m1", 1]]), {
+        showAchievedMissions: true,
+        achievedMissionIds: ["m1"],
+      });
+
+      expect(result[0].missions).toHaveLength(2);
+    });
+
+    it("mission_idがnullのミッションを除外する", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+        }),
+        createMissionCategoryView({
+          mission_id: null,
+          category_id: "c1",
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      expect(result[0].missions).toHaveLength(1);
+    });
+  });
+
+  describe("変換処理", () => {
+    it("MissionCategoryViewをMissionForComponent型に変換する", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+          title: "テストミッション",
+          content: "テストコンテンツ",
+          difficulty: 3,
+          icon_url: "https://example.com/icon.png",
+          artifact_label: "成果物ラベル",
+          max_achievement_count: 5,
+          event_date: "2024-06-01",
+          is_featured: true,
+          is_hidden: false,
+          ogp_image_url: "https://example.com/ogp.png",
+          required_artifact_type: "IMAGE",
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-02T00:00:00Z",
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      const mission = result[0].missions[0];
+      expect(mission.id).toBe("m1");
+      expect(mission.title).toBe("テストミッション");
+      expect(mission.content).toBe("テストコンテンツ");
+      expect(mission.difficulty).toBe(3);
+      expect(mission.icon_url).toBe("https://example.com/icon.png");
+      expect(mission.artifact_label).toBe("成果物ラベル");
+      expect(mission.max_achievement_count).toBe(5);
+      expect(mission.event_date).toBe("2024-06-01");
+      expect(mission.is_featured).toBe(true);
+      expect(mission.is_hidden).toBe(false);
+      expect(mission.ogp_image_url).toBe("https://example.com/ogp.png");
+      expect(mission.required_artifact_type).toBe("IMAGE");
+      expect(mission.created_at).toBe("2024-01-01T00:00:00Z");
+      expect(mission.updated_at).toBe("2024-01-02T00:00:00Z");
+      expect(mission.featured_importance).toBeNull();
+    });
+
+    it("nullの値にデフォルト値を設定する", () => {
+      const data: MissionCategoryView[] = [
+        createMissionCategoryView({
+          mission_id: "m1",
+          category_id: "c1",
+          title: null,
+          content: null,
+          difficulty: null,
+          is_featured: null,
+          is_hidden: null,
+          required_artifact_type: null,
+          created_at: null,
+          updated_at: null,
+        }),
+      ];
+
+      const result = groupMissionsByCategory(data, new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      const mission = result[0].missions[0];
+      expect(mission.title).toBe("");
+      expect(mission.content).toBe("");
+      expect(mission.difficulty).toBe(1);
+      expect(mission.is_featured).toBe(false);
+      expect(mission.is_hidden).toBe(false);
+      expect(mission.required_artifact_type).toBe("");
+      // created_at, updated_atはnewDate().toISOString()が設定される
+      expect(mission.created_at).toBeDefined();
+      expect(mission.updated_at).toBeDefined();
+    });
+  });
+
+  describe("空のデータ", () => {
+    it("空の配列を渡すと空の結果を返す", () => {
+      const result = groupMissionsByCategory([], new Map(), {
+        showAchievedMissions: true,
+        achievedMissionIds: [],
+      });
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/features/missions/utils/group-missions-by-category.ts
+++ b/src/features/missions/utils/group-missions-by-category.ts
@@ -1,0 +1,110 @@
+import type { Tables } from "@/lib/types/supabase";
+
+type MissionCategoryView = Tables<"mission_category_view">;
+export type MissionForComponent = Omit<Tables<"missions">, "slug">;
+
+export interface GroupMissionsByCategoryOptions {
+  showAchievedMissions: boolean;
+  achievedMissionIds: string[];
+}
+
+export interface CategoryWithMissions {
+  categoryId: string;
+  categoryTitle: string;
+  missions: MissionForComponent[];
+}
+
+/**
+ * ミッションをカテゴリごとにグループ化し、各カテゴリ内でソート・フィルタリング・変換を行う
+ *
+ * 処理順:
+ * 1. カテゴリごとにグループ化
+ * 2. 上限まで達成済みのミッションを後ろにソート
+ * 3. 達成済みミッションのフィルタリング（オプション）
+ * 4. MissionForComponent型への変換
+ */
+export function groupMissionsByCategory(
+  data: MissionCategoryView[],
+  userAchievementCountMap: Map<string, number>,
+  options: GroupMissionsByCategoryOptions,
+): CategoryWithMissions[] {
+  const { showAchievedMissions, achievedMissionIds } = options;
+
+  // カテゴリごとにグループ化
+  const grouped = data.reduce<Record<string, MissionCategoryView[]>>(
+    (acc, row) => {
+      // category_idがnullの場合はスキップ
+      if (!row.category_id) return acc;
+
+      if (!acc[row.category_id]) acc[row.category_id] = [];
+      acc[row.category_id].push(row);
+      return acc;
+    },
+    {},
+  );
+
+  // カテゴリ内のミッションをソート
+  for (const categoryId in grouped) {
+    grouped[categoryId].sort((a, b) => {
+      // mission_idがnullの場合の処理
+      if (!a.mission_id || !b.mission_id) return 0;
+
+      // 上限まで達成済みのミッションを後ろに移動
+      const aAchievementCount = userAchievementCountMap.get(a.mission_id) ?? 0;
+      const bAchievementCount = userAchievementCountMap.get(b.mission_id) ?? 0;
+
+      const aIsMaxAchieved =
+        a.max_achievement_count && aAchievementCount >= a.max_achievement_count;
+      const bIsMaxAchieved =
+        b.max_achievement_count && bAchievementCount >= b.max_achievement_count;
+
+      if (aIsMaxAchieved && !bIsMaxAchieved) {
+        return 1; // a を後ろに
+      }
+      if (!aIsMaxAchieved && bIsMaxAchieved) {
+        return -1; // b を後ろに
+      }
+
+      // それ以外はリンクのソート順で比較
+      return (a.link_sort_no ?? 0) - (b.link_sort_no ?? 0);
+    });
+  }
+
+  // カテゴリごとにフィルタリングと変換を行い、結果を配列として返す
+  return Object.entries(grouped).map(([categoryId, missionsInCategory]) => {
+    const category = missionsInCategory[0];
+
+    const missions = missionsInCategory
+      .filter(
+        (m) =>
+          m.mission_id &&
+          (showAchievedMissions || !achievedMissionIds.includes(m.mission_id)),
+      )
+      .map((m): MissionForComponent => {
+        const missionId = m.mission_id as string;
+        return {
+          id: missionId,
+          title: m.title || "",
+          icon_url: m.icon_url,
+          difficulty: m.difficulty || 1,
+          content: m.content || "",
+          created_at: m.created_at || new Date().toISOString(),
+          artifact_label: m.artifact_label,
+          max_achievement_count: m.max_achievement_count,
+          event_date: m.event_date,
+          is_featured: m.is_featured || false,
+          updated_at: m.updated_at || new Date().toISOString(),
+          is_hidden: m.is_hidden || false,
+          ogp_image_url: m.ogp_image_url,
+          required_artifact_type: m.required_artifact_type || "",
+          featured_importance: null,
+        };
+      });
+
+    return {
+      categoryId,
+      categoryTitle: category.category_title || "",
+      missions,
+    };
+  });
+}


### PR DESCRIPTION
* feat: ミッション詳細ページに同一カテゴリの関連ミッション表示機能を追加

- MissionPageDataにsameCategoryMissionsフィールドを追加
- getSameCategoryMissions関数を実装（最初のカテゴリのミッションを取得）
- RelatedMissionsコンポーネントを作成
- ミッション詳細ページ下部に関連ミッション表示セクションを追加
- 現在のミッションは関連ミッション一覧から除外
- カテゴリ内の順序（link_sort_no）で並び替え



* feat: 全カテゴリの関連ミッションを並列表示

ミッションが複数カテゴリに属する場合、全てのカテゴリの関連ミッションを表示するように変更。

- CategoryWithMissions型を追加
- getAllCategoryMissions関数でlimit制限を削除し全カテゴリを取得
- Promise.all()で各カテゴリのミッションを並列取得
- ページで各カテゴリごとにHorizontalScrollContainerで表示
- カテゴリセクション間にgap-8でスペーシングを確保



* perf: クエリ最適化で関連ミッション取得を2リクエストに削減

getAllCategoryMissionsでのデータベースクエリを最適化:
- 以前: 1 + N個のクエリ（カテゴリ数に応じて増加）
- 現在: 2個のクエリ（.in()で全カテゴリを一括取得）

主な変更:
- Promise.allでの並列実行から、.in()による一括クエリに変更
- クライアント側でMap使用してカテゴリごとにグループ化
- sort_no順序を保持しつつパフォーマンス向上

その他の変更:
- HorizontalScrollContainerのprop名をlayout→centeringに変更



* refactor: ミッションのグループ化・ソート・変換処理をutilsに切り出し

missions-by-category.tsxからビジネスロジックを分離し、
groupMissionsByCategory関数としてutils化。
テストも追加してカバレッジ98%を達成。



* refactor: ミッション詳細で共通のgroupMissionsByCategory utilを使用

関連ミッション表示で重複していたグループ化・変換ロジックを
共通ユーティリティに統一し、型定義も一元化



* tweak

* fix: update width class for centering in HorizontalScrollContainer

* feat: add user achievement count mapping to mission page and related missions

* refactor: rename function getAllCategoryMissionsRaw to getRelatedCategoryMissionsRaw for clarity

---------

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました