### PR TITLE
test: add unit tests for pure utility functions (#1965)

### DIFF
--- a/src/features/map-poster/utils/poster-progress.test.ts
+++ b/src/features/map-poster/utils/poster-progress.test.ts
@@ -1,0 +1,104 @@
+import type { BoardStatus } from "../types/poster-types";
+import {
+  calculateProgressRate,
+  getCompletedCount,
+  getRegisteredCount,
+} from "./poster-progress";
+
+// テスト用のステータス別カウントを作成するヘルパー
+function createStatusCounts(
+  overrides: Partial<Record<BoardStatus, number>> = {},
+): Record<BoardStatus, number> {
+  return {
+    not_yet: 0,
+    reserved: 0,
+    done: 0,
+    error_wrong_place: 0,
+    error_damaged: 0,
+    error_wrong_poster: 0,
+    other: 0,
+    not_yet_dangerous: 0,
+    ...overrides,
+  };
+}
+
+describe("calculateProgressRate", () => {
+  it("正常な進捗率を計算する", () => {
+    expect(calculateProgressRate(50, 100)).toBe(50);
+  });
+
+  it("完了数0の場合は0を返す", () => {
+    expect(calculateProgressRate(0, 100)).toBe(0);
+  });
+
+  it("全て完了の場合は100を返す", () => {
+    expect(calculateProgressRate(100, 100)).toBe(100);
+  });
+
+  it("登録数0の場合は0を返す（ゼロ除算回避）", () => {
+    expect(calculateProgressRate(0, 0)).toBe(0);
+  });
+
+  it("小数点以下を切り捨てる", () => {
+    expect(calculateProgressRate(1, 3)).toBe(33); // 33.33... → 33
+    expect(calculateProgressRate(2, 3)).toBe(66); // 66.66... → 66
+  });
+});
+
+describe("getCompletedCount", () => {
+  it("doneステータスの数を返す", () => {
+    const counts = createStatusCounts({ done: 42 });
+    expect(getCompletedCount(counts)).toBe(42);
+  });
+
+  it("doneが0の場合は0を返す", () => {
+    const counts = createStatusCounts({ not_yet: 10, reserved: 5 });
+    expect(getCompletedCount(counts)).toBe(0);
+  });
+});
+
+describe("getRegisteredCount", () => {
+  it("全ステータスの合計を返す（error_wrong_poster除く）", () => {
+    const counts = createStatusCounts({
+      not_yet: 10,
+      reserved: 5,
+      done: 20,
+    });
+    expect(getRegisteredCount(counts)).toBe(35);
+  });
+
+  it("error_wrong_posterは分母から除外される", () => {
+    const counts = createStatusCounts({
+      not_yet: 10,
+      done: 20,
+      error_wrong_poster: 5,
+    });
+    // 10 + 20 = 30（error_wrong_posterの5は含まない）
+    expect(getRegisteredCount(counts)).toBe(30);
+  });
+
+  it("全て0の場合は0を返す", () => {
+    const counts = createStatusCounts();
+    expect(getRegisteredCount(counts)).toBe(0);
+  });
+
+  it("error_wrong_posterだけの場合は0を返す", () => {
+    const counts = createStatusCounts({ error_wrong_poster: 10 });
+    expect(getRegisteredCount(counts)).toBe(0);
+  });
+
+  it("全ステータスが混在するケース", () => {
+    const counts = createStatusCounts({
+      not_yet: 100,
+      reserved: 20,
+      done: 50,
+      error_wrong_place: 3,
+      error_damaged: 2,
+      error_wrong_poster: 15,
+      other: 1,
+      not_yet_dangerous: 5,
+    });
+    // 100 + 20 + 50 + 3 + 2 + 1 + 5 = 181（error_wrong_posterの15は除外）
+    expect(getRegisteredCount(counts)).toBe(181);
+  });
+});

--- a/src/features/prefecture-team/utils/color-scale.test.ts
+++ b/src/features/prefecture-team/utils/color-scale.test.ts
@@ -1,0 +1,78 @@
+import { getColorForRank, LEGEND_COLORS, NO_DATA_COLOR } from "./color-scale";
+
+describe("getColorForRank", () => {
+  describe("有効な順位の場合", () => {
+    it("1位は最も濃い青を返す", () => {
+      expect(getColorForRank(1)).toBe("#08306b");
+    });
+
+    it("47位は最も薄い青を返す", () => {
+      expect(getColorForRank(47)).toBe("#f7fbff");
+    });
+
+    it("中間の順位はグラデーションの中間色を返す", () => {
+      const color25 = getColorForRank(25);
+      expect(color25).toBe("#6baed6");
+    });
+
+    it("順位が上がるほど濃い色になる", () => {
+      const color1 = getColorForRank(1);
+      const color47 = getColorForRank(47);
+      // 1位の色コードは47位より小さい値（濃い青）
+      expect(color1).not.toBe(color47);
+    });
+  });
+
+  describe("境界値の場合", () => {
+    // index = floor(((rank-1) / 47) * 9) なので、グループ境界は rank 7 付近
+    it("6位はまだ最初のグループ", () => {
+      expect(getColorForRank(6)).toBe("#08306b");
+    });
+
+    it("7位で次のグループに移る", () => {
+      expect(getColorForRank(7)).toBe("#08519c");
+    });
+  });
+
+  describe("無効な順位の場合", () => {
+    it("0以下はグレーを返す", () => {
+      expect(getColorForRank(0)).toBe("#e5e7eb");
+      expect(getColorForRank(-1)).toBe("#e5e7eb");
+    });
+
+    it("48以上はグレーを返す", () => {
+      expect(getColorForRank(48)).toBe("#e5e7eb");
+      expect(getColorForRank(100)).toBe("#e5e7eb");
+    });
+  });
+});
+
+describe("NO_DATA_COLOR", () => {
+  it("グレー色が定義されている", () => {
+    expect(NO_DATA_COLOR).toBe("#e5e7eb");
+  });
+
+  it("無効な順位の戻り値と一致する", () => {
+    expect(getColorForRank(0)).toBe(NO_DATA_COLOR);
+  });
+});
+
+describe("LEGEND_COLORS", () => {
+  it("9個の色が定義されている", () => {
+    expect(LEGEND_COLORS).toHaveLength(9);
+  });
+
+  it("最初の色にラベルがある", () => {
+    expect(LEGEND_COLORS[0].label).toBe("1位〜");
+  });
+
+  it("最後の色にラベルがある", () => {
+    const last = LEGEND_COLORS[LEGEND_COLORS.length - 1];
+    expect(last.label).toMatch(/\d+位〜/);
+  });
+
+  it("中間の色はラベルが空文字", () => {
+    expect(LEGEND_COLORS[1].label).toBe("");
+    expect(LEGEND_COLORS[4].label).toBe("");
+  });
+});

--- a/src/lib/utils/admin.test.ts
+++ b/src/lib/utils/admin.test.ts
@@ -1,0 +1,92 @@
+import type { User } from "@supabase/supabase-js";
+import { isAdmin, isPostingAdmin } from "./admin";
+
+// テスト用Userオブジェクトを作成するヘルパー
+function createUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "test-user-id",
+    aud: "authenticated",
+    role: "authenticated",
+    email: "test@example.com",
+    created_at: "2024-01-01T00:00:00Z",
+    app_metadata: {},
+    user_metadata: {},
+    identities: [],
+    ...overrides,
+  };
+}
+
+describe("isAdmin", () => {
+  it("rolesにadminが含まれる場合はtrueを返す", () => {
+    const user = createUser({
+      app_metadata: { roles: ["admin"] },
+    });
+    expect(isAdmin(user)).toBe(true);
+  });
+
+  it("rolesに複数ロールがありadminが含まれる場合はtrueを返す", () => {
+    const user = createUser({
+      app_metadata: { roles: ["user", "admin", "posting-admin"] },
+    });
+    expect(isAdmin(user)).toBe(true);
+  });
+
+  it("rolesにadminが含まれない場合はfalseを返す", () => {
+    const user = createUser({
+      app_metadata: { roles: ["user"] },
+    });
+    expect(isAdmin(user)).toBe(false);
+  });
+
+  it("rolesが空配列の場合はfalseを返す", () => {
+    const user = createUser({
+      app_metadata: { roles: [] },
+    });
+    expect(isAdmin(user)).toBe(false);
+  });
+
+  it("rolesが配列でない場合はfalseを返す", () => {
+    const user = createUser({
+      app_metadata: { roles: "admin" },
+    });
+    expect(isAdmin(user)).toBe(false);
+  });
+
+  it("app_metadataにrolesがない場合はfalseを返す", () => {
+    const user = createUser({
+      app_metadata: {},
+    });
+    expect(isAdmin(user)).toBe(false);
+  });
+
+  it("nullの場合はfalseを返す", () => {
+    expect(isAdmin(null)).toBe(false);
+  });
+});
+
+describe("isPostingAdmin", () => {
+  it("rolesにposting-adminが含まれる場合はtrueを返す", () => {
+    const user = createUser({
+      app_metadata: { roles: ["posting-admin"] },
+    });
+    expect(isPostingAdmin(user)).toBe(true);
+  });
+
+  it("rolesに複数ロールがありposting-adminが含まれる場合はtrueを返す", () => {
+    const user = createUser({
+      app_metadata: { roles: ["admin", "posting-admin"] },
+    });
+    expect(isPostingAdmin(user)).toBe(true);
+  });
+
+  it("rolesにposting-adminが含まれない場合はfalseを返す", () => {
+    const user = createUser({
+      app_metadata: { roles: ["admin"] },
+    });
+    expect(isPostingAdmin(user)).toBe(false);
+  });
+
+  it("nullの場合はfalseを返す", () => {
+    expect(isPostingAdmin(null)).toBe(false);
+  });
+});

--- a/src/lib/utils/metrics-formatter.test.ts
+++ b/src/lib/utils/metrics-formatter.test.ts
@@ -1,0 +1,68 @@
+import {
+  formatAmount,
+  formatNumber,
+  formatUpdateTime,
+} from "./metrics-formatter";
+
+describe("formatAmount", () => {
+  describe("万円単位の場合", () => {
+    it("整数の万円をフォーマットする", () => {
+      expect(formatAmount(1234)).toBe("1234万円");
+    });
+
+    it("小数点以下0は省略する", () => {
+      expect(formatAmount(1234.0)).toBe("1234万円");
+    });
+
+    it("小数点以下がある場合は表示する", () => {
+      expect(formatAmount(1234.5)).toBe("1234.5万円");
+    });
+
+    it("1万円未満をフォーマットする", () => {
+      expect(formatAmount(1)).toBe("1万円");
+    });
+  });
+
+  describe("億円単位の場合", () => {
+    it("ちょうど億円の場合", () => {
+      expect(formatAmount(10000)).toBe("1億円");
+      expect(formatAmount(20000)).toBe("2億円");
+    });
+
+    it("億と万が混在する場合", () => {
+      expect(formatAmount(12345)).toBe("1億2345万円");
+    });
+
+    it("億と万（小数あり）が混在する場合", () => {
+      expect(formatAmount(10001.5)).toBe("1億1.5万円");
+    });
+  });
+
+  describe("0の場合", () => {
+    it("0万円を返す", () => {
+      expect(formatAmount(0)).toBe("0万円");
+    });
+  });
+});
+
+describe("formatNumber", () => {
+  it("カンマ区切りでフォーマットする", () => {
+    expect(formatNumber(1000)).toBe("1,000");
+    expect(formatNumber(1000000)).toBe("1,000,000");
+  });
+
+  it("1000未満はそのまま返す", () => {
+    expect(formatNumber(999)).toBe("999");
+    expect(formatNumber(0)).toBe("0");
+  });
+});
+
+describe("formatUpdateTime", () => {
+  it("ISO形式の日時をJST形式にフォーマットする", () => {
+    // UTC 2025-01-15T05:30:00Z = JST 2025/01/15 14:30
+    const result = formatUpdateTime("2025-01-15T05:30:00Z");
+    expect(result).toContain("2025");
+    expect(result).toContain("01");
+    expect(result).toContain("15");
+  });
+});


### PR DESCRIPTION
## 概要

#1965 に対応し、純粋なユーティリティ関数のユニットテストを追加しました。

## 変更内容

新規テストファイル4件（計48テスト）を追加：

| ファイル | テスト数 | 対象関数 |
|---|---|---|
| `src/features/prefecture-team/utils/color-scale.test.ts` | 14 | `getColorForRank()`, `NO_DATA_COLOR`, `LEGEND_COLORS` |
| `src/features/map-poster/utils/poster-progress.test.ts` | 10 | `calculateProgressRate()`, `getCompletedCount()`, `getRegisteredCount()` |
| `src/lib/utils/metrics-formatter.test.ts` | 10 | `formatAmount()`, `formatNumber()`, `formatUpdateTime()` |
| `src/lib/utils/admin.test.ts` | 14 | `isAdmin()`, `isPostingAdmin()` |

## テスト方針

- 外部依存なしの純粋関数のみを対象
- 正常系・境界値・エッジケースを網羅
- 既存コードの変更なし（テストファイル追加のみ）

## テスト結果

全48テスト PASS、Biome lint/format チェック通過済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * ユーティリティ関数の包括的なテストカバレッジを追加しました。進捗率計算、色スケール、管理者ロール判定、メトリクスフォーマッティング機能など、複数の機能領域をカバーする単体テストを実装しています。これにより、システムの信頼性と安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->