### PR TITLE
ブラウザバック時にレベルアップモーダルが繰り返し出てしまう不具合を修正

### DIFF
--- a/src/features/user-level/actions/level-up.ts
+++ b/src/features/user-level/actions/level-up.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { markLevelUpNotificationAsSeen } from "@/features/user-level/services/level-up-notification";
 import { getUser } from "@/features/user-profile/services/profile";
 
@@ -13,7 +14,11 @@ export async function markLevelUpSeenAction(): Promise<{
       return { success: false, error: "認証が必要です" };
     }
 
-    return await markLevelUpNotificationAsSeen(user.id);
+    const result = await markLevelUpNotificationAsSeen(user.id);
+    if (result.success) {
+      revalidatePath("/");
+    }
+    return result;
   } catch (error) {
     console.error("Error in markLevelUpSeenAction:", error);
     return { success: false, error: "予期しないエラーが発生しました" };


### PR DESCRIPTION
# 変更の概要
- レベルアップ後にトップページ<->別ページ間をブラウザバックで遷移すると、レベルアップモーダルが繰り返し表示される不具合を修正しました
  - [Client-side Router Cache](https://nextjs.org/docs/app/guides/caching#client-side-router-cache) が原因なので、レベルアップ通知の状態を更新する処理が成功したら、トップページのキャッシュを invalidate しました 

# 変更の背景
- closes https://github.com/team-mirai-volunteer/action-board/issues/1926

# スクリーンショット
## before
https://github.com/user-attachments/assets/5ffc004e-0ada-4e55-b595-035b0eaf5cd9

## after
https://github.com/user-attachments/assets/57bab1f8-c6e6-4796-9551-a0ffb363d1aa



- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * レベルアップ通知を確認した後、アプリケーションのデータが適切に更新されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->