### PR TITLE
Biome を 2系にアップグレード

### DIFF
--- a/.github/workflows/check_code.yaml
+++ b/.github/workflows/check_code.yaml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
-        with:
-          version: 1.9.4
 
       - name: Run Biome
         run: biome ci .

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,7 @@
   "editor.defaultFormatter": "biomejs.biome",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "quickfix.biome": "explicit",
-    "source.organizeImports.biome": "explicit"
+    "source.fixAll.biome": "explicit"
   },
   "files.insertFinalNewline": true,
   "[typescriptreact]": {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -7,14 +7,16 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": [
-      "**/.next/**",
-      "**/node_modules/**",
-      "**/.pnpm-store/**",
-      "**/supabase/.temp/**",
-      "**/playwright-report/**",
-      "**/coverage/**",
-      "**/mobile_flutter/**"
+    "includes": [
+      "**",
+      "!**/.next",
+      "!**/node_modules",
+      "!**/.pnpm-store",
+      "!**/supabase/.temp",
+      "!**/playwright-report",
+      "!**/coverage",
+      "!**/mobile_flutter",
+      "!**/supabase/templates"
     ]
   },
   "formatter": {
@@ -22,21 +24,31 @@
     "indentStyle": "space",
     "indentWidth": 2
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
       "recommended": true,
       "correctness": {
-        "noUnusedImports": "warn"
+        "noUnusedImports": "warn",
+        "noUnusedVariables": "warn",
+        "noUnusedFunctionParameters": "warn",
+        "noInvalidUseBeforeDeclaration": "warn",
+        "useExhaustiveDependencies": "warn",
+        "useHookAtTopLevel": "warn"
+      },
+      "a11y": {
+        "useSemanticElements": "warn",
+        "noStaticElementInteractions": "warn"
+      },
+      "performance": {
+        "noImgElement": "warn"
       }
     }
   },
   "overrides": [
     {
-      "include": ["**/*.test.tsx", "**/*.test.ts"],
+      "includes": ["**/*.test.tsx", "**/*.test.ts"],
       "linter": {
         "rules": {
           "suspicious": {
@@ -50,6 +62,11 @@
   "javascript": {
     "formatter": {
       "quoteStyle": "double"
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
     }
   }
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,5 @@
 // Jest setup file
-const React = require("react");
+const _React = require("react");
 
 require("@testing-library/jest-dom");
 
@@ -87,7 +87,7 @@ jest.mock("lucide-react", () => ({
   },
 }));
 
-const createMockSupabaseQuery = () => {
+const _createMockSupabaseQuery = () => {
   const mockQuery = {
     eq: jest.fn(() => mockQuery),
     gte: jest.fn(() => mockQuery),

--- a/mission_data/src/db.ts
+++ b/mission_data/src/db.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
-import { createAdminClient } from "@/lib/supabase/adminClient";
 import * as dotenv from "dotenv";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 
 // Load .env from project root
 dotenv.config({ path: path.resolve(__dirname, "../../.env") });

--- a/mission_data/src/export.ts
+++ b/mission_data/src/export.ts
@@ -1,8 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { createAdminClient } from "@/lib/supabase/adminClient";
 import { Command } from "commander";
 import * as yaml from "js-yaml";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 
 const program = new Command();
 

--- a/mission_data/src/sync.ts
+++ b/mission_data/src/sync.ts
@@ -1,8 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { createAdminClient } from "@/lib/supabase/adminClient";
 import { Command } from "commander";
 import * as yaml from "js-yaml";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import {
   getCategorySlugToIdMap,
   getMissionSlugToIdMap,

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "zod": "^3.25.23"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.4",
+    "@biomejs/biome": "2.3.13",
     "@jest/globals": "^29.7.0",
     "@playwright/test": "^1.52.0",
     "@tailwindcss/postcss": "^4.1.16",

--- a/packages/tiktok_data/src/sync.ts
+++ b/packages/tiktok_data/src/sync.ts
@@ -7,11 +7,11 @@ import {
 } from "./db.js";
 import { getSupabaseClient } from "./supabase.js";
 import {
-  TikTokAPIError,
   extractHashtags,
   fetchVideoList,
   filterTeamMiraiVideos,
   refreshAccessToken,
+  TikTokAPIError,
 } from "./tiktok-client.js";
 import type {
   SyncResult,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.9.4
-        version: 1.9.4
+        specifier: 2.3.13
+        version: 2.3.13
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
@@ -462,55 +462,55 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.3.13':
+    resolution: {integrity: sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.3.13':
+    resolution: {integrity: sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.3.13':
+    resolution: {integrity: sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.3.13':
+    resolution: {integrity: sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.3.13':
+    resolution: {integrity: sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.3.13':
+    resolution: {integrity: sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.3.13':
+    resolution: {integrity: sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.3.13':
+    resolution: {integrity: sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.3.13':
+    resolution: {integrity: sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -4939,39 +4939,39 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.3.13':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.3.13
+      '@biomejs/cli-darwin-x64': 2.3.13
+      '@biomejs/cli-linux-arm64': 2.3.13
+      '@biomejs/cli-linux-arm64-musl': 2.3.13
+      '@biomejs/cli-linux-x64': 2.3.13
+      '@biomejs/cli-linux-x64-musl': 2.3.13
+      '@biomejs/cli-win32-arm64': 2.3.13
+      '@biomejs/cli-win32-x64': 2.3.13
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.3.13':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.3.13':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.3.13':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.3.13':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.3.13':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.3.13':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.3.13':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.3.13':
     optional: true
 
   '@csstools/color-helpers@5.1.0': {}

--- a/poster_data/auto-load-from-drive.ts
+++ b/poster_data/auto-load-from-drive.ts
@@ -3,8 +3,8 @@
 import { execSync } from "node:child_process";
 import {
   existsSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -46,7 +46,7 @@ function loadProcessedFiles(): Record<string, { mtime: number; size: number }> {
   if (existsSync(PROCESSED_FILES_LOG)) {
     try {
       return JSON.parse(readFileSync(PROCESSED_FILES_LOG, "utf-8"));
-    } catch (e) {
+    } catch (_e) {
       console.warn("⚠️  Could not read processed files log, starting fresh");
     }
   }
@@ -75,7 +75,7 @@ function hasFileChanged(
     return (
       processed[filepath].mtime !== mtime || processed[filepath].size !== size
     );
-  } catch (e) {
+  } catch (_e) {
     return true; // If we can't stat it, assume it changed
   }
 }
@@ -112,7 +112,7 @@ function findCsvFiles(dir: string): CsvFiles {
 
         try {
           stat = statSync(fullPath);
-        } catch (e) {
+        } catch (_e) {
           console.warn(`⚠️  Could not stat ${entry}, skipping`);
           continue;
         }
@@ -293,8 +293,8 @@ async function logFileSelection(
 // Log append files
 async function logAppendFiles(
   files: string[],
-  prefecture: string,
-  city: string,
+  _prefecture: string,
+  _city: string,
 ): Promise<void> {
   if (files.length === 0) return;
 

--- a/posting_data/src/db.ts
+++ b/posting_data/src/db.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
-import { createAdminClient } from "@/lib/supabase/adminClient";
 import * as dotenv from "dotenv";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 
 // Load .env from project root
 dotenv.config({ path: path.resolve(__dirname, "../../.env") });

--- a/posting_data/src/sync.ts
+++ b/posting_data/src/sync.ts
@@ -1,10 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { createAdminClient } from "@/lib/supabase/adminClient";
 import { Command } from "commander";
 import * as dotenv from "dotenv";
 import * as yaml from "js-yaml";
 import type { z } from "zod";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import { type PostingEvent, PostingEventDataSchema } from "./types";
 
 // Load .env from project root

--- a/scripts/calculate-badges.ts
+++ b/scripts/calculate-badges.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import { calculateAllBadges } from "@/features/user-badges-calculation/calculate-badges";
 import dotenv from "dotenv";
+import { calculateAllBadges } from "@/features/user-badges-calculation/calculate-badges";
 
 // .envファイルをロード（ローカル開発用）
 dotenv.config({ path: path.resolve(process.cwd(), ".env") });

--- a/scripts/sync-youtube-videos.ts
+++ b/scripts/sync-youtube-videos.ts
@@ -11,8 +11,8 @@
 import "dotenv/config";
 
 import {
-  type VideoSyncResult,
   syncYouTubeVideos,
+  type VideoSyncResult,
 } from "@/features/youtube/services/youtube-video-sync-service";
 
 // 日付文字列をISO 8601形式に変換（YouTube APIが要求する形式）

--- a/scripts/update-user-email.ts
+++ b/scripts/update-user-email.ts
@@ -4,9 +4,9 @@
 // npx tsx scripts/update-user-email.ts --old 旧メールアドレス --new 新メールアドレス
 
 import path from "node:path";
-import { createAdminClient } from "@/lib/supabase/adminClient";
 import { Command } from "commander";
 import dotenv from "dotenv";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 
 // .envファイルをロード（ローカル開発用）
 dotenv.config({ path: path.resolve(process.cwd(), ".env") });

--- a/src/app/(auth-pages)/forgot-password/page.tsx
+++ b/src/app/(auth-pages)/forgot-password/page.tsx
@@ -1,5 +1,5 @@
-import { ForgotPasswordForm } from "@/features/auth/components/forgot-password-form";
 import Image from "next/image";
+import { ForgotPasswordForm } from "@/features/auth/components/forgot-password-form";
 
 export default async function ForgotPassword(props: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;

--- a/src/app/(auth-pages)/sign-in/page.tsx
+++ b/src/app/(auth-pages)/sign-in/page.tsx
@@ -1,7 +1,7 @@
-import { FormMessage, type Message } from "@/components/common/form-message";
-import SignInForm from "@/features/auth/components/sign-in-form";
 import Image from "next/image";
 import Link from "next/link";
+import { FormMessage, type Message } from "@/components/common/form-message";
+import SignInForm from "@/features/auth/components/sign-in-form";
 
 export default async function Login(props: {
   searchParams: Promise<Message & { returnUrl?: string }>;

--- a/src/app/(auth-pages)/sign-up-email/page.tsx
+++ b/src/app/(auth-pages)/sign-up-email/page.tsx
@@ -1,6 +1,6 @@
+import Image from "next/image";
 import type { Message } from "@/components/common/form-message";
 import EmailSignUpForm from "@/features/auth/components/email-sign-up-form";
-import Image from "next/image";
 
 export default async function EmailSignup(props: {
   searchParams: Promise<Message>;

--- a/src/app/(auth-pages)/sign-up-success/page.tsx
+++ b/src/app/(auth-pages)/sign-up-success/page.tsx
@@ -1,5 +1,5 @@
-import { FormMessage } from "@/components/common/form-message";
 import Image from "next/image";
+import { FormMessage } from "@/components/common/form-message";
 
 export default function SignUpSuccess() {
   return (

--- a/src/app/(auth-pages)/sign-up/page.tsx
+++ b/src/app/(auth-pages)/sign-up/page.tsx
@@ -1,6 +1,6 @@
+import Image from "next/image";
 import type { Message } from "@/components/common/form-message";
 import TwoStepSignUpForm from "@/features/auth/components/two-step-sign-up-form";
-import Image from "next/image";
 
 export default async function Signup(props: {
   searchParams: Promise<Message>;

--- a/src/app/(protected)/settings/profile/page.tsx
+++ b/src/app/(protected)/settings/profile/page.tsx
@@ -1,3 +1,7 @@
+import { ChevronRight } from "lucide-react";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
 import type { Message } from "@/components/common/form-message";
 import { PartyBadgeVisibilityToggle } from "@/features/party-membership/components/party-badge-visibility-toggle";
 import { getPartyMembership } from "@/features/party-membership/services/memberships";
@@ -11,10 +15,6 @@ import { AccountDeletionSection } from "@/features/user-settings/components/acco
 import { LoginSection } from "@/features/user-settings/components/login-section";
 import ProfileForm from "@/features/user-settings/components/profile-form";
 import { YouTubeIcon } from "@/features/youtube/components";
-import { ChevronRight } from "lucide-react";
-import { headers } from "next/headers";
-import Link from "next/link";
-import { redirect } from "next/navigation";
 
 type ProfileSettingsPageSearchParams = {
   new: string;

--- a/src/app/(protected)/settings/tiktok/page.tsx
+++ b/src/app/(protected)/settings/tiktok/page.tsx
@@ -1,6 +1,6 @@
+import { redirect } from "next/navigation";
 import { getTikTokLinkStatusAction } from "@/features/tiktok/actions/tiktok-video-actions";
 import { getUser } from "@/features/user-profile/services/profile";
-import { redirect } from "next/navigation";
 import { TikTokSettingsContent } from "./tiktok-settings-content";
 
 export default async function TikTokSettingsPage({

--- a/src/app/(protected)/settings/tiktok/tiktok-settings-content.tsx
+++ b/src/app/(protected)/settings/tiktok/tiktok-settings-content.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import {
   TikTokLinkButton,
   TikTokSyncButton,
   TikTokVideoList,
 } from "@/features/tiktok/components";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 interface TikTokSettingsContentProps {
   isLinked: boolean;

--- a/src/app/(protected)/settings/youtube/page.tsx
+++ b/src/app/(protected)/settings/youtube/page.tsx
@@ -1,6 +1,6 @@
+import { redirect } from "next/navigation";
 import { getUser } from "@/features/user-profile/services/profile";
 import { getYouTubeLinkStatusAction } from "@/features/youtube/actions/youtube-video-actions";
-import { redirect } from "next/navigation";
 import { YouTubeSettingsContent } from "./youtube-settings-content";
 
 export default async function YouTubeSettingsPage({

--- a/src/app/(protected)/settings/youtube/youtube-settings-content.tsx
+++ b/src/app/(protected)/settings/youtube/youtube-settings-content.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   YouTubeCommentList,
@@ -8,9 +11,6 @@ import {
   YouTubeSyncButton,
   YouTubeVideoList,
 } from "@/features/youtube/components";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 interface YouTubeSettingsContentProps {
   isLinked: boolean;

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,35 +1,32 @@
 "use server";
 
 import { randomBytes } from "node:crypto";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { z } from "zod";
 import {
   getOrInitializeUserLevel,
   grantMissionCompletionXp,
 } from "@/features/user-level/services/level";
+import { getCurrentSeasonId } from "@/lib/services/seasons";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
 import { deleteCookie, getCookie } from "@/lib/utils/server-cookies";
 import { calculateAge, encodedRedirect } from "@/lib/utils/utils";
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import { z } from "zod";
-
 import {
   forgotPasswordFormSchema,
   signInAndLoginFormSchema,
   signUpAndLoginFormSchema,
 } from "@/lib/validation/auth";
-
 import {
   isEmailAlreadyUsedInReferral,
   isValidReferralCode,
 } from "@/lib/validation/referral";
-
-import { getCurrentSeasonId } from "@/lib/services/seasons";
-import { createAdminClient } from "@/lib/supabase/adminClient";
 import { validateReturnUrl } from "@/lib/validation/url";
 
 // useActionState用のサインアップアクション
 export const signUpActionWithState = async (
-  prevState: {
+  _prevState: {
     error?: string;
     success?: string;
     message?: string;
@@ -220,7 +217,7 @@ export const signUpActionWithState = async (
 
 // useActionState用のサインインアクション
 export const signInActionWithState = async (
-  prevState: {
+  _prevState: {
     error?: string;
     success?: string;
     message?: string;
@@ -397,7 +394,7 @@ export const signOutAction = async () => {
 
 // Email + Password専用サインアップアクション（Two-Step Signup用）
 export const emailSignUpActionWithState = async (
-  prevState: {
+  _prevState: {
     error?: string;
     success?: string;
     message?: string;

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,10 +1,10 @@
+import type { Metadata } from "next";
 import { Card } from "@/components/ui/card";
 import GlobalActivities from "@/features/user-activity/components/global-activities";
 import {
   getGlobalActivityTimeline,
   getGlobalActivityTimelineCount,
 } from "@/features/user-activity/services/timeline";
-import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "活動タイムライン | アクションボード",

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,5 +1,5 @@
-import { createClient } from "@/lib/supabase/client";
 import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/client";
 
 export async function GET(request: Request) {
   // The `/auth/callback` route is required for the server-side auth flow implemented

--- a/src/app/api/auth/line-callback/route.ts
+++ b/src/app/api/auth/line-callback/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
     if (state) redirectUrl.searchParams.set("state", state);
 
     return NextResponse.redirect(redirectUrl);
-  } catch (error) {
+  } catch (_error) {
     // Error handling: redirect to sign-in page with error
     return NextResponse.redirect(
       new URL("/sign-in?error=callback_failed", baseUrl),

--- a/src/app/api/batch/backfill-missing-xp/route.ts
+++ b/src/app/api/batch/backfill-missing-xp/route.ts
@@ -1,8 +1,8 @@
+import { type NextRequest, NextResponse } from "next/server";
 import { grantXpBatch } from "@/features/user-level/services/level";
 import { calculateMissionXp } from "@/features/user-level/utils/level-calculator";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { executeChunkedQuery } from "@/lib/utils/supabase-utils";
-import { type NextRequest, NextResponse } from "next/server";
 
 // 型定義を明示（Supabaseの!innerJOINが配列を返す可能性を考慮）
 type AchievementWithMission = {

--- a/src/app/api/missions/[slug]/og/route.tsx
+++ b/src/app/api/missions/[slug]/og/route.tsx
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { getMissionPageData } from "@/features/mission-detail/services/mission-detail";
 import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
+import { getMissionPageData } from "@/features/mission-detail/services/mission-detail";
 
 // キャッシュ用Mapを定義（メモリキャッシュ）- completeタイプのみキャッシュ
 // キーはslugベースで管理

--- a/src/app/api/users/[id]/activity-timeline/route.test.ts
+++ b/src/app/api/users/[id]/activity-timeline/route.test.ts
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { getUserActivityTimeline } from "@/features/user-activity/services/timeline";
+
 import { NextRequest } from "next/server";
+import { getUserActivityTimeline } from "@/features/user-activity/services/timeline";
 import { GET } from "./route";
 
 jest.mock("@/features/user-activity/services/timeline");

--- a/src/app/api/users/[id]/activity-timeline/route.ts
+++ b/src/app/api/users/[id]/activity-timeline/route.ts
@@ -1,5 +1,5 @@
-import { getUserActivityTimeline } from "@/features/user-activity/services/timeline";
 import { type NextRequest, NextResponse } from "next/server";
+import { getUserActivityTimeline } from "@/features/user-activity/services/timeline";
 
 export async function GET(
   request: NextRequest,

--- a/src/app/auth/line-callback/page.tsx
+++ b/src/app/auth/line-callback/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { handleLineAuthAction } from "@/app/actions";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
+import { handleLineAuthAction } from "@/app/actions";
 
 function LineCallbackContent() {
   const router = useRouter();

--- a/src/app/auth/tiktok-callback/page.tsx
+++ b/src/app/auth/tiktok-callback/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { handleTikTokLinkAction } from "@/features/tiktok/actions/tiktok-auth-actions";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
+import { handleTikTokLinkAction } from "@/features/tiktok/actions/tiktok-auth-actions";
 
 function TikTokCallbackContent() {
   const router = useRouter();

--- a/src/app/auth/youtube-callback/page.tsx
+++ b/src/app/auth/youtube-callback/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { handleYouTubeLinkAction } from "@/features/youtube/actions/youtube-auth-actions";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
+import { handleYouTubeLinkAction } from "@/features/youtube/actions/youtube-auth-actions";
 
 function YouTubeCallbackContent() {
   const router = useRouter();

--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -1,8 +1,8 @@
+import Image from "next/image";
 import { CopyrightSection } from "@/components/footer/copyright-section";
 import { FeedbackSection } from "@/components/footer/feedback-section";
 import { LogoSection } from "@/components/footer/logo-section";
 import { SeasonsList } from "@/components/footer/seasons-list";
-import Image from "next/image";
 
 export default function Footer() {
   return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@config '../../tailwind.config.ts';
+@config "../../tailwind.config.ts";
 
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
@@ -46,13 +46,15 @@
 }
 
 @utility shadow-soft {
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px
-    rgba(0, 0, 0, 0.03);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.05),
+    0 2px 4px -1px rgba(0, 0, 0, 0.03);
 }
 
 @utility shadow-soft-lg {
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px
-    rgba(0, 0, 0, 0.03);
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.05),
+    0 4px 6px -2px rgba(0, 0, 0, 0.03);
 }
 
 @utility shadow-custom {
@@ -130,7 +132,8 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont,
+    font-family:
+      var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont,
       "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif;
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import Hero from "@/components/top/hero";
 import { MetricsWithSuspense } from "@/features/metrics/components/metrics-with-suspense";
 import FeaturedMissions from "@/features/missions/components/featured-missions";
@@ -5,8 +6,8 @@ import MissionsByCategory from "@/features/missions/components/missions-by-categ
 import { hasFeaturedMissions } from "@/features/missions/services/missions";
 import RankingSection from "@/features/ranking/components/ranking-section";
 import Activities from "@/features/user-activity/components/activities";
-import { BadgeNotificationCheck } from "@/features/user-badges-notification/components/badge-notification-check";
 import { getUnnotifiedBadges } from "@/features/user-badges/services/get-unnotified-badges";
+import { BadgeNotificationCheck } from "@/features/user-badges-notification/components/badge-notification-check";
 import { LevelUpCheck } from "@/features/user-level/components/level-up-check";
 import { checkLevelUpNotification } from "@/features/user-level/services/level-up-notification";
 import {
@@ -15,7 +16,6 @@ import {
 } from "@/features/user-profile/services/profile";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
 import { generateRootMetadata } from "@/lib/utils/metadata";
-import { redirect } from "next/navigation";
 
 // メタデータ生成を外部関数に委譲
 export const generateMetadata = generateRootMetadata;
@@ -26,7 +26,7 @@ export default async function Home({
   searchParams: Promise<{ ref?: string }>;
 }) {
   const params = await searchParams;
-  const referralCode = params.ref;
+  const _referralCode = params.ref;
 
   const user = await getUser();
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,13 @@
+import { ThemeProvider } from "next-themes";
 import Navbar from "@/components/common/navbar";
 import { generateRootMetadata, notoSansJP } from "@/lib/utils/metadata";
-import { ThemeProvider } from "next-themes";
 import Footer from "./footer";
 import "./globals.css";
-import { Toaster } from "@/components/ui/sonner";
-import { ReferralCodeHandlerWrapper } from "@/features/referral/components/referral-code-handler-wrapper";
 import Script from "next/script";
 import NextTopLoader from "nextjs-toploader";
 import { Suspense } from "react";
+import { Toaster } from "@/components/ui/sonner";
+import { ReferralCodeHandlerWrapper } from "@/features/referral/components/referral-code-handler-wrapper";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 

--- a/src/app/map/poster/[district]/page.tsx
+++ b/src/app/map/poster/[district]/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import {
   getPosterBoardStatsByDistrictAction,
@@ -5,14 +7,12 @@ import {
 } from "@/features/map-poster/actions/poster-boards";
 import DetailedPosterMapClient from "@/features/map-poster/components/detailed-poster-map-client";
 import {
+  isValidDistrict,
   POSTER_DISTRICT_MAP,
   type PosterDistrictKey,
-  isValidDistrict,
 } from "@/features/map-poster/constants/poster-district-shugin-2026";
 import { getDistrictsWithBoards } from "@/features/map-poster/services/poster-boards";
 import { getUser } from "@/features/user-profile/services/profile";
-import type { Metadata } from "next";
-import { redirect } from "next/navigation";
 
 export async function generateMetadata({
   params,

--- a/src/app/map/poster/archive/[electionTerm]/[prefecture]/page.tsx
+++ b/src/app/map/poster/archive/[electionTerm]/[prefecture]/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import DetailedPosterMapClient from "@/features/map-poster/components/detailed-poster-map-client";
 import {
@@ -5,8 +7,6 @@ import {
   type PosterPrefectureKey,
 } from "@/features/map-poster/constants/poster-prefectures";
 import { getArchivedPosterBoardStats } from "@/features/map-poster/services/poster-boards";
-import type { Metadata } from "next";
-import { notFound } from "next/navigation";
 
 // Election term display names
 const ELECTION_TERM_NAMES: Record<string, string> = {

--- a/src/app/map/poster/archive/[electionTerm]/page.tsx
+++ b/src/app/map/poster/archive/[electionTerm]/page.tsx
@@ -1,3 +1,7 @@
+import { Archive, ChevronRight, MapPin } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
 import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -10,10 +14,6 @@ import {
   getCompletedCount,
   getRegisteredCount,
 } from "@/features/map-poster/utils/poster-progress";
-import { Archive, ChevronRight, MapPin } from "lucide-react";
-import type { Metadata } from "next";
-import Link from "next/link";
-import { notFound } from "next/navigation";
 
 // Election term display names
 const ELECTION_TERM_NAMES: Record<string, string> = {

--- a/src/app/map/poster/page.tsx
+++ b/src/app/map/poster/page.tsx
@@ -1,9 +1,9 @@
+import type { Metadata } from "next";
 import PosterMapPageClientOptimized from "@/features/map-poster/components/poster-map-page-client-optimized";
 import {
   getPosterBoardSummaryByDistrict,
   getPosterBoardTotals,
 } from "@/features/map-poster/services/poster-boards";
-import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "ポスター掲示板マップ",

--- a/src/app/map/posting/[slug]/page.tsx
+++ b/src/app/map/posting/[slug]/page.tsx
@@ -1,10 +1,10 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
 import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import PostingPageClient from "@/features/map-posting/components/posting-page";
 import { getEventBySlug } from "@/features/map-posting/services/posting-events.server";
 import { getUser } from "@/features/user-profile/services/profile";
 import { isAdmin, isPostingAdmin } from "@/lib/utils/admin";
-import type { Metadata } from "next";
-import { notFound, redirect } from "next/navigation";
 
 interface PostingEventPageProps {
   params: Promise<{ slug: string }>;

--- a/src/app/map/posting/page.tsx
+++ b/src/app/map/posting/page.tsx
@@ -1,10 +1,10 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
 import {
   getActiveEvent,
   getAllEvents,
 } from "@/features/map-posting/services/posting-events.server";
 import { getUser } from "@/features/user-profile/services/profile";
-import type { Metadata } from "next";
-import { notFound, redirect } from "next/navigation";
 
 export const metadata: Metadata = {
   title: "チームみらいポスティングマップ",

--- a/src/app/missions/[slug]/page.tsx
+++ b/src/app/missions/[slug]/page.tsx
@@ -1,3 +1,8 @@
+import { LogIn, Shield } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -30,11 +35,6 @@ import {
   defaultUrl,
   notoSansJP,
 } from "@/lib/utils/metadata";
-import { LogIn, Shield } from "lucide-react";
-import type { Metadata } from "next";
-import Link from "next/link";
-import { redirect } from "next/navigation";
-import { Suspense } from "react";
 
 type Props = {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;

--- a/src/app/seasons/[slug]/ranking/mission/page.tsx
+++ b/src/app/seasons/[slug]/ranking/mission/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { getMissionsForRanking } from "@/features/missions/services/missions";
 import { CurrentUserCardMission } from "@/features/ranking/components/current-user-card-mission";
@@ -11,8 +13,6 @@ import {
 } from "@/features/ranking/services/get-missions-ranking";
 import { getUser } from "@/features/user-profile/services/profile";
 import { getSeasonBySlug } from "@/lib/services/seasons";
-import type { Metadata } from "next";
-import { notFound } from "next/navigation";
 
 interface Props {
   params: Promise<{

--- a/src/app/seasons/[slug]/ranking/page.tsx
+++ b/src/app/seasons/[slug]/ranking/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { CurrentUserCard } from "@/features/ranking/components/current-user-card";
 import {
@@ -10,8 +12,6 @@ import { SeasonRankingHeader } from "@/features/ranking/components/season-rankin
 import { getUserPeriodRanking } from "@/features/ranking/services/get-ranking";
 import { getUser } from "@/features/user-profile/services/profile";
 import { getSeasonBySlug } from "@/lib/services/seasons";
-import type { Metadata } from "next";
-import { notFound } from "next/navigation";
 
 interface Props {
   params: Promise<{

--- a/src/app/seasons/[slug]/ranking/prefecture/page.tsx
+++ b/src/app/seasons/[slug]/ranking/prefecture/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { PageBreadcrumb } from "@/components/common/page-breadcrumb";
 import { CurrentUserCardPrefecture } from "@/features/ranking/components/current-user-card-prefecture";
 import { PrefectureSelect } from "@/features/ranking/components/prefecture-select";
@@ -8,8 +10,6 @@ import { getUserPrefecturesRanking } from "@/features/ranking/services/get-prefe
 import { getProfile, getUser } from "@/features/user-profile/services/profile";
 import { PREFECTURES } from "@/lib/constants/prefectures";
 import { getSeasonBySlug } from "@/lib/services/seasons";
-import type { Metadata } from "next";
-import { notFound } from "next/navigation";
 
 interface Props {
   params: Promise<{

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { ActionPeriodFilter } from "@/features/action-stats/components/action-period-filter";
 import { ActionStatsChart } from "@/features/action-stats/components/action-stats-chart";
 import { ActionStatsSummary } from "@/features/action-stats/components/action-stats-summary";
@@ -10,11 +11,10 @@ import {
   getMissionActionRanking,
 } from "@/features/action-stats/services/action-stats-service";
 import {
-  type PeriodType,
   getPeriodEndDate,
   getPeriodStartDate,
+  type PeriodType,
 } from "@/features/action-stats/types";
-import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "アクション数ダッシュボード | Action Board",

--- a/src/app/tiktok_stats/page.tsx
+++ b/src/app/tiktok_stats/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { TikTokOverallChart } from "@/features/tiktok-stats/components/tiktok-overall-chart";
 import { TikTokPeriodFilter } from "@/features/tiktok-stats/components/tiktok-period-filter";
 import { TikTokSortToggle } from "@/features/tiktok-stats/components/tiktok-sort-toggle";
@@ -12,12 +13,11 @@ import {
   getVideoCountByDate,
 } from "@/features/tiktok-stats/services/tiktok-stats-service";
 import {
-  type PeriodType,
-  type SortType,
   getPeriodEndDate,
   getPeriodStartDate,
+  type PeriodType,
+  type SortType,
 } from "@/features/tiktok-stats/types";
-import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "TikTok動画ダッシュボード | Action Board",

--- a/src/app/youtube_stats/page.tsx
+++ b/src/app/youtube_stats/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { YouTubeOverallChart } from "@/features/youtube-stats/components/youtube-overall-chart";
 import { YouTubePeriodFilter } from "@/features/youtube-stats/components/youtube-period-filter";
 import { YouTubeSortToggle } from "@/features/youtube-stats/components/youtube-sort-toggle";
@@ -12,12 +13,11 @@ import {
   getYouTubeVideosWithStats,
 } from "@/features/youtube-stats/services/youtube-stats-service";
 import {
-  type PeriodType,
-  type SortType,
   getPeriodEndDate,
   getPeriodStartDate,
+  type PeriodType,
+  type SortType,
 } from "@/features/youtube-stats/types";
-import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "YouTube動画ダッシュボード | Action Board",

--- a/src/components/common/env-var-warning.tsx
+++ b/src/components/common/env-var-warning.tsx
@@ -1,6 +1,6 @@
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import Link from "next/link";
 
 export function EnvVarWarning() {
   return (

--- a/src/components/common/form-message.tsx
+++ b/src/components/common/form-message.tsx
@@ -1,5 +1,5 @@
-import { EXTERNAL_LINKS } from "@/lib/constants/external-links";
 import clsx from "clsx";
+import { EXTERNAL_LINKS } from "@/lib/constants/external-links";
 
 export type MessageType =
   | "success"
@@ -69,7 +69,10 @@ const getMessageContent = (type: MessageType) => {
 export function FormMessage({
   className,
   message,
-}: { className?: string; message: Message }) {
+}: {
+  className?: string;
+  message: Message;
+}) {
   if (!message) return null;
 
   // Type-based message handling

--- a/src/components/common/header-auth.tsx
+++ b/src/components/common/header-auth.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { signOutAction } from "@/app/actions";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,7 +12,6 @@ import {
 import { OnboardingButton } from "@/features/onboarding/components/onboarding-button";
 import MyAvatar from "@/features/user-profile/components/my-avatar";
 import { getUser } from "@/features/user-profile/services/profile";
-import Link from "next/link";
 
 export default async function AuthButton() {
   const user = await getUser();

--- a/src/components/common/navbar.tsx
+++ b/src/components/common/navbar.tsx
@@ -1,3 +1,6 @@
+import { Menu } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
 import HeaderAuth from "@/components/common/header-auth";
 import {
   DropdownMenu,
@@ -9,9 +12,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { OnboardingButton } from "@/features/onboarding/components/onboarding-button";
 import { getUser } from "@/features/user-profile/services/profile";
-import { Menu } from "lucide-react";
-import Image from "next/image";
-import Link from "next/link";
 
 export default async function Navbar() {
   const user = await getUser();

--- a/src/components/common/page-breadcrumb.tsx
+++ b/src/components/common/page-breadcrumb.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import { Fragment } from "react";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -6,8 +8,6 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import Link from "next/link";
-import { Fragment } from "react";
 
 export interface BreadcrumbItemData {
   label: string;

--- a/src/components/common/submit-button.tsx
+++ b/src/components/common/submit-button.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import type { ComponentProps } from "react";
 import { useFormStatus } from "react-dom";
+import { Button } from "@/components/ui/button";
 
 type Props = ComponentProps<typeof Button> & {
   pendingText?: string;

--- a/src/components/footer/copyright-section.tsx
+++ b/src/components/footer/copyright-section.tsx
@@ -1,5 +1,5 @@
-import { EXTERNAL_LINKS } from "@/lib/constants/external-links";
 import Link from "next/link";
+import { EXTERNAL_LINKS } from "@/lib/constants/external-links";
 
 export function CopyrightSection() {
   return (

--- a/src/components/footer/feedback-section.tsx
+++ b/src/components/footer/feedback-section.tsx
@@ -1,5 +1,5 @@
-import { EXTERNAL_LINKS } from "@/lib/constants/external-links";
 import Link from "next/link";
+import { EXTERNAL_LINKS } from "@/lib/constants/external-links";
 
 export function FeedbackSection() {
   return (

--- a/src/components/footer/seasons-list.tsx
+++ b/src/components/footer/seasons-list.tsx
@@ -1,5 +1,5 @@
-import { getInactiveSeasons } from "@/lib/services/seasons";
 import Link from "next/link";
+import { getInactiveSeasons } from "@/lib/services/seasons";
 
 export async function SeasonsList() {
   const seasons = await getInactiveSeasons();

--- a/src/components/top/fireworks.tsx
+++ b/src/components/top/fireworks.tsx
@@ -8,14 +8,14 @@
 
 "use client";
 
-import {
-  type ContributorData,
-  getContributorNames,
-} from "@/lib/services/contributors";
 import { useCallback, useEffect, useRef, useState } from "react";
 import Particles from "react-tsparticles";
 import type { Engine } from "tsparticles-engine";
 import { loadFireworksPreset } from "tsparticles-preset-fireworks";
+import {
+  type ContributorData,
+  getContributorNames,
+} from "@/lib/services/contributors";
 
 interface FireworksProps {
   onTrigger?: () => void;
@@ -35,7 +35,7 @@ const EndCredits = ({
   const [ready, setReady] = useState(false);
 
   // contributors が確定→DOM描画→高さ測定
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: DOM描画後の高さ測定のため、contributors確定時のみ実行
   useEffect(() => {
     if (wrapperRef.current) {
       // scrollHeight: padding + 内容全体
@@ -111,7 +111,7 @@ const EndCredits = ({
         <div style={{ fontSize: "16px", lineHeight: "1.6" }}>
           {rows.map((row, idx) => (
             <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+              // biome-ignore lint/suspicious/noArrayIndexKey: 固定的なリスト表示のためインデックスを使用
               key={idx}
               style={{
                 display: "flex",
@@ -210,7 +210,7 @@ export default function Fireworks({ onTrigger }: FireworksProps) {
   );
 
   return (
-    // biome-ignore lint/a11y/useButtonType: <explanation>
+    // biome-ignore lint/a11y/useButtonType: インタラクティブボタンのためtype不要
     <button
       onClick={handleClick}
       onKeyDown={handleKeyDown}

--- a/src/components/top/hero.tsx
+++ b/src/components/top/hero.tsx
@@ -1,9 +1,9 @@
+import Image from "next/image";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { OnboardingButton } from "@/features/onboarding/components/onboarding-button";
 import Levels from "@/features/user-level/components/levels";
 import { getUser } from "@/features/user-profile/services/profile";
-import Image from "next/image";
-import Link from "next/link";
 
 export default async function Hero() {
   const user = await getUser();

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils/utils";

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import { Slot } from "@radix-ui/react-slot";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils/utils";

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -138,7 +138,6 @@ const Carousel = React.forwardRef<
           ref={ref}
           onKeyDownCapture={handleKeyDown}
           className={cn("relative", className)}
-          // biome-ignore lint/a11y/useSemanticElements: <explanation>
           role="region"
           aria-roledescription="carousel"
           {...props}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -78,7 +78,7 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 
   return (
     <style
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: チャートテーマ用CSS変数を動的生成
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as LabelPrimitive from "@radix-ui/react-label";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils/utils";

--- a/src/features/action-stats/components/action-period-filter.tsx
+++ b/src/features/action-stats/components/action-period-filter.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
 import {
   Select,
   SelectContent,
@@ -8,8 +10,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DatePicker } from "@/features/youtube-stats/components/date-picker";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo } from "react";
 import { PERIOD_OPTIONS, type PeriodType } from "../types";
 
 /** ローカルタイムゾーンで日付を YYYY-MM-DD 形式にフォーマット */

--- a/src/features/action-stats/components/action-stats-chart.tsx
+++ b/src/features/action-stats/components/action-stats-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Line, LineChart, XAxis, YAxis } from "recharts";
 import { Card } from "@/components/ui/card";
 import {
   type ChartConfig,
@@ -7,7 +8,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { Line, LineChart, XAxis, YAxis } from "recharts";
 import type { DailyActionItem } from "../types";
 
 interface ActionStatsChartProps {

--- a/src/features/action-stats/components/action-stats-summary.tsx
+++ b/src/features/action-stats/components/action-stats-summary.tsx
@@ -1,5 +1,5 @@
-import { Card } from "@/components/ui/card";
 import { TrendingUp, Users, Zap } from "lucide-react";
+import { Card } from "@/components/ui/card";
 import type { ActionStatsSummary as ActionStatsSummaryType } from "../types";
 
 interface ActionStatsSummaryProps {

--- a/src/features/action-stats/components/active-users-chart.tsx
+++ b/src/features/action-stats/components/active-users-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Line, LineChart, XAxis, YAxis } from "recharts";
 import { Card } from "@/components/ui/card";
 import {
   type ChartConfig,
@@ -7,7 +8,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { Line, LineChart, XAxis, YAxis } from "recharts";
 import type { DailyActiveUsersItem } from "../types";
 
 interface ActiveUsersChartProps {

--- a/src/features/action-stats/components/mission-ranking-list.tsx
+++ b/src/features/action-stats/components/mission-ranking-list.tsx
@@ -1,7 +1,7 @@
-import { Card } from "@/components/ui/card";
 import { EyeOff } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { Card } from "@/components/ui/card";
 import type { MissionActionRanking } from "../types";
 
 interface MissionRankingListProps {

--- a/src/features/action-stats/types/index.ts
+++ b/src/features/action-stats/types/index.ts
@@ -1,9 +1,9 @@
 // 期間フィルター型はyoutube-statsから再利用
 export type { PeriodType } from "@/features/youtube-stats/types";
 export {
-  PERIOD_OPTIONS,
   getPeriodEndDate,
   getPeriodStartDate,
+  PERIOD_OPTIONS,
 } from "@/features/youtube-stats/types";
 
 export interface ActionStatsSummary {

--- a/src/features/auth/components/email-sign-up-form.tsx
+++ b/src/features/auth/components/email-sign-up-form.tsx
@@ -1,15 +1,15 @@
 "use client";
 
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useActionState, useCallback, useEffect, useState } from "react";
+import { useFormStatus } from "react-dom";
 import { emailSignUpActionWithState } from "@/app/actions";
 import { FormMessage, type Message } from "@/components/common/form-message";
 import { SubmitButton } from "@/components/common/submit-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { passwordAlertlessSchema } from "@/lib/validation/auth";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useActionState, useCallback, useEffect, useState } from "react";
-import { useFormStatus } from "react-dom";
 
 interface EmailSignUpFormProps {
   searchParams: Message;

--- a/src/features/auth/components/sign-in-form.tsx
+++ b/src/features/auth/components/sign-in-form.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useActionState, useEffect, useState } from "react";
 import { signInActionWithState } from "@/app/actions";
 import { FormMessage } from "@/components/common/form-message";
 import { SubmitButton } from "@/components/common/submit-button";
@@ -7,9 +10,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { signInWithLine } from "@/features/auth/services/line-auth";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useActionState, useEffect, useState } from "react";
 
 interface SignInFormProps {
   returnUrl?: string;
@@ -31,7 +31,7 @@ export default function SignInForm({ returnUrl }: SignInFormProps) {
     try {
       setIsLineLoading(true);
       await signInWithLine(returnUrl);
-    } catch (error) {
+    } catch (_error) {
       setIsLineLoading(false);
     }
   };

--- a/src/features/auth/components/two-step-sign-up-form.tsx
+++ b/src/features/auth/components/two-step-sign-up-form.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import { CollapsibleInfo } from "@/components/common/collapsible-info";
 import { FormMessage, type Message } from "@/components/common/form-message";
 import { Button } from "@/components/ui/button";
@@ -15,9 +18,6 @@ import {
 } from "@/components/ui/select";
 import { signInWithLine } from "@/features/auth/services/line-auth";
 import { calculateAge } from "@/lib/utils/utils";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
 
 interface TwoStepSignUpFormProps {
   searchParams: Message;

--- a/src/features/map-poster/actions/poster-boards.ts
+++ b/src/features/map-poster/actions/poster-boards.ts
@@ -1,9 +1,9 @@
 "use server";
 
+import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/client";
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import type { Database } from "@/lib/types/supabase";
-import { cookies } from "next/headers";
 
 type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
 type PrefectureName = NonNullable<

--- a/src/features/map-poster/components/poster-board-filter.tsx
+++ b/src/features/map-poster/components/poster-board-filter.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { ChevronDown, ChevronUp, Filter } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import type { Database } from "@/lib/types/supabase";
-import { ChevronDown, ChevronUp, Filter } from "lucide-react";
-import { useEffect, useState } from "react";
 import type {
   FilterStatus,
   PosterBoardFilterState,

--- a/src/features/map-poster/components/poster-map-page-client-optimized.tsx
+++ b/src/features/map-poster/components/poster-map-page-client-optimized.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChevronRight, MapPin } from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { statusConfig } from "../config/status-config";
 import { JP_TO_EN_DISTRICT } from "../constants/poster-district-shugin-2026";
 import type { BoardStatus, PosterBoardTotal } from "../types/poster-types";

--- a/src/features/map-poster/components/poster-map-with-cluster.tsx
+++ b/src/features/map-poster/components/poster-map-with-cluster.tsx
@@ -8,12 +8,12 @@ import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import "../styles/poster-map.css";
 import "../styles/poster-map-filter.css";
+import { Expand, Minimize } from "lucide-react";
 import { MAX_ZOOM } from "@/lib/constants/mission-config";
 import type { Database } from "@/lib/types/supabase";
-import { Expand, Minimize } from "lucide-react";
 import {
-  type PosterPrefectureKey,
   getPrefectureDefaultZoom,
+  type PosterPrefectureKey,
 } from "../constants/poster-prefectures";
 import { usePosterBoardFilterOptimized } from "../hooks/use-poster-board-filter-optimized";
 import { getCurrentUserId } from "../services/poster-boards";
@@ -288,7 +288,7 @@ export default function PosterMapWithCluster({
         if (isMounted && !userIdFromProps) {
           setCurrentUserId(userId ?? undefined);
         }
-      } catch (error) {
+      } catch (_error) {
         // エラーは静かに処理
       }
     };

--- a/src/features/map-poster/components/poster-map.tsx
+++ b/src/features/map-poster/components/poster-map.tsx
@@ -5,11 +5,11 @@ import { useEffect, useRef, useState } from "react";
 import "leaflet/dist/leaflet.css";
 import "../styles/poster-map.css";
 import "../styles/poster-map-filter.css";
-import type { Database } from "@/lib/types/supabase";
 import { Expand, Minimize } from "lucide-react";
+import type { Database } from "@/lib/types/supabase";
 import {
-  type PosterPrefectureKey,
   getPrefectureDefaultZoom,
+  type PosterPrefectureKey,
 } from "../constants/poster-prefectures";
 import { usePosterBoardFilter } from "../hooks/use-poster-board-filter";
 import { getCurrentUserId } from "../services/poster-boards";
@@ -90,7 +90,7 @@ export default function PosterMap({
         if (isMounted) {
           setCurrentUserId(userId ?? undefined);
         }
-      } catch (error) {
+      } catch (_error) {
         // エラーは静かに処理
       }
     };

--- a/src/features/map-poster/hooks/use-poster-board-filter-optimized.ts
+++ b/src/features/map-poster/hooks/use-poster-board-filter-optimized.ts
@@ -1,4 +1,3 @@
-import type { Database } from "@/lib/types/supabase";
 import {
   useCallback,
   useEffect,
@@ -7,6 +6,7 @@ import {
   useState,
   useTransition,
 } from "react";
+import type { Database } from "@/lib/types/supabase";
 
 type PosterBoard = Database["public"]["Tables"]["poster_boards"]["Row"];
 type BoardStatus = Database["public"]["Enums"]["poster_board_status"];

--- a/src/features/map-poster/hooks/use-poster-board-filter.ts
+++ b/src/features/map-poster/hooks/use-poster-board-filter.ts
@@ -1,5 +1,5 @@
-import type { Database } from "@/lib/types/supabase";
 import { useCallback, useMemo, useState } from "react";
+import type { Database } from "@/lib/types/supabase";
 
 type PosterBoard = Database["public"]["Tables"]["poster_boards"]["Row"];
 type BoardStatus = Database["public"]["Enums"]["poster_board_status"];

--- a/src/features/map-poster/styles/poster-map-filter.css
+++ b/src/features/map-poster/styles/poster-map-filter.css
@@ -39,7 +39,9 @@
 
 /* Smooth transitions */
 .filter-panel-transition {
-  transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  transition:
+    max-height 0.3s ease-in-out,
+    opacity 0.3s ease-in-out;
 }
 
 /* Transition for mobile filter expansion */

--- a/src/features/map-posting/components/geoman-map.test.tsx
+++ b/src/features/map-posting/components/geoman-map.test.tsx
@@ -1,6 +1,6 @@
-import { CONTENT_HEIGHT } from "@/lib/constants/layout";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
+import { CONTENT_HEIGHT } from "@/lib/constants/layout";
 import GeomanMap from "./geoman-map";
 
 const originalError = console.error;
@@ -142,7 +142,7 @@ describe("GeomanMap", () => {
         const initializeMap = async () => {
           try {
             throw new Error("Failed to load Leaflet");
-          } catch (error) {
+          } catch (_error) {
             act(() => {
               setError("地図ライブラリの読み込みに失敗しました");
               setIsLoading(false);
@@ -214,7 +214,7 @@ describe("GeomanMap", () => {
           try {
             await Promise.resolve(); // Leaflet loads fine
             throw new Error("Failed to load Geoman");
-          } catch (error) {
+          } catch (_error) {
             act(() => {
               setError("地図編集ツールの読み込みに失敗しました");
               setIsLoading(false);

--- a/src/features/map-posting/components/geoman-map.tsx
+++ b/src/features/map-posting/components/geoman-map.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { CONTENT_HEIGHT } from "@/lib/constants/layout";
 import type { Map as LeafletMap } from "leaflet";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { CONTENT_HEIGHT } from "@/lib/constants/layout";
 
 interface GeomanMapProps {
   onMapReady?: (map: LeafletMap) => void;

--- a/src/features/map-posting/components/posting-control-panel.tsx
+++ b/src/features/map-posting/components/posting-control-panel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { HEADER_HEIGHT } from "@/lib/constants/layout";
 import { ChevronDown } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { type PostingEvent, getAllEvents } from "../services/posting-events";
+import { HEADER_HEIGHT } from "@/lib/constants/layout";
+import { getAllEvents, type PostingEvent } from "../services/posting-events";
 
 interface PostingControlPanelProps {
   eventId: string;

--- a/src/features/map-posting/components/posting-page.tsx
+++ b/src/features/map-posting/components/posting-page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { HEADER_HEIGHT } from "@/lib/constants/layout";
-import type { Json } from "@/lib/types/supabase";
-import { logger } from "@/lib/utils/logger";
 import type { Layer, Map as LeafletMap, Marker } from "leaflet";
 import dynamic from "next/dynamic";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { HEADER_HEIGHT } from "@/lib/constants/layout";
+import type { Json } from "@/lib/types/supabase";
+import { logger } from "@/lib/utils/logger";
 import {
   addButtonLabel,
   geomanJaLang,
@@ -14,8 +14,8 @@ import {
   postingGeomanControls,
 } from "../config/geoman-config";
 import {
-  type PostingShapeStatus,
   getClusterThresholdForArea,
+  type PostingShapeStatus,
   postingStatusConfig,
   postingStatusLabels,
 } from "../config/status-config";
@@ -26,11 +26,11 @@ import {
   saveShape as saveMapShape,
   updateShape as updateMapShape,
 } from "../services/posting-shapes";
-import type { MarkerWithShape } from "../types/posting-types";
 import type {
   GeomanEvent,
   LeafletWindow,
   MapShape as MapShapeData,
+  MarkerWithShape,
   PolygonProperties,
   PostingPageClientProps,
   TextCoordinates,
@@ -58,7 +58,7 @@ export default function PostingPageClient({
   isEventActive,
 }: PostingPageClientProps) {
   const [mapInstance, setMapInstance] = useState<LeafletMap | null>(null);
-  const [showText, setShowText] = useState(true);
+  const [showText, _setShowText] = useState(true);
   const textLayersRef = useRef<Set<Layer>>(new Set());
   const showTextRef = useRef(showText);
   const autoSave = true;
@@ -85,7 +85,7 @@ export default function PostingPageClient({
     Array<{ id: string; area_m2: number | null; user_id: string | null }>
   >([]);
   // Track current zoom level for display mode
-  const [isClusterMode, setIsClusterMode] = useState(true);
+  const [isClusterMode, _setIsClusterMode] = useState(true);
   // Ref to track isClusterMode for use in event handlers
   const isClusterModeRef = useRef(isClusterMode);
   // Current location hook
@@ -674,6 +674,7 @@ export default function PostingPageClient({
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapInstance, eventId, userId, isEventActive]);
 
   const textMarkerStyles = `
@@ -689,10 +690,10 @@ export default function PostingPageClient({
   `;
 
   // 図形削除の共通処理
-  const handleDeleteShape = async (
+  async function handleDeleteShape(
     shapeId: string,
     options?: { layer?: Layer; removeFromMap?: boolean },
-  ) => {
+  ): Promise<void> {
     await deleteMapShape(shapeId);
 
     // モーダルからの削除の場合はマップからレイヤーを削除
@@ -717,7 +718,7 @@ export default function PostingPageClient({
     // Clean up tracking refs
     shapesDataRef.current.delete(shapeId);
     polygonLayersRef.current.delete(shapeId);
-  };
+  }
 
   function attachTextEvents(layer: Layer) {
     if (!layer?.pm) return;
@@ -740,7 +741,7 @@ export default function PostingPageClient({
     });
   }
 
-  const extractShapeData = (layer: Layer): MapShapeData => {
+  function extractShapeData(layer: Layer): MapShapeData {
     const shapeName = layer.pm?.getShape ? layer.pm.getShape() : undefined;
 
     if (shapeName === "Text") {
@@ -768,9 +769,9 @@ export default function PostingPageClient({
       user_id: userId,
       status: "planned", // Default status for new shapes
     };
-  };
+  }
 
-  const saveOrUpdateLayer = async (layer: Layer) => {
+  async function saveOrUpdateLayer(layer: Layer) {
     const shapeData = extractShapeData(layer);
     const sid = getShapeId(layer);
     if (sid) {
@@ -778,14 +779,14 @@ export default function PostingPageClient({
         coordinates: shapeData.coordinates,
         properties: shapeData.properties,
       });
-    } else {
-      const saved = await saveMapShape(shapeData);
-      propagateShapeId(layer, saved.id);
-      return saved;
+      return undefined;
     }
-  };
+    const saved = await saveMapShape(shapeData);
+    propagateShapeId(layer, saved.id);
+    return saved;
+  }
 
-  function propagateShapeId(layer: Layer, id: string) {
+  function propagateShapeId(layer: Layer, id: string): void {
     if (!layer) return;
     layer._shapeId = id;
     if (layer.options) (layer.options as Record<string, unknown>).shapeId = id;
@@ -804,7 +805,12 @@ export default function PostingPageClient({
     attachPersistenceEvents(layer);
   }
 
-  function attachPersistenceEvents(layer: Layer) {
+  async function onLayerChange(e: GeomanEvent): Promise<void> {
+    const layer = e.layer || e.target;
+    if (layer) await saveOrUpdateLayer(layer);
+  }
+
+  function attachPersistenceEvents(layer: Layer): void {
     if (!layer?.pm) return;
 
     layer.off("pm:change", onLayerChange);
@@ -813,11 +819,6 @@ export default function PostingPageClient({
     layer.on("pm:change", onLayerChange);
     layer.on("pm:dragend", onLayerChange);
   }
-
-  const onLayerChange = async (e: GeomanEvent) => {
-    const layer = e.layer || e.target;
-    if (layer) await saveOrUpdateLayer(layer);
-  };
 
   // Handle polygon click to open status dialog
   const handlePolygonClick = useCallback(

--- a/src/features/map-posting/components/shape-status-dialog.tsx
+++ b/src/features/map-posting/components/shape-status-dialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,8 +21,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
 import {
   type PostingShapeStatus,
   postingStatusBadgeColors,

--- a/src/features/map-posting/services/posting-events.server.ts
+++ b/src/features/map-posting/services/posting-events.server.ts
@@ -1,7 +1,7 @@
 import "server-only";
+import { cache } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { Tables } from "@/lib/types/supabase";
-import { cache } from "react";
 
 export type PostingEvent = Tables<"posting_events">;
 

--- a/src/features/map-posting/types/posting-types.ts
+++ b/src/features/map-posting/types/posting-types.ts
@@ -1,5 +1,5 @@
-import type { Json } from "@/lib/types/supabase";
 import type { Layer, Marker } from "leaflet";
+import type { Json } from "@/lib/types/supabase";
 import type { PostingShapeStatus } from "../config/status-config";
 
 // === Cluster/Marker Types ===

--- a/src/features/map-posting/utils/polygon-utils.ts
+++ b/src/features/map-posting/utils/polygon-utils.ts
@@ -1,6 +1,6 @@
-import type { Json } from "@/lib/types/supabase";
 import { area } from "@turf/area";
 import { polygon } from "@turf/helpers";
+import type { Json } from "@/lib/types/supabase";
 
 interface GeoJSONPolygon {
   type: "Polygon";

--- a/src/features/metrics/components/achievement-metric.tsx
+++ b/src/features/metrics/components/achievement-metric.tsx
@@ -1,6 +1,6 @@
+import Link from "next/link";
 import type { AchievementData } from "@/features/metrics/types/metrics-types";
 import { formatNumber } from "@/lib/utils/metrics-formatter";
-import Link from "next/link";
 
 interface AchievementMetricProps {
   data: AchievementData | null;

--- a/src/features/metrics/components/donation-metric.tsx
+++ b/src/features/metrics/components/donation-metric.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import {
   Popover,
   PopoverContent,
@@ -8,7 +9,6 @@ import {
 import type { DonationData } from "@/features/metrics/types/metrics-types";
 import { EXTERNAL_LINKS } from "@/lib/constants/external-links";
 import { formatAmount } from "@/lib/utils/metrics-formatter";
-import { useEffect, useState } from "react";
 
 interface DonationMetricProps {
   data: DonationData | null;

--- a/src/features/metrics/components/metrics-with-suspense.tsx
+++ b/src/features/metrics/components/metrics-with-suspense.tsx
@@ -1,5 +1,5 @@
-import { Skeleton } from "@/components/ui/skeleton";
 import { Suspense } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { MetricsErrorBoundary } from "./metrics-error-boundary";
 import { Metrics } from "./metrics-index";
 

--- a/src/features/metrics/components/video-metric.tsx
+++ b/src/features/metrics/components/video-metric.tsx
@@ -1,5 +1,5 @@
-import { formatNumber } from "@/lib/utils/metrics-formatter";
 import Link from "next/link";
+import { formatNumber } from "@/lib/utils/metrics-formatter";
 
 interface VideoMetricProps {
   totalViews: number;

--- a/src/features/metrics/components/youtube-metric.tsx
+++ b/src/features/metrics/components/youtube-metric.tsx
@@ -1,5 +1,5 @@
-import { formatNumber } from "@/lib/utils/metrics-formatter";
 import Link from "next/link";
+import { formatNumber } from "@/lib/utils/metrics-formatter";
 
 interface YouTubeMetricProps {
   totalViews: number;

--- a/src/features/metrics/services/get-metrics.test.ts
+++ b/src/features/metrics/services/get-metrics.test.ts
@@ -11,6 +11,7 @@ import type {
   SupporterData,
 } from "@/features/metrics/types/metrics-types";
 import { createClient } from "@/lib/supabase/client";
+
 jest.mock("@/lib/supabase/client");
 jest.mock("@/features/metrics/services/get-metrics", () =>
   jest.requireActual("@/features/metrics/services/get-metrics"),
@@ -35,7 +36,7 @@ const setupMockSupabaseClient = (
     from: () => ({
       select: () => ({
         count: dataset.length,
-        gte: (columnName: string, thresholdISO: string) => {
+        gte: (_columnName: string, thresholdISO: string) => {
           capturedGteIsoRef.value = thresholdISO;
           const count = dataset.filter(
             (data) => new Date(data.created_at) >= new Date(thresholdISO),

--- a/src/features/mission-detail/actions/actions.ts
+++ b/src/features/mission-detail/actions/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { z } from "zod";
 import { VALID_JP_PREFECTURES } from "@/features/map-poster/constants/poster-prefectures";
 import {
   getUserXpBonus,
@@ -8,26 +9,24 @@ import {
 } from "@/features/user-level/services/level";
 import type { UserLevel } from "@/features/user-level/types/level-types";
 import { calculateMissionXp } from "@/features/user-level/utils/level-calculator";
-import { getCurrentSeasonId } from "@/lib/services/seasons";
-import { createAdminClient } from "@/lib/supabase/adminClient";
-import { createClient } from "@/lib/supabase/client";
-import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
-
 import {
   MAX_POSTER_COUNT,
   MAX_POSTING_COUNT,
   POSTER_POINTS_PER_UNIT,
   POSTING_POINTS_PER_UNIT,
 } from "@/lib/constants/mission-config";
+import { getCurrentSeasonId } from "@/lib/services/seasons";
+import { createAdminClient } from "@/lib/supabase/adminClient";
+import { createClient } from "@/lib/supabase/client";
+import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
 import type { Database, TablesInsert } from "@/lib/types/supabase";
-import { z } from "zod";
 
 // Quiz関連のServer ActionsとQuizQuestion型をインポート
 import {
-  type QuizQuestion,
   checkQuizAnswersAction,
   getMissionQuizCategoryAction,
   getQuizQuestionsAction,
+  type QuizQuestion,
 } from "./quiz-actions";
 
 // Quiz関連のServer Actionsを再エクスポート

--- a/src/features/mission-detail/components/artifact-display.tsx
+++ b/src/features/mission-detail/components/artifact-display.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type { MissionArtifact } from "@/features/mission-detail/types/detail-types";
 import Link from "next/link";
 import type React from "react";
+import type { MissionArtifact } from "@/features/mission-detail/types/detail-types";
 
 interface ArtifactDisplayProps {
   artifact: MissionArtifact;

--- a/src/features/mission-detail/components/cancel-submission-dialog.tsx
+++ b/src/features/mission-detail/components/cancel-submission-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type React from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,7 +10,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import type React from "react";
 
 interface CancelSubmissionDialogProps {
   isOpen: boolean;

--- a/src/features/mission-detail/components/copy-referral-button.tsx
+++ b/src/features/mission-detail/components/copy-referral-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   referralUrl: string;

--- a/src/features/mission-detail/components/main-link-button.tsx
+++ b/src/features/mission-detail/components/main-link-button.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import type { Tables } from "@/lib/types/supabase";
 import { ExternalLink } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import type { Tables } from "@/lib/types/supabase";
 
 interface MainLinkButtonProps {
   mission: Tables<"missions">;

--- a/src/features/mission-detail/components/mission-form-wrapper.tsx
+++ b/src/features/mission-detail/components/mission-form-wrapper.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import type { User } from "@supabase/supabase-js";
+import { AlertCircle } from "lucide-react";
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
 import { SubmitButton } from "@/components/common/submit-button";
 import { Button } from "@/components/ui/button";
 import { achieveMissionAction } from "@/features/mission-detail/actions/actions";
@@ -12,11 +17,6 @@ import { useQuizMission } from "@/features/missions/hooks/use-quiz-mission";
 import { XpProgressToastContent } from "@/features/user-level/components/xp-progress-toast-content";
 import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
 import type { Tables } from "@/lib/types/supabase";
-import type { User } from "@supabase/supabase-js";
-import { AlertCircle } from "lucide-react";
-import Link from "next/link";
-import { useRef, useState } from "react";
-import { toast } from "sonner";
 
 type Props = {
   mission: Tables<"missions">;

--- a/src/features/mission-detail/components/mission-with-submission-history.tsx
+++ b/src/features/mission-detail/components/mission-with-submission-history.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { User } from "@supabase/supabase-js";
+import { useState } from "react";
 import { CopyReferralButton } from "@/features/mission-detail/components/copy-referral-button";
 import { MissionFormWrapper } from "@/features/mission-detail/components/mission-form-wrapper";
 import QRCodeDisplay from "@/features/mission-detail/components/qr-code-display";
@@ -10,8 +12,6 @@ import { MissionGuidanceArrow } from "@/features/missions/components/mission-gui
 import { useMissionSubmission } from "@/features/missions/hooks/use-mission-submission";
 import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
 import type { Tables } from "@/lib/types/supabase";
-import type { User } from "@supabase/supabase-js";
-import { useState } from "react";
 import { MainLinkButton } from "./main-link-button";
 
 type Props = {

--- a/src/features/mission-detail/components/share-buttons/share-url-button.tsx
+++ b/src/features/mission-detail/components/share-buttons/share-url-button.tsx
@@ -13,7 +13,7 @@ export function ShareUrlButton({ url, className, children }: Props) {
     try {
       await navigator.clipboard.writeText(url);
       toast.success("URLをコピーしました！");
-    } catch (error) {
+    } catch (_error) {
       // フォールバック: 古いブラウザ対応
       const textArea = document.createElement("textarea");
       textArea.value = url;

--- a/src/features/mission-detail/components/submission-history.tsx
+++ b/src/features/mission-detail/components/submission-history.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import type React from "react";
+import { useState } from "react";
 import CancelSubmissionDialog from "@/features/mission-detail/components/cancel-submission-dialog";
 import SubmissionItem from "@/features/mission-detail/components/submission-item";
 import { useSubmissionCancel } from "@/features/mission-detail/hooks/use-submission-cancel";
 import type { Submission } from "@/features/mission-detail/types/component-types";
-import type React from "react";
-import { useState } from "react";
 
 interface SubmissionHistoryProps {
   submissions: Submission[];

--- a/src/features/mission-detail/components/submission-item.tsx
+++ b/src/features/mission-detail/components/submission-item.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import type React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import ArtifactDisplay from "@/features/mission-detail/components/artifact-display";
 import type { Submission } from "@/features/mission-detail/types/component-types";
 import { dateTimeFormatter } from "@/lib/utils/date-formatters";
-import type React from "react";
 
 interface SubmissionItemProps {
   submission: Submission;

--- a/src/features/mission-detail/hooks/use-submission-cancel.ts
+++ b/src/features/mission-detail/hooks/use-submission-cancel.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { cancelSubmissionAction } from "@/features/mission-detail/actions/actions";
 import { useState } from "react";
+import { cancelSubmissionAction } from "@/features/mission-detail/actions/actions";
 
 export const useSubmissionCancel = (missionId: string) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);

--- a/src/features/mission-detail/services/mission-detail.ts
+++ b/src/features/mission-detail/services/mission-detail.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import type {
   Achievement,
   MissionArtifact,
@@ -7,7 +8,6 @@ import type {
 import { groupMissionsByCategory } from "@/features/missions/utils/group-missions-by-category";
 import { createClient } from "@/lib/supabase/client";
 import type { Tables } from "@/lib/types/supabase";
-import { nanoid } from "nanoid";
 
 /**
  * UUIDv4の形式かどうかを検証する

--- a/src/features/mission-detail/types/detail-types.ts
+++ b/src/features/mission-detail/types/detail-types.ts
@@ -1,6 +1,6 @@
+import type { User } from "@supabase/supabase-js";
 import type { CategoryWithMissions } from "@/features/missions/utils/group-missions-by-category";
 import type { Tables } from "@/lib/types/supabase";
-import type { User } from "@supabase/supabase-js";
 
 export type MissionArtifact = Tables<"mission_artifacts">;
 

--- a/src/features/missions/components/artifact-form.test.tsx
+++ b/src/features/missions/components/artifact-form.test.tsx
@@ -1,6 +1,6 @@
-import type { Tables } from "@/lib/types/supabase";
 import type { User } from "@supabase/supabase-js";
 import { render, screen } from "@testing-library/react";
+import type { Tables } from "@/lib/types/supabase";
 import { ArtifactForm } from "./artifact-form";
 
 // Mock lucide-react icons

--- a/src/features/missions/components/artifact-form.tsx
+++ b/src/features/missions/components/artifact-form.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import type { User } from "@supabase/supabase-js";
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { ARTIFACT_TYPES, getArtifactConfig } from "@/lib/types/artifact-types";
 import type { Tables } from "@/lib/types/supabase";
-import type { User } from "@supabase/supabase-js";
-import { useState } from "react";
 import { PosterForm } from "./poster-form";
 import { PostingForm } from "./posting-form";
 import { YouTubeCommentForm } from "./youtube-comment-form";
@@ -33,10 +33,12 @@ export function ArtifactForm({
   disabled,
   submittedArtifactImagePath,
 }: ArtifactFormProps) {
-  const [artifactImagePath, setArtifactImagePath] = useState<
+  const [_artifactImagePath, _setArtifactImagePath] = useState<
     string | undefined
   >(undefined);
-  const [geolocation, setGeolocation] = useState<GeolocationData | null>(null);
+  const [_geolocation, _setGeolocation] = useState<GeolocationData | null>(
+    null,
+  );
 
   const artifactConfig = mission
     ? getArtifactConfig(mission.required_artifact_type)

--- a/src/features/missions/components/difficulty-badge.tsx
+++ b/src/features/missions/components/difficulty-badge.tsx
@@ -12,7 +12,7 @@ export function DifficultyBadge({
   showLabel = true,
   className,
 }: DifficultyBadgeProps) {
-  const getDifficultyStyles = (difficulty: number) => {
+  const getDifficultyStyles = (_difficulty: number) => {
     return "text-gray-700 border-gray-400 hover:bg-gray-50";
   };
 

--- a/src/features/missions/components/horizontal-scroll-container.tsx
+++ b/src/features/missions/components/horizontal-scroll-container.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { cn } from "@/lib/utils/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils/utils";
 
 interface HorizontalScrollContainerProps {
   children: React.ReactNode;

--- a/src/features/missions/components/mission-achievement-status.tsx
+++ b/src/features/missions/components/mission-achievement-status.tsx
@@ -1,5 +1,5 @@
-import { Badge } from "@/components/ui/badge";
 import { CheckIcon, CircleDashed } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 
 interface MissionAchievementStatusProps {
   hasReachedMaxAchievements: boolean;

--- a/src/features/missions/components/mission-card.test.tsx
+++ b/src/features/missions/components/mission-card.test.tsx
@@ -1,6 +1,6 @@
-import type { Tables } from "@/lib/types/supabase";
 import { render, screen } from "@testing-library/react";
 import type React from "react";
+import type { Tables } from "@/lib/types/supabase";
 import Mission from "./mission-card";
 
 jest.mock("next/link", () => {
@@ -25,7 +25,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>
@@ -33,7 +36,10 @@ jest.mock("@/components/ui/card", () => ({
   CardFooter: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card-footer">
       {children}
     </div>
@@ -41,7 +47,10 @@ jest.mock("@/components/ui/card", () => ({
   CardHeader: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card-header">
       {children}
     </div>
@@ -49,7 +58,10 @@ jest.mock("@/components/ui/card", () => ({
   CardTitle: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <h3 className={className} data-testid="card-title">
       {children}
     </h3>
@@ -60,7 +72,10 @@ jest.mock("@/features/missions/components/difficulty-badge", () => ({
   DifficultyBadge: ({
     difficulty,
     className,
-  }: { difficulty: number; className?: string }) => (
+  }: {
+    difficulty: number;
+    className?: string;
+  }) => (
     <span className={className} data-testid="difficulty-badge">
       難易度{difficulty}
     </span>
@@ -72,7 +87,11 @@ jest.mock("@/components/ui/button", () => ({
     children,
     className,
     variant,
-  }: { children: React.ReactNode; className?: string; variant?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    variant?: string;
+  }) => (
     <button type="button" className={className} data-testid="button">
       {children}
     </button>
@@ -84,9 +103,11 @@ jest.mock("@/features/missions/components/mission-icon", () => ({
     src,
     alt,
     size,
-  }: { src: string; alt: string; size: string }) => (
-    <img src={src} alt={alt} data-testid="mission-icon" />
-  ),
+  }: {
+    src: string;
+    alt: string;
+    size: string;
+  }) => <img src={src} alt={alt} data-testid="mission-icon" />,
 }));
 
 jest.mock("@/features/missions/components/mission-achievement-status", () => {

--- a/src/features/missions/components/mission-card.tsx
+++ b/src/features/missions/components/mission-card.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import clsx from "clsx";
+import { motion } from "framer-motion";
+import { UsersRound } from "lucide-react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { MissionIcon } from "@/features/missions/components/mission-icon";
@@ -9,10 +13,6 @@ import {
   POSTING_POINTS_PER_UNIT,
 } from "@/lib/constants/mission-config";
 import type { Tables } from "@/lib/types/supabase";
-import clsx from "clsx";
-import { motion } from "framer-motion";
-import { UsersRound } from "lucide-react";
-import Link from "next/link";
 import MissionAchievementStatus from "./mission-achievement-status";
 
 interface MissionProps {

--- a/src/features/missions/components/mission-details.test.tsx
+++ b/src/features/missions/components/mission-details.test.tsx
@@ -1,5 +1,5 @@
-import type { Tables } from "@/lib/types/supabase";
 import { render, screen } from "@testing-library/react";
+import type { Tables } from "@/lib/types/supabase";
 import { MissionDetails } from "./mission-details";
 
 jest.mock(
@@ -7,7 +7,9 @@ jest.mock(
   () => ({
     YouTubeSubscribeButton: function MockYouTubeSubscribeButton({
       channelId,
-    }: { channelId: string }) {
+    }: {
+      channelId: string;
+    }) {
       return (
         <div data-testid="youtube-button">YouTube Button: {channelId}</div>
       );

--- a/src/features/missions/components/mission-list.test.tsx
+++ b/src/features/missions/components/mission-list.test.tsx
@@ -19,7 +19,7 @@ jest.mock("@/features/missions/components/mission-card", () => {
   };
 });
 
-const mockMissions = [
+const _mockMissions = [
   {
     id: "mission-1",
     title: "ミッション1",
@@ -36,13 +36,13 @@ const mockMissions = [
   },
 ];
 
-const mockAchievements = [
+const _mockAchievements = [
   { mission_id: "mission-1" },
   { mission_id: "mission-1" },
   { mission_id: "mission-2" },
 ];
 
-const mockAchievementCounts = [
+const _mockAchievementCounts = [
   { mission_id: "mission-1", achievement_count: 10 },
   { mission_id: "mission-2", achievement_count: 5 },
 ];

--- a/src/features/missions/components/missions-by-category.test.tsx
+++ b/src/features/missions/components/missions-by-category.test.tsx
@@ -19,7 +19,7 @@ jest.mock("./mission-card", () => {
   };
 });
 
-const mockMissionCategoryViewData = [
+const _mockMissionCategoryViewData = [
   {
     category_id: "category-1",
     category_title: "カテゴリ1",

--- a/src/features/missions/components/poster-form.tsx
+++ b/src/features/missions/components/poster-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,7 +14,6 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { VALID_JP_PREFECTURES } from "@/features/map-poster/constants/poster-prefectures";
-import { useState } from "react";
 
 type PosterFormProps = {
   disabled: boolean;

--- a/src/features/missions/components/quiz-component.tsx
+++ b/src/features/missions/components/quiz-component.tsx
@@ -1,13 +1,5 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { checkQuizAnswersAction } from "@/features/mission-detail/actions/actions";
-import {
-  type MissionLink,
-  getMissionLinksAction,
-} from "@/features/mission-detail/actions/quiz-actions";
 import {
   AlertCircle,
   CheckCircle,
@@ -16,6 +8,14 @@ import {
   XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { checkQuizAnswersAction } from "@/features/mission-detail/actions/actions";
+import {
+  getMissionLinksAction,
+  type MissionLink,
+} from "@/features/mission-detail/actions/quiz-actions";
 
 interface QuizQuestion {
   id: string;
@@ -69,7 +69,7 @@ export default function QuizComponent({
   category,
 }: QuizComponentProps) {
   // カテゴリーによる達成メッセージを生成する関数
-  const getAchievementMessage = (categoryName?: string) => {
+  const _getAchievementMessage = (categoryName?: string) => {
     switch (categoryName) {
       case "政策・マニフェスト":
         return "ミッション達成！政策・マニフェストマスターですね！";
@@ -436,7 +436,7 @@ export default function QuizComponent({
             </p>
           </CardHeader>
           <CardContent className="space-y-2">
-            {missionLinks.map((link, index) => (
+            {missionLinks.map((link, _index) => (
               <a
                 key={link.link}
                 href={link.link}

--- a/src/features/missions/components/youtube-comment-form.tsx
+++ b/src/features/missions/components/youtube-comment-form.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { CheckCircle, ChevronRight, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getYouTubeLinkStatusAction } from "@/features/youtube/actions/youtube-video-actions";
 import { YouTubeIcon } from "@/features/youtube/components";
 import type { YouTubeLinkStatus } from "@/features/youtube/types";
-import { CheckCircle, ChevronRight, Loader2 } from "lucide-react";
-import Link from "next/link";
-import { useEffect, useState } from "react";
 
 // 手動入力セクション
 function ManualInputSection({ disabled }: { disabled: boolean }) {

--- a/src/features/missions/components/youtube-form.tsx
+++ b/src/features/missions/components/youtube-form.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { CheckCircle, ChevronRight, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getYouTubeLinkStatusAction } from "@/features/youtube/actions/youtube-video-actions";
 import { YouTubeIcon } from "@/features/youtube/components";
 import type { YouTubeLinkStatus } from "@/features/youtube/types";
-import { CheckCircle, ChevronRight, Loader2 } from "lucide-react";
-import Link from "next/link";
-import { useEffect, useState } from "react";
 
 // 手動入力セクション
 function ManualInputSection({ disabled }: { disabled: boolean }) {

--- a/src/features/missions/hooks/use-mission-submission.ts
+++ b/src/features/missions/hooks/use-mission-submission.ts
@@ -1,6 +1,6 @@
 "use client";
-import type { Tables } from "@/lib/types/supabase";
 import { useMemo } from "react";
+import type { Tables } from "@/lib/types/supabase";
 
 export function useMissionSubmission(
   mission: Tables<"missions">,

--- a/src/features/missions/hooks/use-quiz-mission.ts
+++ b/src/features/missions/hooks/use-quiz-mission.ts
@@ -1,13 +1,13 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import {
   achieveMissionAction,
   getMissionQuizCategoryAction,
 } from "@/features/mission-detail/actions/actions";
 import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
 import type { Tables } from "@/lib/types/supabase";
-import { useEffect, useState } from "react";
-import { toast } from "sonner";
 
 // クイズ結果の型定義
 export interface QuizResults {

--- a/src/features/missions/utils/group-missions-by-category.test.ts
+++ b/src/features/missions/utils/group-missions-by-category.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "@jest/globals";
 import { groupMissionsByCategory } from "@/features/missions/utils/group-missions-by-category";
 import type { Database } from "@/lib/types/supabase";
-import { describe, expect, it } from "@jest/globals";
 
 type MissionCategoryView =
   Database["public"]["Views"]["mission_category_view"]["Row"];

--- a/src/features/onboarding/components/onboarding-button.tsx
+++ b/src/features/onboarding/components/onboarding-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { Sparkles } from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import { OnboardingModal } from "./onboarding-modal";
 
 interface OnboardingButtonProps {

--- a/src/features/onboarding/components/onboarding-character.tsx
+++ b/src/features/onboarding/components/onboarding-character.tsx
@@ -1,7 +1,7 @@
-import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 import { ChevronDown } from "lucide-react";
 import Image from "next/image";
+import { Button } from "@/components/ui/button";
 import {
   ANIMATION_DURATION,
   SCROLL_TEXT,

--- a/src/features/onboarding/components/onboarding-mission-card.tsx
+++ b/src/features/onboarding/components/onboarding-mission-card.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import clsx from "clsx";
+import { motion } from "framer-motion";
+import { UsersRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import MissionAchievementStatus from "@/features/missions/components/mission-achievement-status";
 import { MissionIcon } from "@/features/missions/components/mission-icon";
 import { calculateMissionXp } from "@/features/user-level/utils/level-calculator";
 import type { Tables } from "@/lib/types/supabase";
-import clsx from "clsx";
-import { motion } from "framer-motion";
-import { UsersRound } from "lucide-react";
 
 interface OnboardingMissionCardProps {
   mission: Omit<Tables<"missions">, "slug">;

--- a/src/features/onboarding/components/onboarding-modal.tsx
+++ b/src/features/onboarding/components/onboarding-modal.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { Dialog, DialogOverlay, DialogPortal } from "@/components/ui/dialog";
-import { cn } from "@/lib/utils/utils";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { X } from "lucide-react";
 import Image from "next/image";
-import { onboardingDialogues } from "../constants/onboarding-texts";
-
+import { Dialog, DialogOverlay, DialogPortal } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils/utils";
 import { MOCK_MISSION } from "../constants/constants";
+import { onboardingDialogues } from "../constants/onboarding-texts";
 import { useOnboardingState } from "../hooks/use-onboarding-state";
 import { OnboardingCharacter } from "./onboarding-character";
 import { OnboardingMissionDetails } from "./onboarding-mission-details";

--- a/src/features/onboarding/hooks/use-onboarding-state.ts
+++ b/src/features/onboarding/hooks/use-onboarding-state.ts
@@ -1,10 +1,10 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import type {
   UseOnboardingActions,
   UseOnboardingState,
 } from "@/features/onboarding/types/types";
-import { useEffect, useRef, useState } from "react";
 import { ANIMATION_DURATION } from "../constants/constants";
 import { onboardingDialogues } from "../constants/onboarding-texts";
 import { calculateDefaultScrollPosition } from "../utils/utils";

--- a/src/features/party-membership/components/party-badge-visibility-toggle.tsx
+++ b/src/features/party-membership/components/party-badge-visibility-toggle.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils/styles";
-import { useState, useTransition } from "react";
-import { toast } from "sonner";
 import { updateBadgeVisibility } from "../actions/update-badge-visibility";
 import { getPartyPlanConfig } from "../constants/plans";
 import type { PartyMembership, PartyPlan } from "../types";
@@ -24,7 +24,7 @@ export function PartyBadgeVisibilityToggle({
   );
   const [isPending, startTransition] = useTransition();
 
-  const planConfig = getPartyPlanConfig(membership.plan as PartyPlan);
+  const _planConfig = getPartyPlanConfig(membership.plan as PartyPlan);
 
   const handleChange = (checked: boolean | "indeterminate") => {
     if (checked === "indeterminate") {

--- a/src/features/party-membership/components/user-name-with-badge.tsx
+++ b/src/features/party-membership/components/user-name-with-badge.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useState } from "react";
 import type {
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
 } from "react";
+import { useCallback, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -15,8 +15,8 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils/styles";
 import {
-  PARTY_MEMBERSHIP_CTA_URL,
   getPartyPlanConfig,
+  PARTY_MEMBERSHIP_CTA_URL,
 } from "../constants/plans";
 import type { PartyMembership } from "../types";
 import { isPartyBadgeVisible } from "../utils";

--- a/src/features/ranking/components/base-current-user-card.test.tsx
+++ b/src/features/ranking/components/base-current-user-card.test.tsx
@@ -25,7 +25,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>
@@ -36,7 +39,10 @@ jest.mock("@/components/ui/card", () => ({
   CardTitle: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <h3 className={className} data-testid="card-title">
       {children}
     </h3>

--- a/src/features/ranking/components/base-current-user-card.tsx
+++ b/src/features/ranking/components/base-current-user-card.tsx
@@ -1,8 +1,8 @@
+import { User } from "lucide-react";
+import type React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { UserNameWithBadge } from "@/features/party-membership/components/user-name-with-badge";
 import type { PartyMembership } from "@/features/party-membership/types";
-import { User } from "lucide-react";
-import type React from "react";
 import {
   formatUserDisplayName,
   formatUserPrefecture,

--- a/src/features/ranking/components/base-ranking.test.tsx
+++ b/src/features/ranking/components/base-ranking.test.tsx
@@ -7,7 +7,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>

--- a/src/features/ranking/components/base-ranking.tsx
+++ b/src/features/ranking/components/base-ranking.tsx
@@ -1,7 +1,7 @@
-import { Card } from "@/components/ui/card";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import type React from "react";
+import { Card } from "@/components/ui/card";
 
 interface BaseRankingProps {
   title: string;

--- a/src/features/ranking/components/current-user-card-mission.test.tsx
+++ b/src/features/ranking/components/current-user-card-mission.test.tsx
@@ -59,7 +59,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>
@@ -73,7 +76,10 @@ jest.mock("@/components/ui/card", () => ({
   CardTitle: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <h2 className={className} data-testid="card-title">
       {children}
     </h2>
@@ -84,7 +90,10 @@ jest.mock("@/components/ui/badge", () => ({
   Badge: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <span className={className} data-testid="badge">
       {children}
     </span>

--- a/src/features/ranking/components/current-user-card.test.tsx
+++ b/src/features/ranking/components/current-user-card.test.tsx
@@ -40,7 +40,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>
@@ -54,7 +57,10 @@ jest.mock("@/components/ui/card", () => ({
   CardTitle: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <h2 className={className} data-testid="card-title">
       {children}
     </h2>

--- a/src/features/ranking/components/mission-select.test.tsx
+++ b/src/features/ranking/components/mission-select.test.tsx
@@ -8,7 +8,7 @@ type Mission = {
 };
 
 const mockPush = jest.fn();
-const mockSearchParams = new URLSearchParams();
+const _mockSearchParams = new URLSearchParams();
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({

--- a/src/features/ranking/components/mission-select.tsx
+++ b/src/features/ranking/components/mission-select.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import type { Tables } from "@/lib/types/supabase";
 import { ChevronDown } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+import type { Tables } from "@/lib/types/supabase";
 
 type MissionWithCategory = Tables<"missions"> & {
   mission_category_link: Array<{

--- a/src/features/ranking/components/period-toggle.tsx
+++ b/src/features/ranking/components/period-toggle.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
+import { Button } from "@/components/ui/button";
 
 export type RankingPeriod = "all" | "daily";
 

--- a/src/features/ranking/components/ranking-item.test.tsx
+++ b/src/features/ranking/components/ranking-item.test.tsx
@@ -65,7 +65,10 @@ jest.mock("@/components/ui/badge", () => ({
   Badge: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <span className={className} data-testid="badge">
       {children}
     </span>

--- a/src/features/ranking/components/ranking-item.tsx
+++ b/src/features/ranking/components/ranking-item.tsx
@@ -1,7 +1,7 @@
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 // TOPページ用のランキングコンポーネント
 import { UserNameWithBadge } from "@/features/party-membership/components/user-name-with-badge";
-import Link from "next/link";
 import type { UserMissionRanking, UserRanking } from "../types/ranking-types";
 import { getRankIcon } from "./ranking-icon";
 

--- a/src/features/ranking/components/ranking-level-badge.test.tsx
+++ b/src/features/ranking/components/ranking-level-badge.test.tsx
@@ -6,7 +6,10 @@ jest.mock("@/components/ui/badge", () => ({
   Badge: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <span className={className} data-testid="badge">
       {children}
     </span>

--- a/src/features/ranking/components/ranking-mission.test.tsx
+++ b/src/features/ranking/components/ranking-mission.test.tsx
@@ -26,7 +26,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>
@@ -85,7 +88,7 @@ const mockPostingCounts: UserPostingCount[] = [
   { user_id: "user-2", posting_count: 8 },
 ];
 
-const mockCurrentUser: UserMissionRanking = {
+const _mockCurrentUser: UserMissionRanking = {
   user_id: "current-user",
   name: "現在のユーザー",
   address_prefecture: "愛知県",

--- a/src/features/ranking/components/ranking-prefecture.test.tsx
+++ b/src/features/ranking/components/ranking-prefecture.test.tsx
@@ -19,7 +19,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>

--- a/src/features/ranking/components/ranking-section.tsx
+++ b/src/features/ranking/components/ranking-section.tsx
@@ -1,3 +1,5 @@
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
 import {
   Carousel,
   CarouselContent,
@@ -6,8 +8,6 @@ import {
   CarouselPrevious,
 } from "@/components/ui/carousel";
 import { RankingTop } from "@/features/ranking/components/ranking-top";
-import { ChevronRight } from "lucide-react";
-import Link from "next/link";
 
 export default async function RankingSection() {
   return (

--- a/src/features/ranking/components/ranking-tabs.tsx
+++ b/src/features/ranking/components/ranking-tabs.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface RankingTabsProps {
   children: React.ReactNode;

--- a/src/features/ranking/components/ranking-top.test.tsx
+++ b/src/features/ranking/components/ranking-top.test.tsx
@@ -19,7 +19,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>

--- a/src/features/ranking/components/season-ranking-header.tsx
+++ b/src/features/ranking/components/season-ranking-header.tsx
@@ -1,7 +1,7 @@
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import type { Tables } from "@/lib/types/supabase";
-import Link from "next/link";
 
 type Season = Tables<"seasons">;
 

--- a/src/features/ranking/services/get-prefectures-ranking.test.ts
+++ b/src/features/ranking/services/get-prefectures-ranking.test.ts
@@ -9,6 +9,7 @@ import { getJSTMidnightToday } from "@/lib/utils/date-utils";
 jest.mock("@/lib/utils/date-utils", () => ({
   getJSTMidnightToday: jest.fn(() => new Date("2024-01-01T00:00:00Z")),
 }));
+
 import { getCurrentSeasonId } from "@/lib/services/seasons";
 import {
   getPrefecturesRanking,

--- a/src/features/referral/components/referral-code-handler.tsx
+++ b/src/features/referral/components/referral-code-handler.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { setClientCookie } from "@/lib/utils/cookies";
 import { useEffect } from "react";
+import { setClientCookie } from "@/lib/utils/cookies";
 
 interface ReferralCodeHandlerProps {
   referralCode: string;

--- a/src/features/tiktok-stats/components/date-picker.tsx
+++ b/src/features/tiktok-stats/components/date-picker.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import { CalendarIcon } from "lucide-react";
+import { useState } from "react";
+import { DayPicker } from "react-day-picker";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -7,11 +12,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { format } from "date-fns";
-import { ja } from "date-fns/locale";
-import { CalendarIcon } from "lucide-react";
-import { useState } from "react";
-import { DayPicker } from "react-day-picker";
 import "react-day-picker/style.css";
 
 interface DatePickerProps {

--- a/src/features/tiktok-stats/components/tiktok-overall-chart.tsx
+++ b/src/features/tiktok-stats/components/tiktok-overall-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Line, LineChart, XAxis, YAxis } from "recharts";
 import { Card } from "@/components/ui/card";
 import {
   type ChartConfig,
@@ -7,7 +8,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { Line, LineChart, XAxis, YAxis } from "recharts";
 import type { OverallStatsHistoryItem } from "../types";
 import { formatNumberJaShort } from "../utils/format";
 

--- a/src/features/tiktok-stats/components/tiktok-period-filter.tsx
+++ b/src/features/tiktok-stats/components/tiktok-period-filter.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
 import {
   Select,
   SelectContent,
@@ -7,8 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo } from "react";
 import { PERIOD_OPTIONS, type PeriodType } from "../types";
 import { DatePicker } from "./date-picker";
 

--- a/src/features/tiktok-stats/components/tiktok-sort-toggle.tsx
+++ b/src/features/tiktok-stats/components/tiktok-sort-toggle.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
+import { Button } from "@/components/ui/button";
 import { SORT_OPTIONS, type SortType } from "../types";
 
 interface TikTokSortToggleProps {

--- a/src/features/tiktok-stats/components/tiktok-stats-summary.tsx
+++ b/src/features/tiktok-stats/components/tiktok-stats-summary.tsx
@@ -1,5 +1,5 @@
-import { Card } from "@/components/ui/card";
 import { Eye, Heart, MessageCircle, MonitorPlay, Share2 } from "lucide-react";
+import { Card } from "@/components/ui/card";
 import type { StatsSummary } from "../types";
 import { formatNumberJa } from "../utils/format";
 

--- a/src/features/tiktok-stats/components/tiktok-upload-chart.tsx
+++ b/src/features/tiktok-stats/components/tiktok-upload-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import { Card } from "@/components/ui/card";
 import {
   type ChartConfig,
@@ -7,7 +8,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import type { VideoCountByDateItem } from "../types";
 
 interface TikTokUploadChartProps {

--- a/src/features/tiktok-stats/components/tiktok-video-card.tsx
+++ b/src/features/tiktok-stats/components/tiktok-video-card.tsx
@@ -1,6 +1,6 @@
-import { TikTokIcon } from "@/features/tiktok/components";
 import { Eye, Heart, MessageCircle, Share2 } from "lucide-react";
 import Link from "next/link";
+import { TikTokIcon } from "@/features/tiktok/components";
 import type { TikTokVideoWithStats } from "../types";
 import { formatNumberJa } from "../utils/format";
 

--- a/src/features/tiktok-stats/components/tiktok-video-list.tsx
+++ b/src/features/tiktok-stats/components/tiktok-video-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
 import type { TikTokVideoWithStats } from "../types";
 import { TikTokVideoCard } from "./tiktok-video-card";
 

--- a/src/features/tiktok-stats/services/tiktok-stats-service.ts
+++ b/src/features/tiktok-stats/services/tiktok-stats-service.ts
@@ -3,8 +3,8 @@ import "server-only";
 import { createClient } from "@/lib/supabase/client";
 import { getJstRecentDates, toJstDateString } from "@/lib/utils/date-utils";
 import {
-  type VideoStatsRecord,
   calculateDailyViewsIncrease,
+  type VideoStatsRecord,
 } from "@/lib/utils/stats-calculator";
 import type {
   OverallStatsHistoryItem,

--- a/src/features/tiktok/actions/tiktok-auth-actions.ts
+++ b/src/features/tiktok/actions/tiktok-auth-actions.ts
@@ -1,8 +1,8 @@
 "use server";
 
+import { headers } from "next/headers";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
-import { headers } from "next/headers";
 import {
   exchangeCodeForToken,
   fetchUserInfo,

--- a/src/features/tiktok/components/tiktok-link-button.tsx
+++ b/src/features/tiktok/components/tiktok-link-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import { unlinkTikTokAccountAction } from "../actions/tiktok-auth-actions";
 import { linkTikTokAccount } from "../services/tiktok-auth";
 import { TikTokIcon } from "./tiktok-icon";

--- a/src/features/tiktok/components/tiktok-sync-button.tsx
+++ b/src/features/tiktok/components/tiktok-sync-button.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import { syncMyTikTokVideosAction } from "../actions/tiktok-video-actions";
 
 interface TikTokSyncButtonProps {

--- a/src/features/user-achievements/components/mission-card.test.tsx
+++ b/src/features/user-achievements/components/mission-card.test.tsx
@@ -6,7 +6,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>

--- a/src/features/user-achievements/components/mission-card.tsx
+++ b/src/features/user-achievements/components/mission-card.tsx
@@ -1,5 +1,5 @@
-import { Card } from "@/components/ui/card";
 import Link from "next/link";
+import { Card } from "@/components/ui/card";
 
 interface MissionAchievementCardProps {
   missionSlug: string;

--- a/src/features/user-achievements/components/total-card.test.tsx
+++ b/src/features/user-achievements/components/total-card.test.tsx
@@ -6,7 +6,10 @@ jest.mock("@/components/ui/card", () => ({
   Card: ({
     children,
     className,
-  }: { children: React.ReactNode; className?: string }) => (
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
     <div className={className} data-testid="card">
       {children}
     </div>

--- a/src/features/user-achievements/components/user-mission-achievements.test.tsx
+++ b/src/features/user-achievements/components/user-mission-achievements.test.tsx
@@ -12,7 +12,10 @@ jest.mock("./mission-card", () => ({
   MissionAchievementCard: ({
     title,
     count,
-  }: { title: string; count: number }) => (
+  }: {
+    title: string;
+    count: number;
+  }) => (
     <div data-testid="mission-card">
       <span data-testid="mission-title">{title}</span>
       <span data-testid="mission-count">{count}</span>

--- a/src/features/user-activity/components/activities.tsx
+++ b/src/features/user-activity/components/activities.tsx
@@ -1,8 +1,8 @@
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
 import { Card } from "@/components/ui/card";
 import { ActivityTimeline } from "@/features/user-activity/components/activity-timeline";
 import { getGlobalActivityTimeline } from "@/features/user-activity/services/timeline";
-import { ChevronRight } from "lucide-react";
-import Link from "next/link";
 
 export default async function Activities() {
   const timeline = await getGlobalActivityTimeline(3);

--- a/src/features/user-activity/components/activity-timeline.tsx
+++ b/src/features/user-activity/components/activity-timeline.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { UserNameWithBadge } from "@/features/party-membership/components/user-name-with-badge";
 import type { ActivityTimelineItem } from "@/features/user-activity/types/activity-types";
@@ -18,7 +19,6 @@ import type { Tables } from "@/lib/types/supabase";
  * - ユーザー詳細ページの活動タイムライン
  */
 import { dateTimeFormatter } from "@/lib/utils/date-formatters";
-import Link from "next/link";
 
 interface ActivityTimelineProps {
   /** 表示する活動データの配列 */

--- a/src/features/user-activity/components/global-activities.tsx
+++ b/src/features/user-activity/components/global-activities.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { fetchMoreGlobalActivities } from "@/features/user-activity/actions/timeline-actions";
 import { ActivityTimeline } from "@/features/user-activity/components/activity-timeline";
 import type { ActivityTimelineItem } from "@/features/user-activity/types/activity-types";
-import { useState } from "react";
 
 interface GlobalActivitiesProps {
   initialTimeline: ActivityTimelineItem[];

--- a/src/features/user-activity/components/user-detail-activities.tsx
+++ b/src/features/user-activity/components/user-detail-activities.tsx
@@ -14,9 +14,9 @@
  */
 "use client";
 
+import { useState } from "react";
 import { ActivityTimeline } from "@/features/user-activity/components/activity-timeline";
 import type { ActivityTimelineItem } from "@/features/user-activity/types/activity-types";
-import { useState } from "react";
 
 interface UserDetailActivitiesProps {
   /** サーバーサイドで取得済みの初期タイムラインデータ */

--- a/src/features/user-activity/services/timeline.ts
+++ b/src/features/user-activity/services/timeline.ts
@@ -1,7 +1,9 @@
 import "server-only";
 
-import { getPartyMembershipMap } from "@/features/party-membership/services/memberships";
-import { getPartyMembership } from "@/features/party-membership/services/memberships";
+import {
+  getPartyMembership,
+  getPartyMembershipMap,
+} from "@/features/party-membership/services/memberships";
 import type { ActivityTimelineItem } from "@/features/user-activity/types/activity-types";
 import { createClient } from "@/lib/supabase/client";
 

--- a/src/features/user-badges-notification/components/badge-notification-check.tsx
+++ b/src/features/user-badges-notification/components/badge-notification-check.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import type { UserBadge } from "@/features/user-badges/badge-types";
 import { markBadgeNotificationAsSeenAction } from "@/features/user-badges-notification/badge-notification-action";
 import { BadgeNotificationDialog } from "@/features/user-badges-notification/components/badge-notification-dialog";
-import type { UserBadge } from "@/features/user-badges/badge-types";
-import { useEffect, useState } from "react";
 
 interface BadgeNotificationCheckProps {
   badgeData?: UserBadge[];

--- a/src/features/user-badges-notification/components/badge-notification-dialog.tsx
+++ b/src/features/user-badges-notification/components/badge-notification-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Award } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,7 +12,6 @@ import {
 } from "@/components/ui/dialog";
 import type { UserBadge } from "@/features/user-badges/badge-types";
 import { BadgeItem } from "@/features/user-badges/components/badge-item";
-import { Award } from "lucide-react";
 
 interface BadgeNotificationDialogProps {
   isOpen: boolean;

--- a/src/features/user-badges/components/badge-item.tsx
+++ b/src/features/user-badges/components/badge-item.tsx
@@ -1,11 +1,11 @@
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import {
-  type UserBadge,
   getBadgeEmoji,
   getBadgeRankingUrl,
   getBadgeTitle,
+  type UserBadge,
 } from "@/features/user-badges/badge-types";
-import Link from "next/link";
 
 interface BadgeDisplayProps {
   badge: UserBadge;
@@ -14,7 +14,7 @@ interface BadgeDisplayProps {
   clickable?: boolean;
 }
 
-export function getGradientClass(rank: number): string {
+export function getGradientClass(_rank: number): string {
   return "bg-linear-to-r from-emerald-500 to-emerald-600 text-white border-0";
 }
 

--- a/src/features/user-level/components/level-up-check.tsx
+++ b/src/features/user-level/components/level-up-check.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { markLevelUpSeenAction } from "@/features/user-level/actions/level-up";
 import { LevelUpDialog } from "@/features/user-level/components/level-up-dialog";
-import { useEffect, useState } from "react";
 
 interface LevelUpCheckProps {
   levelUpData?: {

--- a/src/features/user-level/components/level-up-dialog.tsx
+++ b/src/features/user-level/components/level-up-dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { DialogTitle } from "@radix-ui/react-dialog";
 import Image from "next/image";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 
 interface LevelUpDialogProps {
   isOpen: boolean;

--- a/src/features/user-level/components/levels.tsx
+++ b/src/features/user-level/components/levels.tsx
@@ -1,3 +1,5 @@
+import { MapPin } from "lucide-react";
+import Link from "next/link";
 import { UserNameWithBadge } from "@/features/party-membership/components/user-name-with-badge";
 import { getPartyMembership } from "@/features/party-membership/services/memberships";
 import { UserTopBadge } from "@/features/user-badges/components/user-top-badge";
@@ -5,8 +7,6 @@ import { LevelProgress } from "@/features/user-level/components/level-progress";
 import { getUserLevel } from "@/features/user-level/services/level";
 import UserAvatar from "@/features/user-profile/components/user-avatar";
 import { getProfile } from "@/features/user-profile/services/profile";
-import { MapPin } from "lucide-react";
-import Link from "next/link";
 
 interface LevelsProps {
   userId: string;

--- a/src/features/user-level/components/progress-bar-animated.tsx
+++ b/src/features/user-level/components/progress-bar-animated.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { cn } from "@/lib/utils/utils";
 import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils/utils";
 
 interface ProgressBarAnimatedProps {
   zeroValue: number;

--- a/src/features/user-level/components/xp-progress-toast-content.tsx
+++ b/src/features/user-level/components/xp-progress-toast-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { markLevelUpSeenAction } from "@/features/user-level/actions/level-up";
 import { LevelUpDialog } from "@/features/user-level/components/level-up-dialog";
 import { ProgressBarAnimated } from "@/features/user-level/components/progress-bar-animated";
@@ -8,7 +9,6 @@ import {
   getXpToNextLevel,
   totalXp,
 } from "@/features/user-level/utils/level-calculator";
-import { useEffect, useState } from "react";
 
 interface XpProgressToastContentProps {
   initialXp: number;

--- a/src/features/user-profile/components/my-avatar.tsx
+++ b/src/features/user-profile/components/my-avatar.tsx
@@ -1,7 +1,7 @@
+import type { HTMLProps } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { getProfile, getUser } from "@/features/user-profile/services/profile";
 import { getAvatarUrl } from "@/lib/services/avatar";
-import type { HTMLProps } from "react";
 
 interface MyAvatarProps {
   className?: HTMLProps<HTMLElement>["className"];

--- a/src/features/user-profile/components/social-badge-section.tsx
+++ b/src/features/user-profile/components/social-badge-section.tsx
@@ -3,7 +3,10 @@ import { SocialBadge } from "./social-badge";
 const SocialBadgeSection = ({
   x_username,
   github_username,
-}: { x_username: string | null; github_username: string | null }) => {
+}: {
+  x_username: string | null;
+  github_username: string | null;
+}) => {
   return (
     <div className="flex justify-center gap-2">
       {x_username && (

--- a/src/features/user-profile/components/user-avatar.tsx
+++ b/src/features/user-profile/components/user-avatar.tsx
@@ -1,7 +1,7 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { getAvatarUrl } from "@/lib/services/avatar";
 import clsx from "clsx";
 import type { HTMLProps } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getAvatarUrl } from "@/lib/services/avatar";
 
 interface UserProfile {
   name?: string | null;

--- a/src/features/user-season/components/user-season-history.tsx
+++ b/src/features/user-season/components/user-season-history.tsx
@@ -1,6 +1,6 @@
+import Link from "next/link";
 import { Card } from "@/components/ui/card";
 import type { UserSeasonHistoryProps } from "@/features/user-season/types/season-types";
-import Link from "next/link";
 
 export function UserSeasonHistory({
   userId,

--- a/src/features/user-settings/actions/change-email-actions.ts
+++ b/src/features/user-settings/actions/change-email-actions.ts
@@ -1,9 +1,9 @@
 "use server";
 
+import { z } from "zod";
 import { getUser } from "@/features/user-profile/services/profile";
 import { requestEmailChange } from "@/features/user-settings/services/email";
 import { isEmailUser } from "@/lib/utils/auth-utils";
-import { z } from "zod";
 
 export type ChangeEmailResult = {
   success: boolean;
@@ -23,7 +23,7 @@ const changeEmailFormSchema = z.object({
  * メールアドレスログインユーザーのみ変更可能
  */
 export async function changeEmailAction(
-  previousState: ChangeEmailResult | null,
+  _previousState: ChangeEmailResult | null,
   formData: FormData,
 ): Promise<ChangeEmailResult> {
   const user = await getUser();

--- a/src/features/user-settings/actions/profile-actions.ts
+++ b/src/features/user-settings/actions/profile-actions.ts
@@ -1,5 +1,9 @@
 "use server";
 
+import { nanoid } from "nanoid";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { z } from "zod";
 import { recordSignupActivity } from "@/features/user-activity/services/activity";
 import { PREFECTURES } from "@/lib/constants/prefectures";
 import { AVATAR_MAX_FILE_SIZE } from "@/lib/services/avatar";
@@ -8,10 +12,6 @@ import { sendWelcomeMail } from "@/lib/services/mail";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
 import { encodedRedirect } from "@/lib/utils/utils";
-import { nanoid } from "nanoid";
-import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
-import { z } from "zod";
 
 export type UpdateProfileResult = {
   success: boolean;
@@ -58,7 +58,7 @@ const updateProfileFormSchema = z.object({
 });
 
 export async function updateProfile(
-  previousState: UpdateProfileResult | null,
+  _previousState: UpdateProfileResult | null,
   formData: FormData,
 ): Promise<UpdateProfileResult | null> {
   const supabaseServiceClient = await createAdminClient();

--- a/src/features/user-settings/components/account-deletion-section.tsx
+++ b/src/features/user-settings/components/account-deletion-section.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { DeleteAccountModal } from "@/features/user-settings/components/delete-account-modal";
-import { useState } from "react";
 
 export function AccountDeletionSection() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);

--- a/src/features/user-settings/components/delete-account-modal.tsx
+++ b/src/features/user-settings/components/delete-account-modal.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { AlertTriangle } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,9 +14,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { deleteAccountAction } from "@/features/user-settings/actions/delete-account-action";
-import { AlertTriangle } from "lucide-react";
-import { useState } from "react";
-import { toast } from "sonner";
 
 interface DeleteAccountModalProps {
   isOpen: boolean;
@@ -38,7 +38,7 @@ export function DeleteAccountModal({
       if (result?.success) {
         toast.success("退会処理が完了しました");
       }
-    } catch (err) {
+    } catch (_err) {
       setIsDeleting(false);
       onClose();
       toast.error("退会処理でエラーが発生しました。もう一度お試しください。");

--- a/src/features/user-settings/components/email-change-dialog.tsx
+++ b/src/features/user-settings/components/email-change-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useActionState, useEffect } from "react";
 import { FormMessage } from "@/components/common/form-message";
 import { SubmitButton } from "@/components/common/submit-button";
 import { Button } from "@/components/ui/button";
@@ -14,7 +15,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useActionState, useEffect } from "react";
 import {
   type ChangeEmailResult,
   changeEmailAction,

--- a/src/features/user-settings/components/login-section.tsx
+++ b/src/features/user-settings/components/login-section.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { User } from "@supabase/supabase-js";
+import { useState } from "react";
 import { FormMessage } from "@/components/common/form-message";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
@@ -8,8 +10,6 @@ import {
   isEmailUser as checkIsEmailUser,
   getAuthMethodDisplayName,
 } from "@/lib/utils/auth-utils";
-import type { User } from "@supabase/supabase-js";
-import { useState } from "react";
 
 interface LoginSectionProps {
   user: User;

--- a/src/features/user-settings/components/prefecture-select.tsx
+++ b/src/features/user-settings/components/prefecture-select.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type React from "react";
 import {
   Select,
   SelectContent,
@@ -8,7 +9,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PREFECTURES } from "@/lib/constants/prefectures";
-import type React from "react";
 
 type PrefectureSelectProps = {
   name: string;

--- a/src/features/user-settings/components/profile-form.tsx
+++ b/src/features/user-settings/components/profile-form.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+import { X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  useActionState,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { CollapsibleInfo } from "@/components/common/collapsible-info";
 import { FormMessage, type Message } from "@/components/common/form-message";
 import { SubmitButton } from "@/components/common/submit-button";
@@ -26,15 +35,6 @@ import { updateProfile } from "@/features/user-settings/actions/profile-actions"
 import { PrefectureSelect } from "@/features/user-settings/components/prefecture-select";
 import { AVATAR_MAX_FILE_SIZE, getAvatarUrl } from "@/lib/services/avatar";
 import { calculateAge } from "@/lib/utils/utils";
-import { X } from "lucide-react";
-import { useRouter } from "next/navigation";
-import {
-  useActionState,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
 
 // AvatarUploadコンポーネントを削除し、メインのフォームに統合
 

--- a/src/features/youtube-stats/components/date-picker.tsx
+++ b/src/features/youtube-stats/components/date-picker.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import { CalendarIcon } from "lucide-react";
+import { useState } from "react";
+import { DayPicker } from "react-day-picker";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -7,11 +12,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { format } from "date-fns";
-import { ja } from "date-fns/locale";
-import { CalendarIcon } from "lucide-react";
-import { useState } from "react";
-import { DayPicker } from "react-day-picker";
 import "react-day-picker/style.css";
 
 interface DatePickerProps {

--- a/src/features/youtube-stats/components/youtube-overall-chart.tsx
+++ b/src/features/youtube-stats/components/youtube-overall-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Line, LineChart, XAxis, YAxis } from "recharts";
 import { Card } from "@/components/ui/card";
 import {
   type ChartConfig,
@@ -7,7 +8,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { Line, LineChart, XAxis, YAxis } from "recharts";
 import type { OverallStatsHistoryItem } from "../types";
 import { formatNumberJaShort } from "../utils/format";
 

--- a/src/features/youtube-stats/components/youtube-period-filter.tsx
+++ b/src/features/youtube-stats/components/youtube-period-filter.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
 import {
   Select,
   SelectContent,
@@ -7,8 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo } from "react";
 import { PERIOD_OPTIONS, type PeriodType } from "../types";
 import { DatePicker } from "./date-picker";
 

--- a/src/features/youtube-stats/components/youtube-sort-toggle.tsx
+++ b/src/features/youtube-stats/components/youtube-sort-toggle.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
+import { Button } from "@/components/ui/button";
 import { SORT_OPTIONS, type SortType } from "../types";
 
 interface YouTubeSortToggleProps {

--- a/src/features/youtube-stats/components/youtube-stats-chart.tsx
+++ b/src/features/youtube-stats/components/youtube-stats-chart.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { Line, LineChart, XAxis, YAxis } from "recharts";
 import {
   type ChartConfig,
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { Line, LineChart, XAxis, YAxis } from "recharts";
 import type { StatsHistory } from "../types";
 
 interface YouTubeStatsChartProps {

--- a/src/features/youtube-stats/components/youtube-stats-summary.tsx
+++ b/src/features/youtube-stats/components/youtube-stats-summary.tsx
@@ -1,5 +1,5 @@
-import { Card } from "@/components/ui/card";
 import { Eye, MessageCircle, MonitorPlay, ThumbsUp } from "lucide-react";
+import { Card } from "@/components/ui/card";
 import type { StatsSummary } from "../types";
 import { formatNumberJa } from "../utils/format";
 

--- a/src/features/youtube-stats/components/youtube-upload-chart.tsx
+++ b/src/features/youtube-stats/components/youtube-upload-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import { Card } from "@/components/ui/card";
 import {
   type ChartConfig,
@@ -7,7 +8,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import type { VideoCountByDateItem } from "../types";
 
 interface YouTubeUploadChartProps {

--- a/src/features/youtube-stats/components/youtube-video-list.tsx
+++ b/src/features/youtube-stats/components/youtube-video-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
 import type { YouTubeVideoWithStats } from "../types";
 import { YouTubeVideoCard } from "./youtube-video-card";
 

--- a/src/features/youtube-stats/services/youtube-stats-service.ts
+++ b/src/features/youtube-stats/services/youtube-stats-service.ts
@@ -3,8 +3,8 @@ import "server-only";
 import { createClient } from "@/lib/supabase/client";
 import { getJstRecentDates, toJstDateString } from "@/lib/utils/date-utils";
 import {
-  type VideoStatsRecord,
   calculateDailyViewsIncrease,
+  type VideoStatsRecord,
 } from "@/lib/utils/stats-calculator";
 import type {
   OverallStatsHistoryItem,

--- a/src/features/youtube/actions/youtube-auth-actions.ts
+++ b/src/features/youtube/actions/youtube-auth-actions.ts
@@ -1,8 +1,8 @@
 "use server";
 
+import { headers } from "next/headers";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
-import { headers } from "next/headers";
 import {
   exchangeCodeForToken,
   fetchChannelInfo,

--- a/src/features/youtube/actions/youtube-like-actions.ts
+++ b/src/features/youtube/actions/youtube-like-actions.ts
@@ -3,12 +3,12 @@
 import { achieveMissionAction } from "@/features/mission-detail/actions/actions";
 import { createClient } from "@/lib/supabase/client";
 import {
-  type LikedVideo,
   checkTeamMiraiVideosBatch,
   extractVideoIdFromUrl,
   fetchUserLikedVideos,
   getYouTubeConnection,
   isTokenExpired,
+  type LikedVideo,
 } from "../services/youtube-like-service";
 import { refreshYouTubeTokenAction } from "./youtube-auth-actions";
 

--- a/src/features/youtube/actions/youtube-video-actions.ts
+++ b/src/features/youtube/actions/youtube-video-actions.ts
@@ -3,8 +3,8 @@
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
 import {
-  type YouTubeSyncResult,
   syncUserYouTubeVideos,
+  type YouTubeSyncResult,
 } from "../services/youtube-video-service";
 import type { YouTubeLinkStatus, YouTubeVideoWithStats } from "../types";
 import { refreshYouTubeTokenAction } from "./youtube-auth-actions";

--- a/src/features/youtube/components/youtube-comment-list.tsx
+++ b/src/features/youtube/components/youtube-comment-list.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import {
-  type RecordedComment,
-  getRecordedCommentsAction,
-} from "@/features/youtube/actions/youtube-comment-actions";
 import { Loader2, MessageCircle } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import {
+  getRecordedCommentsAction,
+  type RecordedComment,
+} from "@/features/youtube/actions/youtube-comment-actions";
 
 interface YouTubeCommentListProps {
   refreshTrigger?: number;

--- a/src/features/youtube/components/youtube-liked-list.tsx
+++ b/src/features/youtube/components/youtube-liked-list.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import {
-  type RecordedLike,
-  getRecordedLikesAction,
-} from "@/features/youtube/actions/youtube-like-actions";
 import { Loader2, ThumbsUp } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import {
+  getRecordedLikesAction,
+  type RecordedLike,
+} from "@/features/youtube/actions/youtube-like-actions";
 
 interface YouTubeLikedListProps {
   refreshTrigger?: number;

--- a/src/features/youtube/components/youtube-link-button.tsx
+++ b/src/features/youtube/components/youtube-link-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import { unlinkYouTubeAccountAction } from "../actions/youtube-auth-actions";
 import { linkYouTubeAccount } from "../services/youtube-auth";
 

--- a/src/features/youtube/components/youtube-sync-button.tsx
+++ b/src/features/youtube/components/youtube-sync-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { syncAllYouTubeDataAction } from "../actions/youtube-sync-actions";
 import { syncMyYouTubeVideosAction } from "../actions/youtube-video-actions";
 
@@ -40,7 +40,7 @@ export function YouTubeSyncButton({
       const { syncTeamMiraiVideosAction } = await import(
         "../actions/youtube-video-actions"
       );
-      const teamMiraiResult = await syncTeamMiraiVideosAction();
+      const _teamMiraiResult = await syncTeamMiraiVideosAction();
 
       // 2. 自分のアップロード動画を同期（レート制限なし）
       const videoSyncResult = await syncMyYouTubeVideosAction();

--- a/src/features/youtube/components/youtube-video-list.tsx
+++ b/src/features/youtube/components/youtube-video-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { YouTubeVideoCard } from "@/features/youtube-stats/components/youtube-video-card";
 import type { YouTubeVideoWithStats } from "@/features/youtube-stats/types";
-import { useEffect, useState } from "react";
 import { getMyUploadedVideosAction } from "../actions/youtube-video-actions";
 
 interface YouTubeVideoListProps {

--- a/src/features/youtube/services/youtube-like-service.ts
+++ b/src/features/youtube/services/youtube-like-service.ts
@@ -7,12 +7,12 @@ import { fetchVideoDetailsByApiKey } from "./youtube-client";
 
 // コアロジックを再エクスポート
 export {
-  type LikedVideo,
-  type SyncLikesForUserResult,
   checkTeamMiraiVideosBatch,
   createYouTubeLikeRecord,
   fetchUserLikedVideos,
   getUserRecordedLikes,
+  type LikedVideo,
+  type SyncLikesForUserResult,
   syncLikesForUser,
 } from "./sync-likes-core";
 

--- a/src/features/youtube/services/youtube-video-sync-service.ts
+++ b/src/features/youtube/services/youtube-video-sync-service.ts
@@ -3,8 +3,8 @@
  * #チームみらい ハッシュタグで動画を検索し、DBに同期する
  */
 
-import { createAdminClient } from "@/lib/supabase/adminClient";
 import { google } from "googleapis";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 
 const HASHTAG = "#チームみらい";
 

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,6 +1,6 @@
-import type { Database } from "@/lib/types/supabase";
 import { createBrowserClient, createServerClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/supabase";
 
 /**
  * 実行環境を自動判定してSupabaseクライアントを作成する透過的な関数
@@ -40,7 +40,7 @@ export function createClient(): SupabaseClient<Database> {
               for (const { name, value, options } of cookiesToSet) {
                 cookieStore.set(name, value, options);
               }
-            } catch (error) {
+            } catch (_error) {
               // The `set` method was called from a Server Component.
               // This can be ignored if you have middleware refreshing
               // user sessions.
@@ -48,7 +48,7 @@ export function createClient(): SupabaseClient<Database> {
           },
         },
       });
-    } catch (error) {
+    } catch (_error) {
       // next/headersが利用できない場合（テスト環境など）はシンプルなServerClientを返す
       return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
         cookies: {

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,6 +1,6 @@
-import type { Database } from "@/lib/types/supabase";
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
+import type { Database } from "@/lib/types/supabase";
 
 export const updateSession = async (request: NextRequest) => {
   // This `try/catch` block is only here for the interactive tutorial.
@@ -46,7 +46,7 @@ export const updateSession = async (request: NextRequest) => {
     }
 
     return response;
-  } catch (e) {
+  } catch (_e) {
     // If you are here, a Supabase client could not be created!
     // This is likely because you have not set up environment variables.
     // Check out http://localhost:3000 for Next Steps.

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,6 @@
-import type { Database } from "@/lib/types/supabase";
 import { createServerClient } from "@supabase/ssr";
 import type { cookies } from "next/headers";
+import type { Database } from "@/lib/types/supabase";
 
 export function createClient(cookieStore: Awaited<ReturnType<typeof cookies>>) {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,2 +1,2 @@
 // Barrel export for utils
-export { cn, encodedRedirect, calculateAge } from "./utils/utils";
+export { calculateAge, cn, encodedRedirect } from "./utils/utils";

--- a/src/lib/utils/metadata.ts
+++ b/src/lib/utils/metadata.ts
@@ -39,7 +39,7 @@ export const notoSansJP = Noto_Sans_JP({
 // ==========================================
 
 // URLが有効な画像URLかどうかを検証する関数
-export function isValidImageUrl(url: string): boolean {
+export function isValidImageUrl(_url: string): boolean {
   //TODO: URL検証を追加
   return true;
 }

--- a/src/lib/validation/auth.ts
+++ b/src/lib/validation/auth.ts
@@ -1,8 +1,8 @@
-import { calculateAge } from "@/lib/utils/utils";
 import { z } from "zod";
+import { calculateAge } from "@/lib/utils/utils";
 
 // パスワードの許可文字の正規表現
-const ALLOWED_PASSWORD_CHARS_REGEX = /^[a-zA-Z0-9@+*/#$%&!\-]*$/;
+const ALLOWED_PASSWORD_CHARS_REGEX = /^[a-zA-Z0-9@+*/#$%&!-]*$/;
 // パスワードが英字と数字の両方を含むかチェックする正規表現
 const ALPHANUMERIC_REQUIRED_REGEX = /(?=.*[a-zA-Z])(?=.*[0-9])/;
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
-import { updateSession } from "@/lib/supabase/middleware";
 import type { NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
 
 export async function middleware(request: NextRequest) {
   return await updateSession(request);

--- a/tests/__mocks__/supabase.ts
+++ b/tests/__mocks__/supabase.ts
@@ -37,7 +37,7 @@ export const mockUpload = jest.fn().mockResolvedValue({
 });
 
 export const mockSupabaseClient = {
-  from: jest.fn((table: string) => createMockQuery([])),
+  from: jest.fn((_table: string) => createMockQuery([])),
   storage: {
     from: jest.fn(() => ({
       upload: mockUpload,

--- a/tests/e2e-test-helpers.ts
+++ b/tests/e2e-test-helpers.ts
@@ -1,8 +1,8 @@
-import { type Page, test as base, expect } from "@playwright/test";
+import { test as base, expect, type Page } from "@playwright/test";
 import {
-  type TestUser,
   cleanupTestUser,
   createTestUser,
+  type TestUser,
 } from "./supabase/utils";
 
 // カスタムテストフィクスチャを定義

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -47,7 +47,7 @@ setup("テスト用アカウントのセットアップ", async ({ page }) => {
       timeout: 5000,
     });
     console.log("テスト用アカウントを作成しました");
-  } catch (e) {
+  } catch (_e) {
     console.log("テスト用アカウントはすでに存在しているかもしれません");
   }
 });

--- a/tests/e2e/user-mission.spec.ts
+++ b/tests/e2e/user-mission.spec.ts
@@ -120,7 +120,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
     await signedInPage
       .getByRole("link", { name: "テストユーザーさんのプロフィールへ" })
       .click();
-    await expect(signedInPage).toHaveURL(/\/users\/[^\/]+$/, {
+    await expect(signedInPage).toHaveURL(/\/users\/[^/]+$/, {
       timeout: 10000,
     });
 
@@ -137,7 +137,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       .filter({ hasText: "佐藤太郎" })
       .first()
       .click();
-    await expect(signedInPage).toHaveURL(/\/users\/[^\/]+$/, {
+    await expect(signedInPage).toHaveURL(/\/users\/[^/]+$/, {
       timeout: 10000,
     });
 
@@ -156,7 +156,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       .filter({ hasText: "(seed) ゴミ拾いをしよう (成果物不要)" })
       .getByRole("button", { name: "今すぐチャレンジ" })
       .click();
-    await expect(signedInPage).toHaveURL(/\/missions\/[^\/]+$/, {
+    await expect(signedInPage).toHaveURL(/\/missions\/[^/]+$/, {
       timeout: 10000,
     });
 
@@ -219,7 +219,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       .getByRole("button", { name: "もう一回チャレンジ" })
       .first()
       .click();
-    await expect(signedInPage).toHaveURL(/\/missions\/[^\/]+$/, {
+    await expect(signedInPage).toHaveURL(/\/missions\/[^/]+$/, {
       timeout: 10000,
     });
 

--- a/tests/supabase/utils.ts
+++ b/tests/supabase/utils.ts
@@ -1,5 +1,5 @@
-import type { Database } from "@/lib/types/supabase";
 import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/supabase";
 
 // 環境変数の設定が必要
 if (

--- a/tests/unit/poster-board-progress-calculation.test.ts
+++ b/tests/unit/poster-board-progress-calculation.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it } from "@jest/globals";
 import {
   calculateProgressRate,
   getCompletedCount,
   getRegisteredCount,
 } from "@/features/map-poster/utils/poster-progress";
 import type { Database } from "@/lib/types/supabase";
-import { describe, expect, it } from "@jest/globals";
 
 type PosterBoard = Database["public"]["Tables"]["poster_boards"]["Row"];
 type BoardStatus = Database["public"]["Enums"]["poster_board_status"];

--- a/tests/unit/stats-calculator.test.ts
+++ b/tests/unit/stats-calculator.test.ts
@@ -1,6 +1,6 @@
 import {
-  type VideoStatsRecord,
   calculateDailyViewsIncrease,
+  type VideoStatsRecord,
 } from "@/lib/utils/stats-calculator";
 
 describe("calculateDailyViewsIncrease", () => {


### PR DESCRIPTION
# 変更の概要
- `@biomejs/biome` を 1.9.4 -> 2.3.13 に更新
  - `biome migrate --write` で `biome.json` をマイグレーション 
  - 全ファイルに自動フォーマット・インポート整理を適用
- Biome のバージョンアップによってエラーになったルールを warn に設定
  - エラーを修正するためのコードの変更を含めると PR が大きくなってしまうので、一旦 warn で逃げて徐々にルールを適用して段階的に移行していきます
  - https://github.com/team-mirai-volunteer/action-board/pull/1900/changes#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55L33-R45
- CI の Biome バージョン指定を外す
  - ドキュメントによると、lockfile から自動で取得してくれそう
  - https://github.com/biomejs/setup-biome?tab=readme-ov-file#automatic-version-dete

# 変更の背景
- https://github.com/team-mirai-volunteer/action-board/issues/1520

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました