### PR TITLE
ミッション「選挙区ポスターを貼ろう」において、ラベル「番号」を「掲示板番号」に書き換える

### DIFF
--- a/src/features/missions/components/poster-form.test.tsx
+++ b/src/features/missions/components/poster-form.test.tsx
@@ -53,7 +53,7 @@ describe("PosterForm", () => {
       screen.getByRole("button", { name: /Select Prefecture/i }),
     ).toBeInTheDocument(); // Selectボタンの存在確認
     expect(screen.getByLabelText(/市町村＋区/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/番号/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/掲示板番号/)).toBeInTheDocument();
 
     // 必須マークの確認
     expect(screen.getAllByText("*")).toHaveLength(3);
@@ -79,7 +79,7 @@ describe("PosterForm", () => {
       "true",
     );
     expect(screen.getByRole("textbox", { name: /市町村＋区/ })).toBeDisabled();
-    expect(screen.getByRole("textbox", { name: /番号/ })).toBeDisabled();
+    expect(screen.getByRole("textbox", { name: /掲示板番号/ })).toBeDisabled();
     expect(screen.getByRole("textbox", { name: /名前/ })).toBeDisabled();
     expect(screen.getByRole("textbox", { name: /状況/ })).toBeDisabled();
     expect(screen.getByRole("textbox", { name: /住所/ })).toBeDisabled();
@@ -98,7 +98,9 @@ describe("PosterForm", () => {
     expect(
       screen.getByRole("textbox", { name: /市町村＋区/ }),
     ).not.toBeDisabled();
-    expect(screen.getByRole("textbox", { name: /番号/ })).not.toBeDisabled();
+    expect(
+      screen.getByRole("textbox", { name: /掲示板番号/ }),
+    ).not.toBeDisabled();
     expect(screen.getByRole("textbox", { name: /名前/ })).not.toBeDisabled();
     expect(screen.getByRole("textbox", { name: /状況/ })).not.toBeDisabled();
     expect(screen.getByRole("textbox", { name: /住所/ })).not.toBeDisabled();
@@ -119,7 +121,9 @@ describe("PosterForm", () => {
   it("has correct input attributes for board number field", () => {
     render(<PosterForm disabled={false} />);
 
-    const boardNumberInput = screen.getByRole("textbox", { name: /番号/ });
+    const boardNumberInput = screen.getByRole("textbox", {
+      name: /掲示板番号/,
+    });
     expect(boardNumberInput).toHaveAttribute("type", "text");
     expect(boardNumberInput).toHaveAttribute("name", "boardNumber");
     expect(boardNumberInput).toHaveAttribute("maxLength", "20");
@@ -257,7 +261,9 @@ describe("PosterForm", () => {
     expect(
       screen.getByRole("textbox", { name: /市町村＋区/ }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("textbox", { name: /番号/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: /掲示板番号/ }),
+    ).toBeInTheDocument();
   });
 
   it("has proper accessibility attributes", () => {
@@ -268,7 +274,9 @@ describe("PosterForm", () => {
     const cityInput = screen.getByRole("textbox", { name: /市町村＋区/ });
     expect(cityInput).toHaveAttribute("id", "city");
 
-    const boardNumberInput = screen.getByRole("textbox", { name: /番号/ });
+    const boardNumberInput = screen.getByRole("textbox", {
+      name: /掲示板番号/,
+    });
     expect(boardNumberInput).toHaveAttribute("id", "boardNumber");
 
     const boardNameInput = screen.getByRole("textbox", { name: /名前/ });

--- a/src/features/missions/components/poster-form.tsx
+++ b/src/features/missions/components/poster-form.tsx
@@ -90,10 +90,10 @@ export function PosterForm({ disabled }: PosterFormProps) {
         </p>
       </div>
 
-      {/* 番号 */}
+      {/* 掲示板番号 */}
       <div className="space-y-2">
         <Label htmlFor="boardNumber">
-          番号 <span className="text-red-500">*</span>
+          掲示板番号 <span className="text-red-500">*</span>
         </Label>
         <Input
           type="text"
@@ -106,7 +106,7 @@ export function PosterForm({ disabled }: PosterFormProps) {
           pattern="^(\d+(-\d){0,2})$"
         />
         <p className="text-xs text-gray-500">
-          番号を入力してください（例：10-1、27-2-1、00）
+          掲示板番号を入力してください（例：10-1、27-2-1、00）
         </p>
       </div>
 


### PR DESCRIPTION
# 変更の概要
- ミッション「選挙区ポスターを貼ろう」のフォームのラベルを、「番号」から「掲示板番号」に変更しました

## before
<img width="577" height="354" alt="image" src="https://github.com/user-attachments/assets/6ac3852d-0f36-4e41-b886-1d303a94d0b7" />


## after
<img width="556" height="362" alt="image" src="https://github.com/user-attachments/assets/b4d233b1-162b-4140-a2bb-df14edd40ae7" />


# 変更の背景
- closes https://github.com/team-mirai-volunteer/action-board/issues/1902

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 掲示板番号フィールドのラベルおよびヘルパーテキストを「番号」から「掲示板番号」に更新し、ユーザーが入力する内容をより明確に理解できるようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->