### PR TITLE
fix: RLS issue in user edited boards filter

### DIFF
--- a/src/features/map-poster/actions/poster-boards.ts
+++ b/src/features/map-poster/actions/poster-boards.ts
@@ -1,7 +1,9 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/client";
+import { createClient as createServerClient } from "@/lib/supabase/server";
 import type { Database } from "@/lib/types/supabase";
+import { cookies } from "next/headers";
 
 type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
 type PrefectureName = NonNullable<
@@ -142,7 +144,8 @@ export async function getUserEditedBoardIdsAction(
   prefecture: PrefectureName,
   userId: string,
 ): Promise<string[]> {
-  const supabase = createClient();
+  const cookieStore = await cookies();
+  const supabase = createServerClient(cookieStore);
 
   try {
     // RPC関数を使用して効率的にデータを取得
@@ -263,7 +266,8 @@ export async function getUserEditedBoardIdsByDistrictAction(
   district: string,
   userId: string,
 ): Promise<string[]> {
-  const supabase = createClient();
+  const cookieStore = await cookies();
+  const supabase = createServerClient(cookieStore);
 
   try {
     // 区割りでフィルタリングして取得

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,36 @@
+import type { Database } from "@/lib/types/supabase";
+import { createServerClient } from "@supabase/ssr";
+import type { cookies } from "next/headers";
+
+export function createClient(cookieStore: Awaited<ReturnType<typeof cookies>>) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL environment variable");
+  }
+
+  if (!supabaseAnonKey) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable",
+    );
+  }
+
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // Server Component から setAll が呼ばれた場合はエラーになるため無視する
+          // (Server Action や Route Handler では正常に動作します)
+        }
+      },
+    },
+  });
+}


### PR DESCRIPTION
# 変更の概要
- 従来の createClient() 実装では、Server Action として実行された際にリクエストの Cookie 情報が正しく引き継がれず、DBへのクエリが「匿名ユーザー（認証なし）」として実行され、poster_board_status_history テーブルに設定されている RLS ポリシー（auth.uid() IS NOT NULL）によってアクセスが拒否され、空の結果が返ってきている可能性がある。

# 変更の背景
- closes #1862

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクター**
  * ボード操作のサーバー側認証処理を改善
  * サーバーサイド認証用の新しいヘルパー機能を追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->