### PR TITLE
Unfeature poster mission and remove importance setting

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -502,8 +502,7 @@ missions:
     difficulty: 2
     required_artifact_type: POSTER
     max_achievement_count: null
-    is_featured: true
-    featured_importance: 20
+    is_featured: false
     is_hidden: false
     ogp_image_url: null
   - slug: put-up-proportional-representation-poster


### PR DESCRIPTION
# 変更の概要
- ポスター関連のミッションのフィーチャー設定を無効化しました
- `is_featured: true` から `is_featured: false` に変更
- 不要になった `featured_importance: 20` の設定行を削除

# 変更の背景
- このミッションをフィーチャー対象から外す必要があるため
- featured_importance設定は不要になったため削除

# CLAへの同意
- [ ] CLAの内容を読み、同意しました

https://claude.ai/code/session_012CNh3UCM7iw2me9jEahp7X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ミッション一覧のフィーチャー設定を更新しました。「Put up Poster」ミッションがフィーチャー対象から削除されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->