### PR TITLE
test: polygon-utils のユニットテスト追加

### DIFF
--- a/src/features/map-posting/utils/polygon-utils.test.ts
+++ b/src/features/map-posting/utils/polygon-utils.test.ts
@@ -77,8 +77,8 @@ describe("polygon-utils", () => {
       // 両方とも同じ3点を使っているので結果は同じ
       expect(closedResult).not.toBeNull();
       expect(openResult).not.toBeNull();
-      expect(closedResult?.lat).toBeCloseTo(openResult?.lat, 10);
-      expect(closedResult?.lng).toBeCloseTo(openResult?.lng, 10);
+      expect(closedResult?.lat).toBeCloseTo(openResult!.lat, 10);
+      expect(closedResult?.lng).toBeCloseTo(openResult!.lng, 10);
     });
 
     test("閉じていないリングの場合は全点を使う", () => {


### PR DESCRIPTION
## Summary
- `calculatePolygonCentroid` のテスト追加（10ケース）
  - 三角形・四角形ポリゴンの重心計算
  - 閉じたリング/閉じていないリングの処理
  - 不正データ（null, undefined, 異なるtype等）のエラーハンドリング
- `calculatePolygonArea` のテスト追加（7ケース）
  - 既知ポリゴンの面積妥当性検証
  - 不正データのエラーハンドリング

## Test plan
- [x] 全17テストケースがパスすることを確認
- [x] Biomeフォーマットチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)