### PR TITLE
chore: create_pr コマンドの --ff-only を --rebase に変更

### DIFF
--- a/.claude/commands/create_pr.md
+++ b/.claude/commands/create_pr.md
@@ -36,13 +36,13 @@ git log origin/develop..HEAD --oneline
 git add -A
 git commit -m "wip: temporary"
 git checkout develop
-git pull --ff-only origin develop
+git pull --rebase origin develop
 git checkout -b <新しいブランチ名>
 git cherry-pick <wipコミット>
 
 # すでにコミットがある場合
 git checkout develop
-git pull --ff-only origin develop
+git pull --rebase origin develop
 git checkout -b <新しいブランチ名>
 git cherry-pick <コミット範囲>
 ```
@@ -69,7 +69,7 @@ git checkout -b <新しいブランチ名>
 もし `develop` / `main` で **未コミットの変更が無い** 場合は、先に最新化してからブランチを作成する：
 
 ```bash
-git pull --ff-only origin <develop または main>
+git pull --rebase origin <develop または main>
 git checkout -b <新しいブランチ名>
 ```
 


### PR DESCRIPTION
# 変更の概要
- `create_pr` コマンドで `git pull --ff-only` を `git pull --rebase` に変更
- divergeしたブランチでも同期できるように改善

# 変更の背景
- `--ff-only` ではブランチが分岐している場合にエラーになる問題があった
- `--rebase` を使うことで自動的にリベースして同期できるようになる

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました