### PR TITLE
fix: ミッション達成済みの図形の削除をブロック

### DIFF
--- a/src/features/map-posting/components/posting-page.tsx
+++ b/src/features/map-posting/components/posting-page.tsx
@@ -428,6 +428,17 @@ export default function PostingPageClient({
               if (missionStatus.isCompleted) {
                 toast.error(
                   "ミッション達成済みの図形は削除できません。先にミッション提出を取り消してください。",
+                  {
+                    action: {
+                      label: "取り消しページへ",
+                      onClick: () =>
+                        window.open(
+                          "/missions/posting-activity-magazine",
+                          "_blank",
+                          "noopener,noreferrer",
+                        ),
+                    },
+                  },
                 );
                 layer.addTo(mapInstance);
                 return;

--- a/src/features/map-posting/components/shape-status-dialog.tsx
+++ b/src/features/map-posting/components/shape-status-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -171,11 +172,24 @@ export function ShapeStatusDialog({
 
     // ミッション達成済み、またはミッション状況取得失敗時は削除をブロック
     if (isMissionCompleted || isMissionStatusError) {
-      toast.error(
-        isMissionStatusError
-          ? "ミッション状況の確認に失敗しました。削除を中止します。"
-          : "ミッション達成済みの図形は削除できません。先にミッション提出を取り消してください。",
-      );
+      if (isMissionStatusError) {
+        toast.error("ミッション状況の確認に失敗しました。削除を中止します。");
+      } else {
+        toast.error(
+          "ミッション達成済みの図形は削除できません。先にミッション提出を取り消してください。",
+          {
+            action: {
+              label: "取り消しページへ",
+              onClick: () =>
+                window.open(
+                  "/missions/posting-activity-magazine",
+                  "_blank",
+                  "noopener,noreferrer",
+                ),
+            },
+          },
+        );
+      }
       return;
     }
 
@@ -210,7 +224,16 @@ export function ShapeStatusDialog({
                 : "この図形は他のユーザーが作成したため、変更できません"}
             {isOwner && isMissionCompleted && (
               <span className="mt-1 block text-green-600">
-                ミッション達成済み
+                ミッション達成済み（
+                <Link
+                  href="/missions/posting-activity-magazine"
+                  className="underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  取り消しはこちら
+                </Link>
+                ）
               </span>
             )}
             {isAdmin && !isOwner && isEventActive && (


### PR DESCRIPTION
## Summary
- Closes #1718
- ポスティングミッション達成済みの図形を削除しようとした場合、エラーメッセージを表示して削除をブロックするようにしました
- XPが取り消されないまま図形が削除され、再度描画→達成を繰り返すことでXPが無限増殖できる問題への対策です

## 原因
図形削除時（`deleteShape`）にXP取り消し処理がなく、FKも`ON DELETE SET NULL`のため、`posting_activities`のレコードとXPがそのまま残っていました。

## 修正方針
ミッション達成済みの図形は削除をブロックし、「先にミッション提出を取り消してください」と案内する方式を採用しました。

**他の方針も検討しましたが不採用としました：**
| 方針 | 内容 | 不採用理由 |
|------|------|------------|
| A: 図形削除時にXP減算 | 削除→XP計算→減算の新フロー | 複雑、トランザクション整合性リスク |
| C: 図形削除時にachievementも自動キャンセル | cancelSubmissionAction相当を自動実行 | Server Action連鎖が複雑、エッジケース多い |

## 変更箇所（2ファイル）

### 1. `posting-page.tsx` - マップ上の図形削除（`pm:remove`イベント）
- 削除確認ダイアログの前に `getShapeMissionStatus()` でミッション達成状況をチェック
- 達成済みならtoastエラーを表示し、レイヤーをマップに復元

### 2. `shape-status-dialog.tsx` - ダイアログからの図形削除
- 既存の `isMissionCompleted` ステート（ダイアログ表示時に取得済み）を利用してチェック
- 達成済みならtoastエラーを表示し、削除を中止

## Test plan
- [ ] ミッション未達成の図形が通常通り削除できることを確認
- [ ] ミッション達成済みの図形をマップ上で削除しようとするとエラーメッセージが表示され、図形が復元されることを確認
- [ ] ミッション達成済みの図形をダイアログから削除しようとするとエラーメッセージが表示されることを確認
- [ ] ミッション取り消し後は図形が削除できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ミッション完了済みの図形が誤って削除されるのを防止する安全装置を強化しました。完了した図形を削除しようとするとエラー通知が表示され、削除は中止されます。
  * ミッション状態の取得に失敗した場合も削除をブロックし、取得失敗用のエラー通知が表示されます。

* **ユーザーインターフェース**
  * 所有者が完了済みの図形を表示する際、取り消しページへ移動するリンク（「取り消しはこちら」）をステータス表示に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->