### PR TITLE
fix: poster-totals

### DIFF
--- a/src/features/map-poster/actions/poster-boards.ts
+++ b/src/features/map-poster/actions/poster-boards.ts
@@ -200,6 +200,8 @@ export async function getPosterBoardStatsByDistrictAction(
       .from("poster_boards")
       .select("status")
       .eq("district", district)
+      .not("lat", "is", null) // 座標なしを除外
+      .not("long", "is", null) // 座標なしを除外
       .eq("archived", false);
 
     if (error) {

--- a/src/features/map-poster/services/poster-boards.ts
+++ b/src/features/map-poster/services/poster-boards.ts
@@ -93,6 +93,8 @@ export async function getPosterBoardsMinimalByDistrict(district: string) {
       .from("poster_boards")
       .select("id,lat,long,status,name,address,city,number")
       .eq("district", district)
+      .not("lat", "is", null) // 座標なしを除外
+      .not("long", "is", null) // 座標なしを除外
       .eq("archived", false)
       .range(rangeStart, rangeStart + pageSize - 1)
       .order("id", { ascending: true }); // 一貫した順序を保証
@@ -397,6 +399,8 @@ export async function getDistrictsWithBoards(): Promise<string[]> {
       .from("poster_boards")
       .select("district")
       .not("district", "is", null)
+      .not("lat", "is", null) // 座標なしを除外
+      .not("long", "is", null) // 座標なしを除外
       .eq("archived", false)
       .order("district")
       .order("id", { ascending: true })
@@ -545,6 +549,8 @@ export async function getPosterBoardSummaryByDistrict(): Promise<
     .from("poster_boards")
     .select("district, status")
     .not("district", "is", null)
+    .not("lat", "is", null) // 座標なしを除外
+    .not("long", "is", null) // 座標なしを除外
     .eq("archived", false);
 
   if (error) {
@@ -599,6 +605,8 @@ export async function getPosterBoardStatsByDistrict(district: string): Promise<{
     .from("poster_boards")
     .select("status")
     .eq("district", district)
+    .not("lat", "is", null) // 座標なしを除外
+    .not("long", "is", null) // 座標なしを除外
     .eq("archived", false);
 
   if (error) {


### PR DESCRIPTION
# 変更の概要
- ポスター掲示場の緯度・経度がnullのレコードは削除扱いで集計から除外する。

# 変更の背景
- closes #1802

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* ポスター掲示板の統計情報と地図表示において、座標情報（緯度・経度）が不完全なデータを除外するようにしました。これにより、統計の集計結果がより正確になり、地図上には有効な位置情報を持つ掲示板のみが表示されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->