### PR TITLE
fix: TikTok同期で一時的なinternal_errorを失敗扱いにしない

### DIFF
--- a/packages/tiktok_data/src/tiktok-client.ts
+++ b/packages/tiktok_data/src/tiktok-client.ts
@@ -9,6 +9,9 @@ import type {
 } from "./types.js";
 
 const TIKTOK_API_BASE = "https://open.tiktokapis.com/v2";
+const MAX_VIDEO_LIST_RETRIES = 3;
+const VIDEO_LIST_RETRY_DELAY_MS = 1000;
+const RETRYABLE_VIDEO_LIST_ERROR_CODES = ["internal_error"];
 
 /**
  * TikTok API クライアント設定を取得
@@ -38,6 +41,35 @@ export class TikTokAPIError extends Error {
     super(message);
     this.name = "TikTokAPIError";
   }
+}
+
+function parseApiErrorResponse(errorText: string): {
+  code?: string;
+  message?: string;
+  logId?: string;
+} {
+  try {
+    const errorJson = JSON.parse(errorText);
+    return {
+      code: errorJson.error?.code,
+      message: errorJson.error?.message,
+      logId: errorJson.error?.log_id,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function isRetryableVideoListError(code?: string): boolean {
+  if (!code) {
+    return false;
+  }
+  return RETRYABLE_VIDEO_LIST_ERROR_CODES.includes(code);
+}
+
+async function waitForRetry(attempt: number): Promise<void> {
+  const delayMs = VIDEO_LIST_RETRY_DELAY_MS * attempt;
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 /**
@@ -114,55 +146,77 @@ export async function fetchVideoList(
     body.cursor = cursor;
   }
 
-  const response = await fetch(url.toString(), {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
+  for (let attempt = 1; attempt <= MAX_VIDEO_LIST_RETRIES; attempt++) {
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error("TikTok video list fetch failed:", errorText);
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("TikTok video list fetch failed:", errorText);
 
-    // レスポンスボディからエラーコードを抽出
-    let errorCode: string | undefined;
-    let errorMessage: string | undefined;
-    let logId: string | undefined;
-    try {
-      const errorJson = JSON.parse(errorText);
-      errorCode = errorJson.error?.code;
-      errorMessage = errorJson.error?.message;
-      logId = errorJson.error?.log_id;
-    } catch {
-      console.warn("Failed to parse error response as JSON");
+      const {
+        code: errorCode,
+        message: errorMessage,
+        logId,
+      } = parseApiErrorResponse(errorText);
+
+      if (
+        isRetryableVideoListError(errorCode) &&
+        attempt < MAX_VIDEO_LIST_RETRIES
+      ) {
+        console.warn(
+          `Retrying TikTok video list fetch (attempt ${attempt}/${MAX_VIDEO_LIST_RETRIES}) due to retryable error: ${errorCode}`,
+        );
+        await waitForRetry(attempt);
+        continue;
+      }
+
+      throw new TikTokAPIError(
+        errorMessage || "TikTok動画一覧の取得に失敗しました",
+        errorCode,
+        logId,
+      );
     }
 
-    throw new TikTokAPIError(
-      errorMessage || "TikTok動画一覧の取得に失敗しました",
-      errorCode,
-      logId,
-    );
+    const data: TikTokVideoListResponse = await response.json();
+
+    if (data.error?.code && data.error.code !== "ok") {
+      console.error("TikTok API error:", data.error);
+
+      if (
+        isRetryableVideoListError(data.error.code) &&
+        attempt < MAX_VIDEO_LIST_RETRIES
+      ) {
+        console.warn(
+          `Retrying TikTok video list fetch (attempt ${attempt}/${MAX_VIDEO_LIST_RETRIES}) due to retryable API error: ${data.error.code}`,
+        );
+        await waitForRetry(attempt);
+        continue;
+      }
+
+      throw new TikTokAPIError(
+        `TikTok APIエラー: ${data.error.message}`,
+        data.error.code,
+        data.error.log_id,
+      );
+    }
+
+    return {
+      videos: data.data.videos || [],
+      hasMore: data.data.has_more,
+      cursor: data.data.cursor,
+    };
   }
 
-  const data: TikTokVideoListResponse = await response.json();
-
-  if (data.error?.code && data.error.code !== "ok") {
-    console.error("TikTok API error:", data.error);
-    throw new TikTokAPIError(
-      `TikTok APIエラー: ${data.error.message}`,
-      data.error.code,
-      data.error.log_id,
-    );
-  }
-
-  return {
-    videos: data.data.videos || [],
-    hasMore: data.data.has_more,
-    cursor: data.data.cursor,
-  };
+  throw new TikTokAPIError(
+    "TikTok動画一覧の取得に失敗しました（リトライ上限到達）",
+  );
 }
 
 /**


### PR DESCRIPTION
## 概要
- TikTok video list APIでinternal_errorが返るケースに対し、最大3回のリトライを追加
- リトライ上限到達後もinternal_errorは一時エラーとしてスキップ扱いに変更
- 再認証が必要なエラーと同様にwarningへ集約し、バッチ全体の不要な失敗を防止

## 変更詳細
- packages/tiktok_data/src/tiktok-client.ts
  - エラーレスポンスのパース処理を共通化
  - internal_errorをリトライ対象に追加（1s, 2sの待機付き）
- packages/tiktok_data/src/sync.ts
  - TRANSIENT_ERROR_CODESを追加
  - internal_error発生時はfailedSyncsではなくskippedSyncsに計上

## 確認
- GitHub Actions失敗ログでinternal_errorが起点でジョブ失敗していたことを確認済み
- ローカルの型チェックはnode_modules未導入のため未実施

Resolves #1970


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* TikTok APIの一時的なエラーに対する処理を改善しました。一時的なエラーが発生した場合、同期は失敗ではなくスキップされ、ワーニングメッセージが記録されます。
* ビデオリスト取得機能に自動リトライロジックを追加しました。エラー発生時は自動的に再試行され、同期の信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->