### PR TITLE
fix: YouTubeコメント同期で非致命的エラーを警告として扱う

### DIFF
--- a/src/features/youtube/services/youtube-client.ts
+++ b/src/features/youtube/services/youtube-client.ts
@@ -484,16 +484,21 @@ export async function fetchVideoComments(
 
     if (!response.ok) {
       const errorBody = await response.text();
-      // コメントが無効化されている動画などはエラーになるので、空配列を返す
-      if (response.status === 403) {
-        console.log(`Comments disabled for video ${videoId}`);
+      // コメントが無効化されている動画(403)、削除された動画(404)などは空配列を返す
+      if (response.status === 403 || response.status === 404) {
+        console.log(
+          `Comments unavailable for video ${videoId} (status: ${response.status})`,
+        );
         return [];
       }
       console.error(
         `YouTube comments fetch failed for video ${videoId}:`,
         errorBody,
       );
-      throw new YouTubeAPIError("コメントの取得に失敗しました");
+      throw new YouTubeAPIError(
+        "コメントの取得に失敗しました",
+        response.status,
+      );
     }
 
     const data = await response.json();


### PR DESCRIPTION
# 変更の概要
- YouTubeコメント同期スクリプトのエラー処理を改善
- エラーを「警告（warnings）」と「致命的エラー（fatalErrors）」に分類
- コメント取得失敗（コメントが無効な動画など）は警告として扱う
- 致命的エラー（ミッション未発見、コメント記録失敗など）のみでCIを失敗させる

# 変更の背景
- コメントが無効になっている動画でコメント取得に失敗すると、CIがfailureになっていた
- これらのエラーは正常な動作であり、他の処理には影響しないため、successとすべき
- 参考: https://github.com/team-mirai-volunteer/action-board/actions/runs/21635769655/job/62427355768

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * エラーハンドリングを改善し、非致命的な警告（例：特定のYouTube取得失敗や動画非公開/削除）と致命的なエラー（例：重要な処理失敗）を明確に区別するようになりました。
  * 非致命的な問題は警告として記録して処理を継続し、致命的な問題がある場合のみプロセスを終了（終了コード1）します。
  * YouTubeコメント取得時のステータス別の扱いとログ表現を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->