### PR TITLE
fix: Supabase Image Transformationを無効化 (#1555)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,11 @@ const nextConfig: NextConfig = {
         hostname: "i.ytimg.com",
         pathname: "/vi/**",
       },
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/**",
+      },
     ],
   },
 };

--- a/src/features/mission-detail/services/mission-detail.ts
+++ b/src/features/mission-detail/services/mission-detail.ts
@@ -209,13 +209,7 @@ export async function getSubmissionHistory(
             if (artifact.image_storage_path) {
               const { data: signedUrlData } = await supabase.storage
                 .from("mission_artifact_files")
-                .createSignedUrl(artifact.image_storage_path, 60, {
-                  transform: {
-                    width: 240,
-                    height: 240,
-                    resize: "contain",
-                  },
-                });
+                .createSignedUrl(artifact.image_storage_path, 60);
 
               if (signedUrlData) {
                 return {

--- a/src/lib/services/avatar.ts
+++ b/src/lib/services/avatar.ts
@@ -5,12 +5,6 @@ export const AVATAR_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 export function getAvatarUrl(avatarPath: string): string {
   if (!avatarPath) return "";
   const client = createClient();
-  const { data } = client.storage.from("avatars").getPublicUrl(avatarPath, {
-    transform: {
-      width: 240,
-      height: 240,
-      resize: "cover",
-    },
-  });
+  const { data } = client.storage.from("avatars").getPublicUrl(avatarPath);
   return data.publicUrl;
 }


### PR DESCRIPTION
## Summary
- Supabase Image TransformationがUsage上限を超過して動作していないため、`transform`オプションを削除
- `avatar.ts`のアバター画像取得と`mission-detail.ts`のミッション成果物画像取得の2箇所から`transform`パラメータを削除
- 将来のNext.js `<Image>`移行に備え、`next.config.ts`にSupabase Storageドメインを`remotePatterns`に追加

## 変更箇所
| ファイル | 変更内容 |
|---|---|
| `src/lib/services/avatar.ts` | `getPublicUrl`の`transform`オプション削除 |
| `src/features/mission-detail/services/mission-detail.ts` | `createSignedUrl`の`transform`オプション削除 |
| `next.config.ts` | `remotePatterns`にSupabase Storageドメイン追加 |

## 備考
- 表示サイズはCSS（`w-8`〜`w-32`、`w-24 h-24 object-cover`等）で制御済みのため、transform削除による表示崩れなし
- ミッション成果物画像はSigned URL（60秒有効期限）のためNext.js Imageとの互換性がなく、`<img>`タグのまま維持
- アバター表示コンポーネントのNext.js `<Image>`への切り替えは、Radix UI Avatarのfallback機構との整合が必要なため、別PRで対応可能

Closes #1555

## Test plan
- [x] `pnpm run test:unit` — 662 tests all passed
- [x] `pnpm exec tsc --noEmit` — no errors
- [x] `pnpm exec biome check` — no new errors (既存の警告のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **インフラストラクチャ**
  * Supabaseストレージからの画像に対応しました
  * 成果物とアバター画像の表示形式を更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->