### PR TITLE
Fix youtube_video_likes RLS policy by adding TO authenticated

### DIFF
--- a/supabase/migrations/20260131000000_fix_youtube_video_likes_rls_policy.sql
+++ b/supabase/migrations/20260131000000_fix_youtube_video_likes_rls_policy.sql
@@ -1,0 +1,21 @@
+-- youtube_video_likesのRLSポリシーを修正
+-- ALLポリシーに TO authenticated を追加
+
+-- 既存のALLポリシーを削除
+DROP POLICY IF EXISTS "Users can manage their own youtube video likes" ON youtube_video_likes;
+
+-- TO authenticated を追加したALLポリシーを再作成
+CREATE POLICY "Users can manage their own youtube video likes"
+  ON youtube_video_likes
+  FOR ALL
+  TO authenticated
+  USING (
+    auth.uid() = (
+      SELECT ma.user_id FROM mission_artifacts ma WHERE ma.id = mission_artifact_id
+    )
+  )
+  WITH CHECK (
+    auth.uid() = (
+      SELECT ma.user_id FROM mission_artifacts ma WHERE ma.id = mission_artifact_id
+    )
+  );


### PR DESCRIPTION
# 変更の概要
- `youtube_video_likes`テーブルのRLSポリシーを修正し、ALLポリシーに`TO authenticated`句を追加しました
- 既存のポリシーを削除し、認証ユーザーのみがアクセス可能なポリシーを再作成しました

# 変更の背景
- `youtube_video_likes`テーブルのRLSポリシーが不完全な設定になっていました
- ALLポリシーに`TO authenticated`句がなかったため、ポリシーの適用範囲が明確でありませんでした
- 認証済みユーザーのみが自身の関連するYouTube動画のいいね情報を管理できるようにするため、ポリシーを修正しました

# CLAへの同意
- [ ] CLAの内容を読み、同意しました

https://claude.ai/code/session_014PeJfxWFhb9pp97sRxwyyR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * YouTube動画の「いいね」機能のアクセス制御ルールを更新しました。認証済みユーザーのデータへのアクセスがより厳密に管理されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->