### PR TITLE
fix: TikTokAPIErrorがcatchブロックで握りつぶされるバグを修正

### DIFF
--- a/packages/tiktok_data/src/tiktok-client.ts
+++ b/packages/tiktok_data/src/tiktok-client.ts
@@ -128,19 +128,23 @@ export async function fetchVideoList(
     console.error("TikTok video list fetch failed:", errorText);
 
     // レスポンスボディからエラーコードを抽出
+    let errorCode: string | undefined;
+    let errorMessage: string | undefined;
+    let logId: string | undefined;
     try {
       const errorJson = JSON.parse(errorText);
-      if (errorJson.error?.code) {
-        throw new TikTokAPIError(
-          errorJson.error.message || "TikTok動画一覧の取得に失敗しました",
-          errorJson.error.code,
-          errorJson.error.log_id,
-        );
-      }
-    } catch (parseError) {
-      // JSONパースに失敗した場合は無視
+      errorCode = errorJson.error?.code;
+      errorMessage = errorJson.error?.message;
+      logId = errorJson.error?.log_id;
+    } catch {
+      console.warn("Failed to parse error response as JSON");
     }
-    throw new TikTokAPIError("TikTok動画一覧の取得に失敗しました");
+
+    throw new TikTokAPIError(
+      errorMessage || "TikTok動画一覧の取得に失敗しました",
+      errorCode,
+      logId,
+    );
   }
 
   const data: TikTokVideoListResponse = await response.json();


### PR DESCRIPTION
# 変更の概要
- JSON.parseのtry-catch内でスローしたTikTokAPIErrorがcatchブロックでキャッチされて無視されていた問題を修正
- エラー情報を変数に抽出してからthrowするようリファクタリング
- JSONパース失敗時にログを出力するよう改善

# 変更の背景
- TikTok同期で`scope_not_authorized`エラーが発生した際、エラーコードが`undefined`になり、スキップ扱いにならない問題があった
- #1920 で追加したエラーコード抽出ロジックにバグがあり、TikTokAPIErrorがcatchブロックで握りつぶされていた

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * API通信エラー発生時に、エラーコード、メッセージ、ログIDなどの詳細情報がより正確に取得・表示されるようになりました。これにより、問題発生時のトラブルシューティングが容易になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->