### PR TITLE
mission_artifacts テーブルに achievement_id ユニーク制約を追加

### DIFF
--- a/supabase/migrations/20260128074210_add_unique_constraint_mission_artifacts_achievement_id.sql
+++ b/supabase/migrations/20260128074210_add_unique_constraint_mission_artifacts_achievement_id.sql
@@ -1,0 +1,9 @@
+-- mission_artifactsテーブルのachievement_idにユニーク制約を追加
+-- 1つのachievementに対して1つのartifactのみ許可する
+
+-- 既存のインデックスを削除（ユニーク制約で新しいインデックスが作成されるため）
+DROP INDEX IF EXISTS idx_mission_artifacts_achievement_id;
+
+-- ユニーク制約を追加
+ALTER TABLE mission_artifacts
+  ADD CONSTRAINT mission_artifacts_achievement_id_unique UNIQUE (achievement_id);


### PR DESCRIPTION
# 変更の概要
- `mission_artifacts` テーブルの `achievement_id` カラムにユニーク制約を追加しました
- 既存の非ユニークインデックス `idx_mission_artifacts_achievement_id` を削除し、ユニーク制約で置き換えました
- これにより、1つの achievement に対して最大1つの artifact のみが関連付けられることを保証します

# 変更の背景
- 1つの achievement に複数の artifact が関連付けられることを防ぐため、データベースレベルでの制約が必要でした
- ユニーク制約を追加することで、データの整合性を強化し、アプリケーションロジックの信頼性を向上させます

# CLAへの同意
- [x] CLAの内容を読み、同意しました

https://claude.ai/code/session_01UUQ22fjHUm3LDZauEQv5Vo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ミッション成果物のデータ整合性を強化する制約を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->