### PR TITLE
fix: revalidate user page cache when prefecture is updated

### DIFF
--- a/src/features/user-settings/actions/profile-actions.ts
+++ b/src/features/user-settings/actions/profile-actions.ts
@@ -394,6 +394,7 @@ export async function updateProfile(
 
   revalidatePath("/settings/profile");
   revalidatePath("/"); // ホームページの活動タイムラインも更新
+  revalidatePath(`/users/${user.id}`); // マイページのキャッシュも更新
   return {
     success: true,
   };


### PR DESCRIPTION
## Summary
- プロフィール設定で都道府県を変更した際、マイページ（`/users/[id]`）のキャッシュが無効化されていなかった問題を修正
- `revalidatePath` を追加してユーザーページのキャッシュも更新するようにした

## 変更内容
- `src/features/user-settings/actions/profile-actions.ts`: `revalidatePath(`/users/${user.id}`)` を追加

## 関連Issue
Fixes #1770

## Test plan
- [ ] プロフィール設定で都道府県を変更
- [ ] マイページ（`/users/[id]`）に遷移
- [ ] 変更した都道府県が即座に反映されていることを確認

## CLAへの同意
- [x] 本リポジトリへのコントリビュートには、コントリビューターライセンス契約（CLA）に同意することが必須です。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プロフィール更新後、ユーザーの個人ページが確実に最新の情報に更新されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->