### PR TITLE
statsで本日のデータを非表示

### DIFF
--- a/src/features/action-stats/services/action-stats-service.ts
+++ b/src/features/action-stats/services/action-stats-service.ts
@@ -45,7 +45,7 @@ export async function getActionStatsSummary(
  * 日別アクション推移を取得する（RPC使用）
  * @param startDate - 開始日（オプション）
  * @param endDate - 終了日（オプション）
- * @returns 日別アクション数
+ * @returns 日別アクション数（本日以降のデータは除外）
  */
 export async function getDailyActionHistory(
   startDate?: Date,
@@ -63,10 +63,13 @@ export async function getDailyActionHistory(
     return [];
   }
 
-  return (data ?? []).map((item: { date: string; count: number }) => ({
+  // 本日以降のデータを除外
+  const { filterBeforeToday } = await import("@/lib/utils/date-utils");
+  const items = (data ?? []).map((item: { date: string; count: number }) => ({
     date: item.date,
     count: Number(item.count),
   }));
+  return filterBeforeToday(items);
 }
 
 /**

--- a/src/features/tiktok-stats/services/tiktok-stats-service.ts
+++ b/src/features/tiktok-stats/services/tiktok-stats-service.ts
@@ -334,6 +334,8 @@ export async function getOverallStatsHistory(
     });
   }
 
+  // 配列に変換して本日以降のデータを除外
+  const { filterBeforeToday } = await import("@/lib/utils/date-utils");
   const result = Array.from(dailyStats.entries())
     .map(([date, stats]) => ({
       date,
@@ -342,7 +344,7 @@ export async function getOverallStatsHistory(
     }))
     .sort((a, b) => a.date.localeCompare(b.date));
 
-  return result;
+  return filterBeforeToday(result);
 }
 
 /**
@@ -399,5 +401,7 @@ export async function getVideoCountByDate(
     currentDate.setDate(currentDate.getDate() + 1);
   }
 
-  return result;
+  // 本日以降のデータを除外
+  const { filterBeforeToday } = await import("@/lib/utils/date-utils");
+  return filterBeforeToday(result);
 }

--- a/src/features/youtube-stats/services/youtube-stats-service.ts
+++ b/src/features/youtube-stats/services/youtube-stats-service.ts
@@ -338,7 +338,8 @@ export async function getOverallStatsHistory(
     });
   }
 
-  // 配列に変換
+  // 配列に変換して本日以降のデータを除外
+  const { filterBeforeToday } = await import("@/lib/utils/date-utils");
   const result = Array.from(dailyStats.entries())
     .map(([date, stats]) => ({
       date,
@@ -347,7 +348,7 @@ export async function getOverallStatsHistory(
     }))
     .sort((a, b) => a.date.localeCompare(b.date));
 
-  return result;
+  return filterBeforeToday(result);
 }
 
 /**
@@ -406,5 +407,7 @@ export async function getVideoCountByDate(
     currentDate.setDate(currentDate.getDate() + 1);
   }
 
-  return result;
+  // 本日以降のデータを除外
+  const { filterBeforeToday } = await import("@/lib/utils/date-utils");
+  return filterBeforeToday(result);
 }

--- a/src/lib/utils/date-utils.ts
+++ b/src/lib/utils/date-utils.ts
@@ -48,3 +48,24 @@ export function getJstRecentDates(now: Date = new Date()): {
     dayBeforeYesterday: toJstDateString(new Date(now.getTime() - DAY_MS * 2)),
   };
 }
+
+/**
+ * JSTで今日の日付文字列(YYYY-MM-DD)を取得する
+ */
+export function getTodayJstString(now: Date = new Date()): string {
+  return toJstDateString(now);
+}
+
+/**
+ * 日付配列から本日以降のデータを除外する
+ * @param items - date プロパティを持つオブジェクトの配列
+ * @param now - 基準日時（デフォルトは現在時刻）
+ * @returns 本日より前のデータのみの配列
+ */
+export function filterBeforeToday<T extends { date: string }>(
+  items: T[],
+  now: Date = new Date(),
+): T[] {
+  const todayJst = toJstDateString(now);
+  return items.filter((item) => item.date < todayJst);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 複数の統計機能(アクション統計、TikTok統計、YouTube統計)において、履歴データから本日以降のデータが除外されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->