### PR TITLE
Hide policy quiz missions from public view

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -568,7 +568,7 @@ missions:
     required_artifact_type: QUIZ
     max_achievement_count: 3
     is_featured: false
-    is_hidden: false
+    is_hidden: true
     artifact_label: null
     ogp_image_url: null
   - slug: quiz-policy-step1
@@ -579,7 +579,7 @@ missions:
     required_artifact_type: QUIZ
     max_achievement_count: 3
     is_featured: false
-    is_hidden: false
+    is_hidden: true
     artifact_label: null
     ogp_image_url: null
   - slug: quiz-policy-step2
@@ -590,7 +590,7 @@ missions:
     required_artifact_type: QUIZ
     max_achievement_count: 3
     is_featured: false
-    is_hidden: false
+    is_hidden: true
     artifact_label: null
   - slug: quiz-policy-step3
     title: 政策クイズ（ステップ３）に挑戦しよう
@@ -600,7 +600,7 @@ missions:
     required_artifact_type: QUIZ
     max_achievement_count: 3
     is_featured: false
-    is_hidden: false
+    is_hidden: true
     artifact_label: null
   - slug: quiz-policy-100days
     title: 政策クイズ（100日プラン）に挑戦しよう
@@ -610,7 +610,7 @@ missions:
     required_artifact_type: QUIZ
     max_achievement_count: 3
     is_featured: false
-    is_hidden: false
+    is_hidden: true
     artifact_label: null
   - slug: "quiz-electionlaw-basic"
     title: 公職選挙法クイズ（基礎編）に挑戦しよう


### PR DESCRIPTION
# 変更の概要
- 政策クイズ関連のミッション5件を非表示に設定しました
  - `quiz-policy-intro`
  - `quiz-policy-step1`
  - `quiz-policy-step2`
  - `quiz-policy-step3`
  - `quiz-policy-100days`

# 変更の背景
政策クイズミッションの`is_hidden`フラグを`false`から`true`に変更し、これらのミッションをユーザーの公開ビューから非表示にします。

# CLAへの同意
- [ ] CLAの内容を読み、同意しました

https://claude.ai/code/session_01WyKE7v2qEumC74PWMbrcFv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 5つのクイズミッション（ポリシー関連のステップクイズ4つとビジョンクイズ）がシステムで非表示状態に変更されました。これらはエンドユーザーの公開ミッション一覧には表示されず、検索結果にも見えなくなります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->