### PR TITLE
fix: ポスター貼りミッション失敗時にエラーメッセージを表示

### DIFF
--- a/src/features/map-poster/components/detailed-poster-map-client.tsx
+++ b/src/features/map-poster/components/detailed-poster-map-client.tsx
@@ -323,6 +323,8 @@ export default function DetailedPosterMapClient({
 
     if (result.success) {
       toast.success(`ミッション達成！ +${result.xpGranted}XP獲得`);
+    } else {
+      toast.error(result.error || "ミッション達成に失敗しました");
     }
   };
 
@@ -345,9 +347,9 @@ export default function DetailedPosterMapClient({
           );
 
           if (!hasCompleted) {
-            // ミッション達成処理を実行（非同期で実行し、失敗してもステータス更新は成功扱い）
+            // ミッション達成処理を実行（失敗してもステータス更新は成功扱い）
             completePosterBoardMission(selectedBoard).catch(() => {
-              // エラーは無視して、ステータス更新自体は成功として扱う
+              toast.error("ミッション達成に失敗しました");
             });
           }
         }


### PR DESCRIPTION
## Summary
- ポスター貼りミッション達成処理が失敗した際、エラーが無視されユーザーに通知されない問題を修正
- `completePosterBoardMission()`に`toast.error()`を追加し、ポスティングマップ(`shape-status-dialog.tsx`)と同様のエラー通知パターンに統一
- ステータス更新自体は成功として扱う既存動作を維持

## Changes
- `detailed-poster-map-client.tsx`: `achieveMissionAction`の失敗時に`toast.error()`を表示
- `.catch()`内でも予期しないエラー時にエラーメッセージを表示

## Test plan
- [ ] ポスター貼りでステータスを「完了」に変更 → ミッション達成成功時にXP獲得トーストが表示される（既存動作）
- [ ] ミッション達成処理が失敗した場合にエラートーストが表示される
- [ ] ミッション達成が失敗してもステータス更新自体は成功する

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ミッション達成時のエラー処理を改善。ミッション完了に失敗した場合、ユーザーに対してエラーメッセージが適切に表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->