### PR TITLE
fix: 貢献度のパーセンテージ表示を修正

### DIFF
--- a/src/features/prefecture-team/components/prefecture-team-user-card-content.tsx
+++ b/src/features/prefecture-team/components/prefecture-team-user-card-content.tsx
@@ -3,18 +3,13 @@ import type {
   PrefectureTeamRanking,
   UserPrefectureContribution,
 } from "../types/prefecture-team-types";
+import { formatContributionPercent } from "../utils/format-contribution-percent";
 
 function getPrefectureInternalLabel(prefecture: string): string {
   if (prefecture === "東京都") return "都内";
   if (prefecture === "北海道") return "道内";
   if (prefecture.endsWith("府")) return "府内";
   return "県内";
-}
-
-function formatContributionPercent(percent: number): string {
-  if (percent >= 0.1) return percent.toFixed(1);
-  if (percent >= 0.01) return percent.toFixed(2);
-  return percent.toFixed(3);
 }
 
 interface PrefectureTeamUserCardContentProps {

--- a/src/features/prefecture-team/services/get-prefecture-team-ranking.ts
+++ b/src/features/prefecture-team/services/get-prefecture-team-ranking.ts
@@ -117,9 +117,7 @@ export async function getUserPrefectureContribution(
 
     const contributionPercent =
       contribution.prefecture_total_xp > 0
-        ? Math.round(
-            (contribution.user_xp / contribution.prefecture_total_xp) * 1000,
-          ) / 10
+        ? (contribution.user_xp / contribution.prefecture_total_xp) * 100
         : 0;
 
     return {

--- a/src/features/prefecture-team/utils/format-contribution-percent.test.ts
+++ b/src/features/prefecture-team/utils/format-contribution-percent.test.ts
@@ -1,0 +1,63 @@
+import { formatContributionPercent } from "./format-contribution-percent";
+
+describe("formatContributionPercent", () => {
+  describe("0の場合", () => {
+    it("0を返す", () => {
+      expect(formatContributionPercent(0)).toBe("0");
+    });
+  });
+
+  describe("0.1以上の場合", () => {
+    it("小数点第1位までフォーマットする", () => {
+      expect(formatContributionPercent(0.1)).toBe("0.1");
+      expect(formatContributionPercent(0.15)).toBe("0.1"); // 切り捨て
+      expect(formatContributionPercent(0.16)).toBe("0.2"); // 四捨五入
+      expect(formatContributionPercent(1.5)).toBe("1.5");
+      expect(formatContributionPercent(10.25)).toBe("10.3");
+      expect(formatContributionPercent(100)).toBe("100.0");
+    });
+  });
+
+  describe("0.01以上0.1未満の場合", () => {
+    it("小数点第2位までフォーマットする", () => {
+      expect(formatContributionPercent(0.01)).toBe("0.01");
+      expect(formatContributionPercent(0.05)).toBe("0.05");
+      expect(formatContributionPercent(0.099)).toBe("0.10");
+      expect(formatContributionPercent(0.0479)).toBe("0.05");
+    });
+  });
+
+  describe("0.001以上0.01未満の場合", () => {
+    it("小数点第3位までフォーマットする", () => {
+      expect(formatContributionPercent(0.001)).toBe("0.001");
+      expect(formatContributionPercent(0.005)).toBe("0.005");
+      expect(formatContributionPercent(0.0099)).toBe("0.010");
+    });
+  });
+
+  describe("0.001未満の場合", () => {
+    it("有効数字が出るまで桁数を増やす", () => {
+      expect(formatContributionPercent(0.0001)).toBe("0.0001");
+      expect(formatContributionPercent(0.00005)).toBe("0.00005");
+      expect(formatContributionPercent(0.00001)).toBe("0.00001");
+      expect(formatContributionPercent(0.000001)).toBe("0.000001");
+    });
+
+    it("極小値の場合は < 0.000001 を返す", () => {
+      expect(formatContributionPercent(0.0000001)).toBe("< 0.000001");
+      expect(formatContributionPercent(0.00000001)).toBe("< 0.000001");
+    });
+  });
+
+  describe("実際のユースケース", () => {
+    it("東京都での貢献度 (7150 / 14925900 * 100)", () => {
+      const percent = (7150 / 14925900) * 100;
+      expect(formatContributionPercent(percent)).toBe("0.05");
+    });
+
+    it("小規模県での高貢献度", () => {
+      const percent = (10000 / 100000) * 100;
+      expect(formatContributionPercent(percent)).toBe("10.0");
+    });
+  });
+});

--- a/src/features/prefecture-team/utils/format-contribution-percent.ts
+++ b/src/features/prefecture-team/utils/format-contribution-percent.ts
@@ -1,0 +1,17 @@
+/**
+ * 貢献度のパーセンテージを適切な小数点桁数でフォーマットする
+ * - 0.1以上: 小数点第1位
+ * - 0.01以上: 小数点第2位
+ * - 0.001以上: 小数点第3位
+ * - 0.001未満: 有効数字が出るまで桁数を増やす（最大6桁）
+ */
+export function formatContributionPercent(percent: number): string {
+  if (percent === 0) return "0";
+  if (percent >= 0.1) return percent.toFixed(1);
+  if (percent >= 0.01) return percent.toFixed(2);
+  if (percent >= 0.001) return percent.toFixed(3);
+  if (percent >= 0.0001) return percent.toFixed(4);
+  if (percent >= 0.00001) return percent.toFixed(5);
+  if (percent >= 0.000001) return percent.toFixed(6);
+  return "< 0.000001";
+}


### PR DESCRIPTION
# 変更の概要
- 貢献度のパーセンテージ計算で `Math.round` による丸め処理を削除し、生の値を保持
- `formatContributionPercent` 関数をユーティリティに切り出し
- 値の大きさに応じて適切な小数点桁数で表示
  - 0.1以上: 小数点第1位
  - 0.01以上: 小数点第2位
  - 0.001以上: 小数点第3位
  - 以下、0.000001まで対応
- ユニットテストを追加

# 変更の背景
- 貢献度が0.05%などの小さな値の場合、`Math.round` で0になってしまう問題を修正
- 例: 東京都で 7150 / 14925900 * 100 = 0.0479% → 以前は 0% と表示されていた

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
  * ユーザーの貢献率の計算結果がより正確に改善されました。

## テスト
  * 貢献率のフォーマット処理に関する包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->