### PR TITLE
トンマナ調整: 背景色とレイアウトの統一

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -20,7 +20,7 @@ export default async function ActivitiesPage() {
   ]);
 
   return (
-    <div className="min-h-screen bg-gray-50 py-12">
+    <div className="min-h-screen py-12">
       <div className="max-w-6xl mx-auto px-4">
         <div className="flex flex-col gap-6">
           <div className="text-center">

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -38,18 +38,18 @@ export default async function RankingPage({ searchParams }: PageProps) {
       </h2>
       <RankingTabs>
         {/* 期間選択トグル */}
-        <section className="py-4 bg-white">
+        <section className="py-4">
           <PeriodToggle defaultPeriod={period} />
         </section>
 
         {/* ユーザーのランキングカード */}
         {userRanking && (
-          <section className="py-4 bg-white">
+          <section className="py-4">
             <CurrentUserCard currentUser={userRanking} />
           </section>
         )}
 
-        <section className="py-4 bg-white">
+        <section className="py-4">
           {/* ランキング */}
           <RankingTop limit={100} period={period} />
         </section>

--- a/src/app/ranking/ranking-mission/page.tsx
+++ b/src/app/ranking/ranking-mission/page.tsx
@@ -93,13 +93,13 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
       </h2>
       <RankingTabs>
         {/* ミッション選択 */}
-        <section className="py-4 bg-white">
+        <section className="py-4">
           <MissionSelect missions={missions} />
         </section>
 
         {/* ユーザーのランキングカード */}
         {userRanking && (
-          <section className="py-4 bg-white">
+          <section className="py-4">
             <CurrentUserCardMission
               currentUser={userRanking}
               mission={selectedMission}
@@ -108,7 +108,7 @@ export default async function RankingMissionPage({ searchParams }: PageProps) {
           </section>
         )}
 
-        <section className="py-4 bg-white">
+        <section className="py-4">
           {/* ミッション別ランキング（シーズン対応） */}
           <RankingMission
             limit={100}

--- a/src/app/ranking/ranking-prefecture/page.tsx
+++ b/src/app/ranking/ranking-prefecture/page.tsx
@@ -70,7 +70,7 @@ export default async function RankingPrefecturePage({
       </h2>
       <RankingTabs>
         {/* 都道府県選択 */}
-        <section className="py-4 bg-white">
+        <section className="py-4">
           <PrefectureSelect
             prefectures={prefectures}
             selectedPrefecture={selectedPrefecture}
@@ -79,7 +79,7 @@ export default async function RankingPrefecturePage({
 
         {/* ユーザーのランキングカード */}
         {userRanking && (
-          <section className="py-4 bg-white">
+          <section className="py-4">
             <CurrentUserCardPrefecture
               currentUser={userRanking}
               prefecture={selectedPrefecture}
@@ -87,7 +87,7 @@ export default async function RankingPrefecturePage({
           </section>
         )}
 
-        <section className="py-4 bg-white">
+        <section className="py-4">
           {/* 都道府県別ランキング（シーズン対応） */}
           <RankingPrefecture
             limit={100}

--- a/src/components/top/hero.tsx
+++ b/src/components/top/hero.tsx
@@ -10,7 +10,11 @@ export default async function Hero() {
 
   if (user) {
     try {
-      return <Levels userId={user.id} clickable={true} showBadge={true} />;
+      return (
+        <section className="mt-[-96px] pt-24 bg-gradient-hero ">
+          <Levels userId={user.id} clickable={true} showBadge={true} />
+        </section>
+      );
     } catch (error) {
       console.error("Error fetching user levels:", error);
     }

--- a/src/features/ranking/components/period-toggle.tsx
+++ b/src/features/ranking/components/period-toggle.tsx
@@ -36,7 +36,7 @@ export function PeriodToggle({ defaultPeriod = "daily" }: PeriodToggleProps) {
   );
 
   return (
-    <div className="flex justify-center gap-1 p-1 bg-gray-100 rounded-lg max-w-fit mx-auto">
+    <div className="flex justify-center gap-1 p-1 bg-white rounded-lg max-w-fit mx-auto">
       {periodOptions.map((option) => (
         <Button
           key={option.value}

--- a/src/features/ranking/components/ranking-tabs.tsx
+++ b/src/features/ranking/components/ranking-tabs.tsx
@@ -52,7 +52,7 @@ export function RankingTabs({ children, seasonSlug }: RankingTabsProps) {
   };
 
   return (
-    <Tabs value={getTabValue()} className="w-full max-w-6xl mx-auto px-4">
+    <Tabs value={getTabValue()} className="w-full max-w-xl mx-auto px-4">
       <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="overall" asChild>
           <Link href={getTabHref("overall")}>全体</Link>
@@ -64,7 +64,9 @@ export function RankingTabs({ children, seasonSlug }: RankingTabsProps) {
           <Link href={getTabHref("mission")}>ミッション別</Link>
         </TabsTrigger>
       </TabsList>
-      <TabsContent value={getTabValue()}>{children}</TabsContent>
+      <section className="max-w-lg mx-auto">
+        <TabsContent value={getTabValue()}>{children}</TabsContent>
+      </section>
     </Tabs>
   );
 }

--- a/src/features/tiktok-stats/components/tiktok-sort-toggle.tsx
+++ b/src/features/tiktok-stats/components/tiktok-sort-toggle.tsx
@@ -29,7 +29,7 @@ export function TikTokSortToggle({
   );
 
   return (
-    <div className="flex justify-center gap-1 p-1 bg-gray-100 rounded-lg max-w-fit mx-auto">
+    <div className="flex justify-center gap-1 p-1 bg-white rounded-lg max-w-fit mx-auto">
       {SORT_OPTIONS.map((option) => (
         <Button
           key={option.value}

--- a/src/features/tiktok-stats/components/tiktok-video-card.tsx
+++ b/src/features/tiktok-stats/components/tiktok-video-card.tsx
@@ -30,7 +30,7 @@ export function TikTokVideoCard({ video }: TikTokVideoCardProps) {
       href={video.video_url}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex gap-3 p-2 rounded-lg hover:bg-gray-50 transition-colors"
+      className="flex gap-3 p-2 rounded-lg hover:bg-gray-50 transition-colors bg-white"
     >
       {/* サムネイル（縦長） */}
       <div className="relative w-10 h-15 flex-shrink-0 bg-gray-100 rounded overflow-hidden">

--- a/src/features/user-level/components/levels.tsx
+++ b/src/features/user-level/components/levels.tsx
@@ -80,7 +80,7 @@ export default async function Levels({
 
   if (clickable) {
     return (
-      <section className="bg-gradient-hero flex justify-center py-6 px-4">
+      <section className="flex justify-center py-6 px-4">
         <Link
           href={`/users/${userId}`}
           aria-label={`${profile.name}さんのプロフィールへ`}
@@ -93,8 +93,6 @@ export default async function Levels({
   }
 
   return (
-    <section className="bg-gradient-hero flex justify-center py-6 px-4">
-      {cardContent}
-    </section>
+    <section className="flex justify-center py-6 px-4">{cardContent}</section>
   );
 }


### PR DESCRIPTION
# 変更の概要
- ランキングページ各セクションから `bg-white` を削除し、背景色を統一
- アクティビティページから `bg-gray-50` を削除
- PeriodToggle・TikTokSortToggle の背景を `bg-gray-100` から `bg-white` に変更
- TikTokVideoCard に `bg-white` を追加
- ランキングタブのコンテンツ幅を `max-w-6xl` から `max-w-xl` / `max-w-lg` に調整
- Levels コンポーネントから `bg-gradient-hero` を削除し、Hero コンポーネント側に移動

# 変更の背景
- トンマナ（トーン＆マナー）の統一のためのUI調整

# スクリーンショット
- フロントエンドの変更があるため、スクリーンショットの添付をお願いします

- [ ] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました