### PR TITLE
Add Codecov integration for code coverage tracking

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -35,3 +35,13 @@ jobs:
           name: jest-report
           path: jest-report/
           retention-days: 30
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-action-board
+          fail_ci_if_error: false
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Check code with Biome and tsc](https://github.com/team-mirai/action-board/actions/workflows/check_code.yaml/badge.svg)](https://github.com/team-mirai/action-board/actions/workflows/check_code.yaml)
 [![Build & Test E2E/RLS](https://github.com/team-mirai/action-board/actions/workflows/e2e_test.yaml/badge.svg)](https://github.com/team-mirai/action-board/actions/workflows/e2e_test.yaml)
+[![codecov](https://codecov.io/gh/team-mirai-volunteer/action-board/graph/badge.svg)](https://codecov.io/gh/team-mirai-volunteer/action-board)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/team-mirai-volunteer/action-board)
 
 ## コントリビュートについて

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,43 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+        threshold: 2%
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: false
+
+flags:
+  unittests:
+    paths:
+      - src/
+    carryforward: true
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "tests/**/*"
+  - "node_modules/**/*"
+  - "coverage/**/*"
+  - ".next/**/*"
+  - "supabase/**/*"
+  - "mission_data/**/*"
+  - "poster_data/**/*"
+  - "posting_data/**/*"
+  - "packages/**/*"
+  - "scripts/**/*"


### PR DESCRIPTION
# 変更の概要
- GitHub Actions のユニットテストワークフローに Codecov アップロード機能を追加
- Codecov 設定ファイル（codecov.yml）を新規作成し、カバレッジ目標と検証ルールを定義
- README に Codecov バッジを追加して、プロジェクトのコード品質を可視化

# 変更の背景
プロジェクトのコード品質を継続的に監視し、テストカバレッジを追跡するために Codecov を統合しました。これにより、以下が実現されます：

- ユニットテスト実行後、自動的にカバレッジレポートを Codecov にアップロード
- PR ごとにカバレッジの変化を追跡可能
- 80% のカバレッジ目標を設定し、品質基準を維持
- テストファイルやビルド成果物などの不要なファイルをカバレッジ計算から除外

# CLAへの同意
- [x] CLAの内容を読み、同意しました

https://claude.ai/code/session_013TRMgPtyay9vKuoGsMZZHG