### PR TITLE
fix: TikTok同期で再認証が必要なエラーをスキップ扱いにする

### DIFF
--- a/packages/tiktok_data/src/tiktok-client.ts
+++ b/packages/tiktok_data/src/tiktok-client.ts
@@ -126,6 +126,20 @@ export async function fetchVideoList(
   if (!response.ok) {
     const errorText = await response.text();
     console.error("TikTok video list fetch failed:", errorText);
+
+    // レスポンスボディからエラーコードを抽出
+    try {
+      const errorJson = JSON.parse(errorText);
+      if (errorJson.error?.code) {
+        throw new TikTokAPIError(
+          errorJson.error.message || "TikTok動画一覧の取得に失敗しました",
+          errorJson.error.code,
+          errorJson.error.log_id,
+        );
+      }
+    } catch (parseError) {
+      // JSONパースに失敗した場合は無視
+    }
     throw new TikTokAPIError("TikTok動画一覧の取得に失敗しました");
   }
 

--- a/packages/tiktok_data/src/types.ts
+++ b/packages/tiktok_data/src/types.ts
@@ -90,11 +90,13 @@ export interface SyncResult {
   totalUsers: number;
   successfulSyncs: number;
   failedSyncs: number;
+  skippedSyncs: number;
   newVideos: number;
   updatedVideos: number;
   statsRecorded: number;
   tokensRefreshed: number;
   errors: string[];
+  warnings: string[];
 }
 
 // ユーザーごとの同期結果


### PR DESCRIPTION
scope_not_authorizedなどの再認証が必要なエラーが発生した場合、
ワークフロー全体を失敗させずにスキップとして扱うように変更。

- SyncResultにskippedSyncsとwarningsを追加
- 再認証が必要なエラーコードを定義（scope_not_authorized等）
- HTTPエラー時もJSONレスポンスからエラーコードを抽出

Resolves #1909

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * TikTokデータ同期時の認証エラーハンドリングを強化
  * API エラーの詳細情報（エラーコードとログID）を抽出し、より詳細なエラー報告を提供
  * 同期結果で「スキップ」と「失敗」を区別し、スキップされたユーザーを追跡可能に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->