### PR TITLE
fix: 貢献度の小数点表示を動的に調整

### DIFF
--- a/src/features/prefecture-team/components/prefecture-team-user-card-content.tsx
+++ b/src/features/prefecture-team/components/prefecture-team-user-card-content.tsx
@@ -11,6 +11,12 @@ function getPrefectureInternalLabel(prefecture: string): string {
   return "県内";
 }
 
+function formatContributionPercent(percent: number): string {
+  if (percent >= 0.1) return percent.toFixed(1);
+  if (percent >= 0.01) return percent.toFixed(2);
+  return percent.toFixed(3);
+}
+
 interface PrefectureTeamUserCardContentProps {
   prefectureRanking: PrefectureTeamRanking;
   userContribution: UserPrefectureContribution;
@@ -54,7 +60,8 @@ export function PrefectureTeamUserCardContent({
           <div className="flex items-center gap-2">
             <TrendingUp className="w-4 h-4 text-teal-500" />
             <span className="text-sm font-bold">
-              貢献度 {userContribution.contributionPercent.toFixed(1)}%
+              貢献度{" "}
+              {formatContributionPercent(userContribution.contributionPercent)}%
             </span>
           </div>
         </div>


### PR DESCRIPTION
# 変更の概要
- 都道府県チームパワーの貢献度表示で、小数点以下の桁数を値に応じて動的に調整
  - 0.1以上: 小数点第1位まで（例: 3.5%）
  - 0.01以上: 小数点第2位まで（例: 0.05%）
  - 0.01未満: 小数点第3位まで（例: 0.005%）

# 変更の背景
- 貢献度が0.05%などの小さな値の場合、`toFixed(1)`では`0.0%`と表示されてしまう問題を修正

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * チーム貢献度のパーセンテージ表示の精度を向上。パーセンテージの値に応じて、より正確な小数点精度で表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->