### PR TITLE
youtube_videosスキーマ変更: video_idをPRIMARY KEYに

### DIFF
--- a/packages/youtube_data/src/converters.ts
+++ b/packages/youtube_data/src/converters.ts
@@ -25,12 +25,12 @@ export function toVideoRecord(video: YouTubeVideoDetails): YouTubeVideoRecord {
 }
 
 export function toStatsRecord(
-  youtubeVideoId: string,
+  videoId: string,
   video: YouTubeVideoDetails,
   recordedAt: string,
 ): YouTubeVideoStatsRecord {
   return {
-    youtube_video_id: youtubeVideoId,
+    video_id: videoId,
     recorded_at: recordedAt,
     view_count: video.statistics?.viewCount
       ? Number.parseInt(video.statistics.viewCount, 10)

--- a/packages/youtube_data/src/types.ts
+++ b/packages/youtube_data/src/types.ts
@@ -45,8 +45,7 @@ export interface YouTubeVideoDetails {
 
 // DBに保存する動画データの型
 export interface YouTubeVideoRecord {
-  id?: string;
-  video_id: string;
+  video_id: string; // PRIMARY KEY
   video_url: string;
   title: string;
   description: string | null;
@@ -64,7 +63,7 @@ export interface YouTubeVideoRecord {
 // DBに保存する統計スナップショットの型
 export interface YouTubeVideoStatsRecord {
   id?: string;
-  youtube_video_id: string;
+  video_id: string; // youtube_videos.video_id への外部キー
   recorded_at: string;
   view_count: number | null;
   like_count: number | null;

--- a/src/features/youtube-stats/components/youtube-video-list.tsx
+++ b/src/features/youtube-stats/components/youtube-video-list.tsx
@@ -50,7 +50,7 @@ export function YouTubeVideoList({
       {/* リストレイアウト */}
       <div className="flex flex-col divide-y">
         {videos.map((video) => (
-          <YouTubeVideoCard key={video.id} video={video} />
+          <YouTubeVideoCard key={video.video_id} video={video} />
         ))}
       </div>
 

--- a/src/features/youtube-stats/services/youtube-stats-service.ts
+++ b/src/features/youtube-stats/services/youtube-stats-service.ts
@@ -165,7 +165,7 @@ export async function getYouTubeStatsSummary(
     .from("youtube_videos")
     .select(
       `
-      id,
+      video_id,
       published_at,
       youtube_video_stats(
         view_count,

--- a/src/features/youtube/actions/youtube-video-actions.ts
+++ b/src/features/youtube/actions/youtube-video-actions.ts
@@ -153,7 +153,6 @@ export async function getMyUploadedVideosAction(
         )[0];
 
         return {
-          id: video.id,
           video_id: video.video_id,
           video_url: video.video_url,
           title: video.title,

--- a/src/features/youtube/components/youtube-video-list.tsx
+++ b/src/features/youtube/components/youtube-video-list.tsx
@@ -73,7 +73,7 @@ export function YouTubeVideoList({
   return (
     <div className="flex flex-col divide-y">
       {videos.map((video) => (
-        <YouTubeVideoCard key={video.id} video={video} />
+        <YouTubeVideoCard key={video.video_id} video={video} />
       ))}
     </div>
   );

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -1412,8 +1412,8 @@ export type Database = {
           id: string;
           like_count: number | null;
           recorded_at: string;
+          video_id: string;
           view_count: number | null;
-          youtube_video_id: string | null;
         };
         Insert: {
           comment_count?: number | null;
@@ -1421,8 +1421,8 @@ export type Database = {
           id?: string;
           like_count?: number | null;
           recorded_at: string;
+          video_id: string;
           view_count?: number | null;
-          youtube_video_id?: string | null;
         };
         Update: {
           comment_count?: number | null;
@@ -1430,16 +1430,16 @@ export type Database = {
           id?: string;
           like_count?: number | null;
           recorded_at?: string;
+          video_id?: string;
           view_count?: number | null;
-          youtube_video_id?: string | null;
         };
         Relationships: [
           {
-            foreignKeyName: "youtube_video_stats_youtube_video_id_fkey";
-            columns: ["youtube_video_id"];
+            foreignKeyName: "youtube_video_stats_video_id_fkey";
+            columns: ["video_id"];
             isOneToOne: false;
             referencedRelation: "youtube_videos";
-            referencedColumns: ["id"];
+            referencedColumns: ["video_id"];
           },
         ];
       };
@@ -1450,7 +1450,6 @@ export type Database = {
           created_at: string | null;
           description: string | null;
           duration: string | null;
-          id: string;
           is_active: boolean | null;
           published_at: string | null;
           tags: string[] | null;
@@ -1466,7 +1465,6 @@ export type Database = {
           created_at?: string | null;
           description?: string | null;
           duration?: string | null;
-          id?: string;
           is_active?: boolean | null;
           published_at?: string | null;
           tags?: string[] | null;
@@ -1482,7 +1480,6 @@ export type Database = {
           created_at?: string | null;
           description?: string | null;
           duration?: string | null;
-          id?: string;
           is_active?: boolean | null;
           published_at?: string | null;
           tags?: string[] | null;

--- a/supabase/migrations/20260128134251_change_youtube_videos_pk.sql
+++ b/supabase/migrations/20260128134251_change_youtube_videos_pk.sql
@@ -1,0 +1,56 @@
+-- youtube_videosスキーマ変更: video_idをPRIMARY KEYに
+-- Issue #1833
+
+-- ==============================================
+-- Part 1: youtube_video_statsの外部キーを移行
+-- ==============================================
+
+-- 1-1. youtube_video_statsの外部キー制約を一時削除
+ALTER TABLE youtube_video_stats DROP CONSTRAINT IF EXISTS youtube_video_stats_youtube_video_id_fkey;
+
+-- 1-2. youtube_video_statsにvideo_idカラムを追加（データ移行用）
+ALTER TABLE youtube_video_stats ADD COLUMN video_id VARCHAR;
+
+-- 1-3. 既存データのvideo_idを移行
+UPDATE youtube_video_stats AS s
+SET video_id = v.video_id
+FROM youtube_videos AS v
+WHERE s.youtube_video_id = v.id;
+
+-- 1-4. youtube_video_statsの旧カラムを削除
+ALTER TABLE youtube_video_stats DROP COLUMN youtube_video_id;
+
+-- ==============================================
+-- Part 2: youtube_videosのPKを変更
+-- ==============================================
+
+-- 2-1. youtube_videosのUNIQUE制約を削除（PKに変更するため）
+ALTER TABLE youtube_videos DROP CONSTRAINT IF EXISTS youtube_videos_video_id_key;
+
+-- 2-2. youtube_videos: idを削除してvideo_idをPKに
+ALTER TABLE youtube_videos DROP CONSTRAINT youtube_videos_pkey;
+ALTER TABLE youtube_videos DROP COLUMN id;
+ALTER TABLE youtube_videos ADD PRIMARY KEY (video_id);
+
+-- 2-3. video_idのインデックスを削除（PKなので不要）
+DROP INDEX IF EXISTS idx_youtube_videos_video_id;
+
+-- ==============================================
+-- Part 3: youtube_video_statsの外部キーを再設定
+-- ==============================================
+
+-- 3-1. video_idをNOT NULLに
+ALTER TABLE youtube_video_stats ALTER COLUMN video_id SET NOT NULL;
+
+-- 3-2. 外部キー制約を再設定
+ALTER TABLE youtube_video_stats ADD CONSTRAINT youtube_video_stats_video_id_fkey
+  FOREIGN KEY (video_id) REFERENCES youtube_videos(video_id) ON DELETE CASCADE;
+
+-- 3-3. UNIQUE制約を更新
+ALTER TABLE youtube_video_stats DROP CONSTRAINT IF EXISTS youtube_video_stats_youtube_video_id_recorded_at_key;
+ALTER TABLE youtube_video_stats ADD CONSTRAINT youtube_video_stats_video_id_recorded_at_key
+  UNIQUE(video_id, recorded_at);
+
+-- 3-4. インデックスを更新
+DROP INDEX IF EXISTS idx_youtube_video_stats_video_date;
+CREATE INDEX idx_youtube_video_stats_video_date ON youtube_video_stats(video_id, recorded_at DESC);


### PR DESCRIPTION
## Summary
- `youtube_videos`テーブルの`id UUID`を削除し、`video_id VARCHAR`をPRIMARY KEYに変更
- `youtube_video_stats`の外部キーを`youtube_video_id` → `video_id`に変更
- 関連するTypeScriptコードを全て更新

## 変更内容

### マイグレーション
`supabase/migrations/20260128134251_change_youtube_videos_pk.sql`
- `youtube_video_stats`の外部キー制約を一時削除
- データ移行（youtube_video_id → video_id）
- `youtube_videos.id`を削除、`video_id`をPKに
- 制約・インデックスを再設定

### コード修正
- `packages/youtube_data/src/db.ts, converters.ts, types.ts, sync.ts`
- `src/features/youtube/services/youtube-video-service.ts`
- `src/features/youtube/actions/youtube-video-actions.ts`
- `src/features/youtube/components/youtube-video-list.tsx`
- `src/features/youtube-stats/services/youtube-stats-service.ts`
- `src/features/youtube-stats/components/youtube-video-list.tsx`

## Test plan
- [x] `pnpm run db:reset` でマイグレーション適用
- [x] `pnpm run typecheck` で型エラーなし
- [x] `pnpm run biome:check:write` でlintエラーなし
- [ ] YouTube統計ページが正常に表示される
- [ ] YouTube動画同期が正常に動作する

Resolves #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**リファクタリング**
- YouTube動画データベーススキーマを最適化し、主キー識別子の命名規則を統一しました。これにより、システム全体のデータ整合性が向上し、内部データ処理がより効率的になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->