### PR TITLE
feat: 3階層目以降のページにパンくずリスト表示

### DIFF
--- a/src/app/map/poster/[district]/page.tsx
+++ b/src/app/map/poster/[district]/page.tsx
@@ -1,3 +1,4 @@
+import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import {
   getPosterBoardStatsByDistrictAction,
   getUserEditedBoardIdsByDistrictAction,
@@ -97,16 +98,27 @@ export default async function DistrictPosterMapPage({
   }
 
   return (
-    <DetailedPosterMapClient
-      userId={user?.id}
-      prefecture={districtJp}
-      prefectureName={districtJp}
-      center={center}
-      initialStats={stats}
-      boardTotal={null}
-      userEditedBoardIds={userEditedBoardIds}
-      defaultZoom={defaultZoom}
-      isDistrict={true}
-    />
+    <>
+      <div className="container mx-auto max-w-7xl px-4 pt-4">
+        <PageBreadcrumb
+          items={[
+            { label: "ホーム", href: "/" },
+            { label: "ポスター掲示板マップ", href: "/map/poster" },
+            { label: districtJp },
+          ]}
+        />
+      </div>
+      <DetailedPosterMapClient
+        userId={user?.id}
+        prefecture={districtJp}
+        prefectureName={districtJp}
+        center={center}
+        initialStats={stats}
+        boardTotal={null}
+        userEditedBoardIds={userEditedBoardIds}
+        defaultZoom={defaultZoom}
+        isDistrict={true}
+      />
+    </>
   );
 }

--- a/src/app/map/poster/archive/[electionTerm]/[prefecture]/page.tsx
+++ b/src/app/map/poster/archive/[electionTerm]/[prefecture]/page.tsx
@@ -1,3 +1,4 @@
+import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import DetailedPosterMapClient from "@/features/map-poster/components/detailed-poster-map-client";
 import {
   POSTER_PREFECTURE_MAP,
@@ -65,19 +66,34 @@ export default async function ArchivePrefecturePage({
   const stats = await getArchivedPosterBoardStats(electionTerm, prefectureJp);
 
   return (
-    <DetailedPosterMapClient
-      userId={undefined}
-      prefecture={prefectureJp}
-      prefectureName={prefectureJp}
-      center={prefectureData.center}
-      initialStats={stats}
-      boardTotal={null}
-      userEditedBoardIds={[]}
-      defaultZoom={prefectureData.defaultZoom}
-      isDistrict={false}
-      isArchive={true}
-      archiveElectionTerm={electionTerm}
-      archiveTermName={termName}
-    />
+    <>
+      <div className="container mx-auto max-w-7xl px-4 pt-4">
+        <PageBreadcrumb
+          items={[
+            { label: "ホーム", href: "/" },
+            { label: "ポスター掲示板マップ", href: "/map/poster" },
+            {
+              label: termName,
+              href: `/map/poster/archive/${electionTerm}`,
+            },
+            { label: prefectureJp },
+          ]}
+        />
+      </div>
+      <DetailedPosterMapClient
+        userId={undefined}
+        prefecture={prefectureJp}
+        prefectureName={prefectureJp}
+        center={prefectureData.center}
+        initialStats={stats}
+        boardTotal={null}
+        userEditedBoardIds={[]}
+        defaultZoom={prefectureData.defaultZoom}
+        isDistrict={false}
+        isArchive={true}
+        archiveElectionTerm={electionTerm}
+        archiveTermName={termName}
+      />
+    </>
   );
 }

--- a/src/app/map/poster/archive/[electionTerm]/page.tsx
+++ b/src/app/map/poster/archive/[electionTerm]/page.tsx
@@ -1,3 +1,4 @@
+import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { statusConfig } from "@/features/map-poster/config/status-config";
@@ -87,6 +88,14 @@ export default async function ArchiveElectionTermPage({
 
   return (
     <div className="container mx-auto max-w-7xl space-y-6 p-4">
+      <PageBreadcrumb
+        items={[
+          { label: "ホーム", href: "/" },
+          { label: "ポスター掲示板マップ", href: "/map/poster" },
+          { label: termName },
+        ]}
+      />
+
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-center gap-2">

--- a/src/app/map/posting/[slug]/page.tsx
+++ b/src/app/map/posting/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import PostingPageClient from "@/features/map-posting/components/posting-page";
 import { getEventBySlug } from "@/features/map-posting/services/posting-events.server";
 import { getUser } from "@/features/user-profile/services/profile";
@@ -44,12 +45,23 @@ export default async function PostingEventPage({
   }
 
   return (
-    <PostingPageClient
-      userId={user.id}
-      eventId={event.id}
-      eventTitle={event.title}
-      isAdmin={isAdmin(user) || isPostingAdmin(user)}
-      isEventActive={event.is_active}
-    />
+    <>
+      <div className="container mx-auto max-w-7xl px-4 pt-4">
+        <PageBreadcrumb
+          items={[
+            { label: "ホーム", href: "/" },
+            { label: "ポスティングマップ", href: "/map/posting" },
+            { label: event.title },
+          ]}
+        />
+      </div>
+      <PostingPageClient
+        userId={user.id}
+        eventId={event.id}
+        eventTitle={event.title}
+        isAdmin={isAdmin(user) || isPostingAdmin(user)}
+        isEventActive={event.is_active}
+      />
+    </>
   );
 }

--- a/src/app/seasons/[slug]/ranking/mission/page.tsx
+++ b/src/app/seasons/[slug]/ranking/mission/page.tsx
@@ -1,3 +1,4 @@
+import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { getMissionsForRanking } from "@/features/missions/services/missions";
 import { CurrentUserCardMission } from "@/features/ranking/components/current-user-card-mission";
 import { MissionSelect } from "@/features/ranking/components/mission-select";
@@ -110,6 +111,17 @@ export default async function SeasonMissionRankingPage({
 
   return (
     <div className="flex flex-col items-center min-h-screen py-4 w-full">
+      <div className="w-full max-w-7xl px-4">
+        <PageBreadcrumb
+          items={[
+            { label: "ホーム", href: "/" },
+            { label: "ランキング", href: "/ranking" },
+            { label: season.name, href: `/seasons/${slug}/ranking` },
+            { label: "ミッション別" },
+          ]}
+        />
+      </div>
+
       <h2 className="text-2xl font-bold text-center mb-4">
         ミッション別ランキング
       </h2>

--- a/src/app/seasons/[slug]/ranking/page.tsx
+++ b/src/app/seasons/[slug]/ranking/page.tsx
@@ -1,3 +1,4 @@
+import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { CurrentUserCard } from "@/features/ranking/components/current-user-card";
 import {
   PeriodToggle,
@@ -60,6 +61,16 @@ export default async function SeasonRankingPage({
 
   return (
     <div className="flex flex-col items-center min-h-screen py-4 w-full">
+      <div className="w-full max-w-7xl px-4">
+        <PageBreadcrumb
+          items={[
+            { label: "ホーム", href: "/" },
+            { label: "ランキング", href: "/ranking" },
+            { label: season.name },
+          ]}
+        />
+      </div>
+
       <h2 className="text-2xl font-bold text-center mb-4">
         アクションリーダー
       </h2>

--- a/src/app/seasons/[slug]/ranking/prefecture/page.tsx
+++ b/src/app/seasons/[slug]/ranking/prefecture/page.tsx
@@ -1,3 +1,4 @@
+import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { CurrentUserCardPrefecture } from "@/features/ranking/components/current-user-card-prefecture";
 import { PrefectureSelect } from "@/features/ranking/components/prefecture-select";
 import { RankingPrefecture } from "@/features/ranking/components/ranking-prefecture";
@@ -85,6 +86,17 @@ export default async function SeasonPrefectureRankingPage({
 
   return (
     <div className="flex flex-col items-center min-h-screen py-4 w-full">
+      <div className="w-full max-w-7xl px-4">
+        <PageBreadcrumb
+          items={[
+            { label: "ホーム", href: "/" },
+            { label: "ランキング", href: "/ranking" },
+            { label: season.name, href: `/seasons/${slug}/ranking` },
+            { label: "都道府県別" },
+          ]}
+        />
+      </div>
+
       <h2 className="text-2xl font-bold text-center mb-4">
         都道府県別ランキング
       </h2>

--- a/src/app/seasons/[slug]/users/[userId]/page.tsx
+++ b/src/app/seasons/[slug]/users/[userId]/page.tsx
@@ -1,3 +1,4 @@
+import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { Card } from "@/components/ui/card";
 import { UserMissionAchievements } from "@/features/user-achievements/components/user-mission-achievements";
 import { getUserRepeatableMissionAchievements } from "@/features/user-achievements/services/achievements";
@@ -65,6 +66,17 @@ export default async function SeasonUserDetailPage({ params }: Props) {
 
   return (
     <div className="flex flex-col items-stretch w-full max-w-xl gap-4">
+      <div className="mx-4 mt-4">
+        <PageBreadcrumb
+          items={[
+            { label: "ホーム", href: "/" },
+            { label: "ランキング", href: "/ranking" },
+            { label: season.name, href: `/seasons/${slug}/ranking` },
+            { label: user.name || "ユーザー" },
+          ]}
+        />
+      </div>
+
       {/* シーズン情報ヘッダー */}
       <div className="mx-4 mt-4">
         <UserSeasonHeader season={season} userId={userId} />

--- a/src/components/common/page-breadcrumb.tsx
+++ b/src/components/common/page-breadcrumb.tsx
@@ -1,0 +1,42 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import Link from "next/link";
+import { Fragment } from "react";
+
+export interface BreadcrumbItemData {
+  label: string;
+  href?: string;
+}
+
+interface PageBreadcrumbProps {
+  items: BreadcrumbItemData[];
+}
+
+export function PageBreadcrumb({ items }: PageBreadcrumbProps) {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {items.map((item, index) => (
+          <Fragment key={item.href ?? item.label}>
+            {index > 0 && <BreadcrumbSeparator />}
+            <BreadcrumbItem>
+              {item.href ? (
+                <BreadcrumbLink asChild>
+                  <Link href={item.href}>{item.label}</Link>
+                </BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>{item.label}</BreadcrumbPage>
+              )}
+            </BreadcrumbItem>
+          </Fragment>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,116 @@
+import { Slot } from "@radix-ui/react-slot";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils/utils";
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"nav"> & {
+    separator?: React.ReactNode;
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
+Breadcrumb.displayName = "Breadcrumb";
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<"ol">
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      className,
+    )}
+    {...props}
+  />
+));
+BreadcrumbList.displayName = "BreadcrumbList";
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn("inline-flex items-center gap-1.5", className)}
+    {...props}
+  />
+));
+BreadcrumbItem.displayName = "BreadcrumbItem";
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean;
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a";
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  );
+});
+BreadcrumbLink.displayName = "BreadcrumbLink";
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    tabIndex={0}
+    aria-disabled="true"
+    aria-current="page"
+    className={cn("font-normal text-foreground", className)}
+    {...props}
+  />
+));
+BreadcrumbPage.displayName = "BreadcrumbPage";
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn("[&>svg]:h-3.5 [&>svg]:w-3.5", className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+);
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator";
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+);
+BreadcrumbEllipsis.displayName = "BreadcrumbEllipsis";
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+};


### PR DESCRIPTION
## Summary
- 3階層以上のURLを持つ8ページにパンくずリストナビゲーションを追加
- shadcn/ui Breadcrumbコンポーネントを導入
- 再利用可能な`PageBreadcrumb`ヘルパーコンポーネントを作成

## 変更内容

### 新規ファイル
- `src/components/ui/breadcrumb.tsx` — shadcn/ui Breadcrumbコンポーネント
- `src/components/common/page-breadcrumb.tsx` — 再利用可能なヘルパー

### パンくず追加ページ（8ページ）
| ページ | パンくず |
|-------|---------|
| `/map/poster/[district]` | ホーム > ポスター掲示板マップ > {区名} |
| `/map/poster/archive/[electionTerm]` | ホーム > ポスター掲示板マップ > {選挙名} |
| `/map/poster/archive/[electionTerm]/[prefecture]` | ホーム > ポスター掲示板マップ > {選挙名} > {都道府県名} |
| `/map/posting/[slug]` | ホーム > ポスティングマップ > {イベント名} |
| `/seasons/[slug]/ranking` | ホーム > ランキング > {シーズン名} |
| `/seasons/[slug]/ranking/mission` | ホーム > ランキング > {シーズン名} > ミッション別 |
| `/seasons/[slug]/ranking/prefecture` | ホーム > ランキング > {シーズン名} > 都道府県別 |
| `/seasons/[slug]/users/[userId]` | ホーム > ランキング > {シーズン名} > {ユーザー名} |

## Test plan
- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm test:unit` — 642テスト全パス
- [ ] 各ページでパンくずリストが正しく表示されることを確認
- [ ] パンくずのリンクが正しい遷移先に飛ぶことを確認

Closes #1818

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ポスター掲示板マップ、ポスティングマップ、ランキング、ユーザープロフィールなど複数のページにパンくずリストを追加しました。ユーザーは階層構造を視覚的に把握でき、サイト内のナビゲーションがより直感的になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->