### PR TITLE
fix: YouTube連携設定ページのスマホ表示崩れを修正

### DIFF
--- a/src/app/(protected)/settings/youtube/page.tsx
+++ b/src/app/(protected)/settings/youtube/page.tsx
@@ -22,7 +22,7 @@ export default async function YouTubeSettingsPage({
   const linkStatus = await getYouTubeLinkStatusAction();
 
   return (
-    <div className="max-w-2xl mx-auto py-6 px-4">
+    <div className="w-full max-w-2xl mx-auto py-6 px-4">
       <h1 className="text-2xl font-bold text-gray-900 mb-6">YouTube連携設定</h1>
 
       {justLinked && (

--- a/src/app/(protected)/settings/youtube/youtube-settings-content.tsx
+++ b/src/app/(protected)/settings/youtube/youtube-settings-content.tsx
@@ -41,9 +41,9 @@ export function YouTubeSettingsContent({
   };
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 overflow-hidden">
       {/* 連携状態セクション */}
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <section className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6 overflow-hidden">
         <h2 className="text-lg font-semibold text-gray-900 mb-4">
           アカウント連携
         </h2>
@@ -69,14 +69,16 @@ export function YouTubeSettingsContent({
 
       {/* 動画/いいね/コメントタブセクション（連携済みの場合のみ表示） */}
       {isLinked && (
-        <section className="bg-white rounded-lg border border-gray-200 p-6">
+        <section className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6 overflow-hidden">
           <Tabs defaultValue={defaultTab} className="w-full">
-            <div className="flex items-center justify-between mb-4">
-              <TabsList>
-                <TabsTrigger value="likes">いいね</TabsTrigger>
-                <TabsTrigger value="comments">コメント</TabsTrigger>
-                <TabsTrigger value="videos">アップロード</TabsTrigger>
-              </TabsList>
+            <div className="space-y-3 mb-4">
+              <div className="w-full overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+                <TabsList>
+                  <TabsTrigger value="likes">いいね</TabsTrigger>
+                  <TabsTrigger value="comments">コメント</TabsTrigger>
+                  <TabsTrigger value="videos">アップロード</TabsTrigger>
+                </TabsList>
+              </div>
               <YouTubeSyncButton onSyncComplete={handleSyncComplete} />
             </div>
 

--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
       <div className="relative w-full bg-linear-to-b from-[#A4F1C9] to-[#D1F6DF] overflow-hidden">
         <div className="relative h-[280px]">
           <div className="absolute bottom-0 left-0 right-0 w-full flex justify-center">
-            <div className="relative w-[756px] min-w-[756px] h-[392px]">
+            <div className="relative w-full max-w-[756px] h-[392px]">
               <Image
                 src="/img/hero-background.svg"
                 alt="街並みと雲のイラスト"
@@ -26,7 +26,7 @@ export default function Footer() {
           </div>
 
           <div className="absolute bottom-0 left-0 right-0 w-full flex justify-center z-10">
-            <div className="relative w-[756px] h-[157px]">
+            <div className="relative w-full max-w-[756px] h-[157px]">
               <Image
                 src="/img/hero-people.svg"
                 alt="チームみらいの仲間たち"

--- a/src/features/youtube/components/youtube-sync-button.tsx
+++ b/src/features/youtube/components/youtube-sync-button.tsx
@@ -115,7 +115,7 @@ export function YouTubeSyncButton({
   };
 
   return (
-    <div className="flex flex-col items-end gap-1">
+    <div className="flex flex-col items-start gap-1">
       <Button
         onClick={handleSync}
         disabled={isLoading || disabled}


### PR DESCRIPTION
# 変更の概要
- YouTube連携設定ページ（/settings/youtube）のスマホ表示で横にはみ出す問題を修正
- page.tsxに`w-full`を追加してコンテナ幅を親要素に制限
- セクションに`overflow-hidden`とレスポンシブパディング（`p-4 sm:p-6`）を追加
- タブリストを横スクロール可能な`div`でラップしてはみ出しを防止
- フッターの固定幅（756px）を`max-w-[756px] w-full`に変更して全ページ共通のはみ出しを防止
- 同期ボタンを左揃えに変更

# 変更の背景
- iPhone SE等の小さい画面でYouTube連携設定ページを開くと、タブやコンテンツが横にはみ出して表示が崩れていた
- 原因はTabsListの`inline-flex`と親コンテナの`max-w-2xl`だけでは内部コンテンツが幅を押し広げていたこと
- フッターの756px固定幅も全ページに影響していた

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル

* YouTubeプロフィール設定ページのタブセクションレイアウトが改善され、水平スクロール対応になりました
* フッターのレスポンシブデザインが向上し、様々な画面サイズでコンテンツが正しく表示されるようになりました
* ページ全体のレイアウトとオーバーフロー処理が最適化されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->