### PR TITLE
feat: YouTube CI workflowをjob分割して個別再実行可能に

### DIFF
--- a/.github/workflows/sync-youtube-videos-production.yml
+++ b/.github/workflows/sync-youtube-videos-production.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  sync-youtube-videos:
+  sync-videos:
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -17,34 +17,79 @@ jobs:
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       APP_URL: ${{ secrets.APP_URL }}
       BATCH_ADMIN_KEY: ${{ secrets.BATCH_ADMIN_KEY }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "pnpm"
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Sync YouTube videos
         run: pnpm youtube:sync-videos
 
+  sync-likes:
+    needs: sync-videos
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      APP_URL: ${{ secrets.APP_URL }}
+      BATCH_ADMIN_KEY: ${{ secrets.BATCH_ADMIN_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Sync YouTube likes
         run: pnpm youtube:sync-likes
 
+  sync-comments:
+    needs: sync-likes
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      APP_URL: ${{ secrets.APP_URL }}
+      BATCH_ADMIN_KEY: ${{ secrets.BATCH_ADMIN_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Sync YouTube comments
         run: pnpm youtube:sync-comments
 
-      - name: Notify on failure
-        if: failure()
+  notify-failure:
+    needs: [sync-videos, sync-likes, sync-comments]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue on failure
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
# 変更の概要
- YouTube CI workflowを3つの独立したjobに分割
  - `sync-videos` → `sync-likes` → `sync-comments`
- これにより、GitHub Actionsの「Re-run failed jobs」で失敗したjobのみ再実行可能に
- 失敗通知を独立したjob (`notify-failure`) として分離

# 変更の背景
- YouTube CIは実行に約2時間かかる
- likeは成功してcommentのsyncだけ失敗するケースで、全体を再実行せずにcommentのsyncだけ再実行したい

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このリリースには、ユーザー向けの変更はありません。本プルリクエストは、内部の継続的インテグレーション・ワークフローの改善に関するもので、アプリケーションの機能や動作には影響しません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->