### PR TITLE
update Dockerfile to set NODE_OPTIONS for memory management during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-RUN SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN} \
+RUN NODE_OPTIONS="--max-old-space-size=4096" \
+    SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN} \
     SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY} \
     pnpm run build
 


### PR DESCRIPTION
cloud buildでエラー出たのでそれの対応

  > next build
  Attention: Next.js now collects completely anonymous telemetry regarding usage.
  This information is used to shape Next.js' roadmap and prioritize features.
  You can learn more, including how to opt-out if you'd not like to participate
  in this anonymous program, by visiting the following URL:
  https://nextjs.org/telemetry
     ▲ Next.js 15.5.9
     - Experiments (use with caution):
       · serverActions
       · clientTraceMetadata
     Creating an optimized production build ...
  [@sentry/nextjs - Node.js] Info: Sending telemetry data on issues and
  performance to Sentry. To disable telemetry, set `options.telemetry` to
  `false`.
  <--- Last few GCs --->
  [30:0x8389000]    60892 ms: Scavenge 2037.9 (2077.7) -> 2037.8 (2088.2) MB,
  pooled: 0 MB, 5.46 / 0.00 ms  (average mu = 0.407, current mu = 0.192)
  allocation failure;
  [30:0x8389000]    61491 ms: Mark-Compact (reduce) 2046.3 (2090.1) -> 2041.1
  (2079.8) MB, pooled: 0 MB, 467.04 / 0.00 ms  (+ 91.6 ms in 0 steps since start
  of marking, biggest step 0.0 ms, walltime since start of marking 599 ms)
  (average mu = 0.329, curren
  <--- JS stacktrace --->
  FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of
  memory
  ----- Native stack trace -----
   1: 0xe1bdfe node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
   2: 0x123e800 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*,
  v8::OOMDetails const&) [node]
   3: 0x123ead7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*,
   char const*, v8::OOMDetails const&) [node]
   4: 0x146c615  [node]
   5: 0x1485e89 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace,
   v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
   6: 0x145a558
  v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int,
  v8::internal::AllocationType, v8::internal::AllocationOrigin,
  v8::internal::AllocationAlignment) [node]
   7: 0x145b485
  v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int,
  v8::internal::AllocationType, v8::internal::AllocationOrigin,
  v8::internal::AllocationAlignment) [node]
   8: 0x143415e v8::internal::Factory::NewFillerObject(int,
  v8::internal::AllocationAlignment, v8::internal::AllocationType,
  v8::internal::AllocationOrigin) [node]
   9: 0x189588c v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned
  long*, v8::internal::Isolate*) [node]
  10: 0x7f0003eac7c9