### PR TITLE
Update street speech schedule information with unofficial map link

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -297,8 +297,8 @@ missions:
     content: |-
       「チームみらい」の街頭演説を一緒に盛り上げよう！あなたの声援が力になります。
       ぜひご参加ください！
-    # 演説のスケジュールについては、候補者のSNSよりご確認ください。
-    # <a href="https://team-mir.ai/election/shugiin-2026" target="_blank" rel="noopener noreferrer">公式サイトの一覧</a>にSNSへのリンクが掲載されています。
+
+      演説のスケジュールは<a href="https://mirai-street-speech-map.vercel.app" target="_blank" rel="noopener noreferrer">街頭演説マップ（非公式）</a>をご覧ください。
     difficulty: 3
     required_artifact_type: TEXT
     max_achievement_count: null


### PR DESCRIPTION
# 変更の概要
- ミッション「チームみらい」の街頭演説スケジュール情報を更新しました
- 候補者のSNS確認を促すコメントを削除し、非公式の街頭演説マップへのリンクに変更しました

# 変更の背景
- ユーザーがスケジュール情報をより簡単にアクセスできるようにするため、専用の街頭演説マップ（https://mirai-street-speech-map.vercel.app）へのリンクを提供することにしました
- 複数のSNSを確認する手間を削減し、ユーザー体験を向上させます

# CLAへの同意
- [x] CLAの内容を読み、同意しました

https://claude.ai/code/session_01J8qLHNj6X8qCvirUc1BA6N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * イベント参加ミッションのユーザーガイダンスを更新しました。プレースホルダーコメントをクリック可能なマップリンクに置き換え、より直接的な案内を提供するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->