### PR TITLE
feat: 「街頭演説に参加しよう」ミッションに街頭演説マップへのリンクを追加

### DIFF
--- a/mission_data/mission_main_links.yaml
+++ b/mission_data/mission_main_links.yaml
@@ -20,6 +20,9 @@ mission_main_links:
   - mission_slug: join-slack
     label: チームみらいサポーターSlackはこちら
     link: https://team-mirai.notion.site/Slack-25bf6f56bae1807582edde6f29562d0b
+  - mission_slug: join-street-speech
+    label: 街頭演説マップはこちら
+    link: https://mirai-street-speech-map.vercel.app/
   - mission_slug: youtube-clip
     label: 動画切り抜きガイドはこちら
     link: https://team-mirai.notion.site/255f6f56bae1804cbdecdd7b81f9e591


### PR DESCRIPTION
## Summary
- ミッション「街頭演説に参加しよう」のページに街頭演説マップ（https://mirai-street-speech-map.vercel.app/）へのリンクを追加
- `mission_main_links.yaml` に `join-street-speech` ミッション用のリンクエントリを追加

closes #1851

## Test plan
- [ ] ミッションページ `/missions/join-street-speech` に「街頭演説マップはこちら」リンクが表示されること
- [ ] リンクをクリックすると街頭演説マップサイトが開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 街頭演説マップへのアクセスポイントが追加されました。ユーザーはこのリンクから街頭演説マップに直接アクセスできるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->