### PR TITLE
refactor: achieveMissionActionのtype別ロジックを分離

### DIFF
--- a/src/features/mission-detail/actions/actions.ts
+++ b/src/features/mission-detail/actions/actions.ts
@@ -20,6 +20,13 @@ import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
 import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
 import type { Database, TablesInsert } from "@/lib/types/supabase";
+import {
+  buildArtifactPayload,
+  getArtifactTypeLabel,
+  grantActivityBonusXp,
+  savePosterActivity,
+  savePostingActivity,
+} from "./artifact-helpers";
 
 // Quiz関連のServer ActionsとQuizQuestion型をインポート
 import {
@@ -230,6 +237,8 @@ const achieveMissionFormSchema = z.discriminatedUnion("requiredArtifactType", [
   youtubeArtifactSchema,
   youtubeCommentArtifactSchema,
 ]);
+
+export type AchieveMissionFormData = z.infer<typeof achieveMissionFormSchema>;
 
 // 提出キャンセルアクションのバリデーションスキーマ
 const cancelSubmissionFormSchema = z.object({
@@ -587,14 +596,23 @@ export const achieveMissionAction = async (formData: FormData) => {
     validatedRequiredArtifactType !== ARTIFACT_TYPES.NONE.key &&
     validatedRequiredArtifactType !== ARTIFACT_TYPES.LINK_ACCESS.key
   ) {
+    // artifact type に基づいてペイロードフィールドをビルド
+    const artifactFields = buildArtifactPayload(
+      validatedRequiredArtifactType,
+      validatedData,
+    );
+    const artifactTypeLabel = getArtifactTypeLabel(
+      validatedRequiredArtifactType,
+    );
+
     const artifactPayload: TablesInsert<"mission_artifacts"> = {
       achievement_id: achievement.id,
       user_id: authUser.id,
       artifact_type: validatedRequiredArtifactType,
       description: validatedArtifactDescription || null,
+      ...artifactFields,
     };
 
-    let artifactTypeLabel = "OTHER";
     let validationError = null;
 
     // formDataの内容を全てログ出力
@@ -602,113 +620,6 @@ export const achieveMissionAction = async (formData: FormData) => {
     formData.forEach((value, key) => {
       formDataObj[key] = String(value);
     });
-
-    if (validatedRequiredArtifactType === ARTIFACT_TYPES.LINK.key) {
-      artifactTypeLabel = "LINK";
-      if (validatedData.requiredArtifactType === ARTIFACT_TYPES.LINK.key) {
-        artifactPayload.link_url = validatedData.artifactLink;
-        // CHECK制約: link_url必須、他はnull
-        artifactPayload.image_storage_path = null;
-        artifactPayload.text_content = null;
-      }
-    } else if (validatedRequiredArtifactType === ARTIFACT_TYPES.TEXT.key) {
-      artifactTypeLabel = "TEXT";
-      if (validatedData.requiredArtifactType === ARTIFACT_TYPES.TEXT.key) {
-        artifactPayload.text_content = validatedData.artifactText;
-        // CHECK制約: text_content必須、他はnull
-        artifactPayload.link_url = null;
-        artifactPayload.image_storage_path = null;
-      }
-    } else if (validatedRequiredArtifactType === ARTIFACT_TYPES.EMAIL.key) {
-      artifactTypeLabel = "EMAIL";
-      if (validatedData.requiredArtifactType === ARTIFACT_TYPES.EMAIL.key) {
-        artifactPayload.text_content = validatedData.artifactEmail;
-        // CHECK制約: text_content必須、他はnull
-        artifactPayload.link_url = null;
-        artifactPayload.image_storage_path = null;
-      }
-    } else if (validatedRequiredArtifactType === ARTIFACT_TYPES.IMAGE.key) {
-      artifactTypeLabel = "IMAGE";
-      if (validatedData.requiredArtifactType === ARTIFACT_TYPES.IMAGE.key) {
-        artifactPayload.image_storage_path = validatedData.artifactImagePath;
-        // CHECK制約: image_storage_path必須、他はnull
-        artifactPayload.link_url = null;
-        artifactPayload.text_content = null;
-      }
-    } else if (
-      validatedRequiredArtifactType ===
-      ARTIFACT_TYPES.IMAGE_WITH_GEOLOCATION.key
-    ) {
-      artifactTypeLabel = "IMAGE_WITH_GEOLOCATION";
-      if (
-        validatedData.requiredArtifactType ===
-        ARTIFACT_TYPES.IMAGE_WITH_GEOLOCATION.key
-      ) {
-        artifactPayload.image_storage_path = validatedData.artifactImagePath;
-        artifactPayload.link_url = null;
-        artifactPayload.text_content = null;
-      }
-    } else if (validatedRequiredArtifactType === ARTIFACT_TYPES.POSTING.key) {
-      artifactTypeLabel = "POSTING";
-      if (validatedData.requiredArtifactType === ARTIFACT_TYPES.POSTING.key) {
-        // ポスティング情報をtext_contentに格納
-        artifactPayload.text_content = `${validatedData.postingCount}枚を${validatedData.locationText}に配布`;
-        // CHECK制約: text_content必須、他はnull
-        artifactPayload.link_url = null;
-        artifactPayload.image_storage_path = null;
-      }
-    } else if (validatedRequiredArtifactType === ARTIFACT_TYPES.POSTER.key) {
-      artifactTypeLabel = "POSTER";
-      if (validatedData.requiredArtifactType === ARTIFACT_TYPES.POSTER.key) {
-        // ポスター情報をtext_contentに詳細に格納
-        const locationInfo = `${validatedData.prefecture}${validatedData.city} ${validatedData.boardNumber}`;
-        const nameInfo = validatedData.boardName
-          ? ` (${validatedData.boardName})`
-          : "";
-        const statusInfo = validatedData.boardNote
-          ? ` - 状況: ${validatedData.boardNote}`
-          : "";
-
-        artifactPayload.text_content = `${locationInfo}${nameInfo}に貼付${statusInfo}`;
-        // CHECK制約: text_content必須、他はnull
-        artifactPayload.link_url = null;
-        artifactPayload.image_storage_path = null;
-      }
-    } else if (validatedRequiredArtifactType === ARTIFACT_TYPES.QUIZ.key) {
-      artifactTypeLabel = "QUIZ";
-      if (validatedData.requiredArtifactType === ARTIFACT_TYPES.QUIZ.key) {
-        // クイズ結果はdescriptionのみに格納
-        artifactPayload.text_content = null;
-        artifactPayload.link_url = null;
-        artifactPayload.image_storage_path = null;
-      }
-    } else if (validatedRequiredArtifactType === ARTIFACT_TYPES.YOUTUBE.key) {
-      artifactTypeLabel = "YOUTUBE";
-      if (validatedData.requiredArtifactType === ARTIFACT_TYPES.YOUTUBE.key) {
-        artifactPayload.link_url = validatedData.artifactLink;
-        // CHECK制約: link_url必須、他はnull
-        artifactPayload.image_storage_path = null;
-        artifactPayload.text_content = null;
-      }
-    } else if (
-      validatedRequiredArtifactType === ARTIFACT_TYPES.YOUTUBE_COMMENT.key
-    ) {
-      artifactTypeLabel = "YOUTUBE_COMMENT";
-      if (
-        validatedData.requiredArtifactType ===
-        ARTIFACT_TYPES.YOUTUBE_COMMENT.key
-      ) {
-        artifactPayload.link_url = validatedData.artifactLink;
-        // CHECK制約: link_url必須、他はnull
-        artifactPayload.image_storage_path = null;
-        artifactPayload.text_content = null;
-      }
-    } else {
-      // その他のタイプは全てnullに
-      artifactPayload.link_url = null;
-      artifactPayload.image_storage_path = null;
-      artifactPayload.text_content = null;
-    }
 
     // CHECK制約: QUIZタイプ以外はlink_url、text_content、image_storage_pathのいずれか一つは必須
     if (
@@ -773,116 +684,63 @@ export const achieveMissionAction = async (formData: FormData) => {
       validatedRequiredArtifactType === ARTIFACT_TYPES.POSTING.key &&
       validatedData.requiredArtifactType === ARTIFACT_TYPES.POSTING.key
     ) {
-      // shapeIdが渡された場合は紐付ける（ポスティングマップから）
       const shapeId = formData.get("shapeId") as string | null;
 
-      const { error: postingError } = await supabase
-        .from("posting_activities")
-        .insert({
-          mission_artifact_id: newArtifact.id,
-          posting_count: validatedData.postingCount,
-          location_text: validatedData.locationText ?? "",
-          shape_id: shapeId || null,
-        });
-
-      if (postingError) {
-        console.error("Posting activity save error:", postingError);
-        return {
-          success: false,
-          error: `ポスティング活動の保存に失敗しました: ${postingError.message}`,
-        };
+      const postingResult = await savePostingActivity(supabase, {
+        artifactId: newArtifact.id,
+        postingCount: validatedData.postingCount,
+        locationText: validatedData.locationText ?? "",
+        shapeId: shapeId || null,
+      });
+      if (!postingResult.success) {
+        return { success: false, error: postingResult.error };
       }
 
-      // ポスティング用のポイント計算とXP付与（注目ミッションは2倍）
-      const pointsPerUnit = POSTING_POINTS_PER_UNIT; // 固定値（フェーズ1では固定、フェーズ2で設定テーブルから取得予定）
-      const basePoints = validatedData.postingCount * pointsPerUnit;
-      const totalPoints = missionData?.is_featured
-        ? basePoints * 2
-        : basePoints;
-
-      // 通常のXP（ミッション難易度ベース）に加えて、ポスティングボーナスXPを付与
-      const bonusXpResult = await grantXp(
-        authUser.id,
-        totalPoints,
-        "BONUS",
-        achievement.id,
-        `ポスティング活動ボーナス（${validatedData.postingCount}枚=${totalPoints}ポイント${missionData?.is_featured ? "【2倍】" : ""}）`,
-      );
-
-      if (!bonusXpResult.success) {
-        console.error(
-          "ポスティングボーナスXP付与に失敗しました:",
-          bonusXpResult.error,
-        );
-        // ボーナスXP付与の失敗はミッション達成の成功を妨げない
-      } else {
-        totalXpGranted += totalPoints;
-      }
+      totalXpGranted += await grantActivityBonusXp({
+        userId: authUser.id,
+        achievementId: achievement.id,
+        count: validatedData.postingCount,
+        pointsPerUnit: POSTING_POINTS_PER_UNIT,
+        isFeatured: missionData?.is_featured ?? false,
+        descriptionLabel: "ポスティング活動ボーナス",
+      });
     }
 
-    // ポスター活動の詳細情報をposter_activitiesテーブルに保存
+    // ポスター活動の詳細情報を保存
     if (
       validatedRequiredArtifactType === ARTIFACT_TYPES.POSTER.key &&
       validatedData.requiredArtifactType === ARTIFACT_TYPES.POSTER.key
     ) {
-      // poster_activitiesテーブルに必要なデータを準備
-      const posterActivityPayload = {
-        user_id: authUser.id,
-        mission_artifact_id: newArtifact.id,
-        poster_count: MAX_POSTER_COUNT,
+      const posterResult = await savePosterActivity(supabase, {
+        userId: authUser.id,
+        artifactId: newArtifact.id,
         prefecture:
           validatedData.prefecture as Database["public"]["Enums"]["poster_prefecture_enum"],
         city: validatedData.city,
-        number: validatedData.boardNumber,
-        name: validatedData.boardName || null,
-        note: validatedData.boardNote || null,
-        address: validatedData.boardAddress || null,
-        lat: validatedData.boardLat
+        boardNumber: validatedData.boardNumber,
+        boardName: validatedData.boardName || null,
+        boardNote: validatedData.boardNote || null,
+        boardAddress: validatedData.boardAddress || null,
+        boardLat: validatedData.boardLat
           ? Number.parseFloat(validatedData.boardLat)
           : null,
-        long: validatedData.boardLong
+        boardLong: validatedData.boardLong
           ? Number.parseFloat(validatedData.boardLong)
           : null,
-        board_id: boardId || null,
-      };
-
-      const { error: posterActivityError } = await supabase
-        .from("poster_activities")
-        .insert(posterActivityPayload);
-
-      if (posterActivityError) {
-        console.error("Poster activity save error:", posterActivityError);
-        return {
-          success: false,
-          error: `ポスター活動の保存に失敗しました: ${posterActivityError.message}`,
-        };
+        boardId: boardId || null,
+      });
+      if (!posterResult.success) {
+        return { success: false, error: posterResult.error };
       }
 
-      // ポスター用のポイント計算とXP付与（注目ミッションは2倍）
-      const pointsPerUnit = POSTER_POINTS_PER_UNIT;
-      const basePoints = MAX_POSTER_COUNT * pointsPerUnit;
-      const totalPoints = missionData?.is_featured
-        ? basePoints * 2
-        : basePoints;
-
-      // 通常のXP（ミッション難易度ベース）に加えて、ポスターボーナスXPを付与
-      const bonusXpResult = await grantXp(
-        authUser.id,
-        totalPoints,
-        "BONUS",
-        achievement.id,
-        `ポスターボーナス（${MAX_POSTER_COUNT}枚=${totalPoints}ポイント${missionData?.is_featured ? "【2倍】" : ""}）`,
-      );
-
-      if (!bonusXpResult.success) {
-        console.error(
-          "ポスターボーナスXP付与に失敗しました:",
-          bonusXpResult.error,
-        );
-        // ボーナスXP付与の失敗はミッション達成の成功を妨げない
-      } else {
-        totalXpGranted += totalPoints;
-      }
+      totalXpGranted += await grantActivityBonusXp({
+        userId: authUser.id,
+        achievementId: achievement.id,
+        count: MAX_POSTER_COUNT,
+        pointsPerUnit: POSTER_POINTS_PER_UNIT,
+        isFeatured: missionData?.is_featured ?? false,
+        descriptionLabel: "ポスターボーナス",
+      });
     }
 
     // YouTubeいいね記録をyoutube_video_likesテーブルに保存

--- a/src/features/mission-detail/actions/artifact-helpers.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.ts
@@ -1,0 +1,254 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { grantXp } from "@/features/user-level/services/level";
+import { MAX_POSTER_COUNT } from "@/lib/constants/mission-config";
+import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
+import type { Database } from "@/lib/types/supabase";
+import type { AchieveMissionFormData } from "./actions";
+
+// buildArtifactPayload の戻り値型
+type ArtifactFields = {
+  link_url: string | null;
+  text_content: string | null;
+  image_storage_path: string | null;
+};
+
+function nullFields(): ArtifactFields {
+  return { link_url: null, text_content: null, image_storage_path: null };
+}
+
+/**
+ * artifact type ごとのペイロードフィールドビルダー
+ */
+const ARTIFACT_PAYLOAD_BUILDERS: Record<
+  string,
+  (data: AchieveMissionFormData) => ArtifactFields
+> = {
+  [ARTIFACT_TYPES.LINK.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.LINK.key)
+      return nullFields();
+    return {
+      link_url: data.artifactLink,
+      text_content: null,
+      image_storage_path: null,
+    };
+  },
+  [ARTIFACT_TYPES.TEXT.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.TEXT.key)
+      return nullFields();
+    return {
+      link_url: null,
+      text_content: data.artifactText,
+      image_storage_path: null,
+    };
+  },
+  [ARTIFACT_TYPES.EMAIL.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.EMAIL.key)
+      return nullFields();
+    return {
+      link_url: null,
+      text_content: data.artifactEmail,
+      image_storage_path: null,
+    };
+  },
+  [ARTIFACT_TYPES.IMAGE.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.IMAGE.key)
+      return nullFields();
+    return {
+      link_url: null,
+      text_content: null,
+      image_storage_path: data.artifactImagePath,
+    };
+  },
+  [ARTIFACT_TYPES.IMAGE_WITH_GEOLOCATION.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.IMAGE_WITH_GEOLOCATION.key)
+      return nullFields();
+    return {
+      link_url: null,
+      text_content: null,
+      image_storage_path: data.artifactImagePath,
+    };
+  },
+  [ARTIFACT_TYPES.POSTING.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.POSTING.key)
+      return nullFields();
+    return {
+      link_url: null,
+      text_content: `${data.postingCount}枚を${data.locationText}に配布`,
+      image_storage_path: null,
+    };
+  },
+  [ARTIFACT_TYPES.POSTER.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.POSTER.key)
+      return nullFields();
+    const locationInfo = `${data.prefecture}${data.city} ${data.boardNumber}`;
+    const nameInfo = data.boardName ? ` (${data.boardName})` : "";
+    const statusInfo = data.boardNote ? ` - 状況: ${data.boardNote}` : "";
+    return {
+      link_url: null,
+      text_content: `${locationInfo}${nameInfo}に貼付${statusInfo}`,
+      image_storage_path: null,
+    };
+  },
+  [ARTIFACT_TYPES.QUIZ.key]: () => nullFields(),
+  [ARTIFACT_TYPES.YOUTUBE.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.YOUTUBE.key)
+      return nullFields();
+    return {
+      link_url: data.artifactLink,
+      text_content: null,
+      image_storage_path: null,
+    };
+  },
+  [ARTIFACT_TYPES.YOUTUBE_COMMENT.key]: (data) => {
+    if (data.requiredArtifactType !== ARTIFACT_TYPES.YOUTUBE_COMMENT.key)
+      return nullFields();
+    return {
+      link_url: data.artifactLink,
+      text_content: null,
+      image_storage_path: null,
+    };
+  },
+};
+
+/**
+ * artifact type に基づいてペイロードフィールドをビルドする。
+ * 10分岐の if-else チェーンを置き換える。
+ */
+export function buildArtifactPayload(
+  artifactType: string,
+  validatedData: AchieveMissionFormData,
+): ArtifactFields {
+  const builder = ARTIFACT_PAYLOAD_BUILDERS[artifactType];
+  if (!builder) {
+    return nullFields();
+  }
+  return builder(validatedData);
+}
+
+/**
+ * artifact type のラベルを取得する（ログ用）。
+ */
+export function getArtifactTypeLabel(artifactType: string): string {
+  for (const type of Object.values(ARTIFACT_TYPES)) {
+    if (type.key === artifactType) {
+      return type.key;
+    }
+  }
+  return "OTHER";
+}
+
+/**
+ * POSTING / POSTER 共通のボーナスXP計算・付与。
+ * 失敗時は 0 を返す（ボーナス失敗はミッション達成の成功を妨げない）。
+ */
+export async function grantActivityBonusXp(params: {
+  userId: string;
+  achievementId: string;
+  count: number;
+  pointsPerUnit: number;
+  isFeatured: boolean;
+  descriptionLabel: string;
+}): Promise<number> {
+  const {
+    userId,
+    achievementId,
+    count,
+    pointsPerUnit,
+    isFeatured,
+    descriptionLabel,
+  } = params;
+
+  const basePoints = count * pointsPerUnit;
+  const totalPoints = isFeatured ? basePoints * 2 : basePoints;
+
+  const bonusXpResult = await grantXp(
+    userId,
+    totalPoints,
+    "BONUS",
+    achievementId,
+    `${descriptionLabel}（${count}枚=${totalPoints}ポイント${isFeatured ? "【2倍】" : ""}）`,
+  );
+
+  if (!bonusXpResult.success) {
+    console.error(
+      `${descriptionLabel}XP付与に失敗しました:`,
+      bonusXpResult.error,
+    );
+    return 0;
+  }
+
+  return totalPoints;
+}
+
+/**
+ * posting_activities テーブルにレコードを挿入する。
+ */
+export async function savePostingActivity(
+  supabase: SupabaseClient<Database>,
+  params: {
+    artifactId: string;
+    postingCount: number;
+    locationText: string;
+    shapeId: string | null;
+  },
+): Promise<{ success: boolean; error?: string }> {
+  const { error } = await supabase.from("posting_activities").insert({
+    mission_artifact_id: params.artifactId,
+    posting_count: params.postingCount,
+    location_text: params.locationText,
+    shape_id: params.shapeId,
+  });
+
+  if (error) {
+    console.error("Posting activity save error:", error);
+    return {
+      success: false,
+      error: `ポスティング活動の保存に失敗しました: ${error.message}`,
+    };
+  }
+  return { success: true };
+}
+
+/**
+ * poster_activities テーブルにレコードを挿入する。
+ */
+export async function savePosterActivity(
+  supabase: SupabaseClient<Database>,
+  params: {
+    userId: string;
+    artifactId: string;
+    prefecture: Database["public"]["Enums"]["poster_prefecture_enum"];
+    city: string;
+    boardNumber: string;
+    boardName: string | null;
+    boardNote: string | null;
+    boardAddress: string | null;
+    boardLat: number | null;
+    boardLong: number | null;
+    boardId: string | null;
+  },
+): Promise<{ success: boolean; error?: string }> {
+  const { error } = await supabase.from("poster_activities").insert({
+    user_id: params.userId,
+    mission_artifact_id: params.artifactId,
+    poster_count: MAX_POSTER_COUNT,
+    prefecture: params.prefecture,
+    city: params.city,
+    number: params.boardNumber,
+    name: params.boardName,
+    note: params.boardNote,
+    address: params.boardAddress,
+    lat: params.boardLat,
+    long: params.boardLong,
+    board_id: params.boardId,
+  });
+
+  if (error) {
+    console.error("Poster activity save error:", error);
+    return {
+      success: false,
+      error: `ポスター活動の保存に失敗しました: ${error.message}`,
+    };
+  }
+  return { success: true };
+}


### PR DESCRIPTION
## 概要

closes #1838

`achieveMissionAction`（595行）からtype別ロジックを`artifact-helpers.ts`に分離し、関数の肥大化を解消しました。

**動作変更なし**（純粋リファクタリング）

## 変更内容

### 新規: `artifact-helpers.ts`（254行）
- `buildArtifactPayload()`: 12分岐if-elseチェーン → ルックアップテーブルに置換
- `getArtifactTypeLabel()`: ログ用ラベル取得
- `grantActivityBonusXp()`: POSTING/POSTERで重複していたボーナスXP計算を共通関数化
- `savePostingActivity()`: posting_activitiesテーブルINSERT
- `savePosterActivity()`: poster_activitiesテーブルINSERT

### 変更: `actions.ts`（-199行, +112行）
- 上記ヘルパー関数の呼び出しに置換
- `AchieveMissionFormData`型をexport（ヘルパーから参照）

### 変更なし
- Zodスキーマ定義、FormData抽出、認証チェック、LINK/YouTube重複チェック、achievement作成、XP付与ロジック、`cancelSubmissionAction`

## テストプラン
- [x] `pnpm run test:unit` 60スイート 662テスト全通過
- [x] `pnpm exec tsc --noEmit` 通過
- [x] `pnpm exec biome check` 通過（upstream既存warningのみ）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ミッション達成機能の内部コード構造を最適化しました。アーティファクト関連の処理をヘルパー関数に統合し、コード管理性と保守性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->