### PR TITLE
refactor: ランキング期間フィルターのロジックを共通化

### DIFF
--- a/src/features/ranking/services/get-missions-ranking.ts
+++ b/src/features/ranking/services/get-missions-ranking.ts
@@ -6,8 +6,11 @@ import {
 } from "@/features/party-membership/services/memberships";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
 import { createClient } from "@/lib/supabase/client";
-import { getJSTMidnightToday } from "@/lib/utils/date-utils";
 import type { RankingPeriod, UserMissionRanking } from "../types/ranking-types";
+import {
+  dateFilterToISOString,
+  getPeriodDateFilter,
+} from "../utils/period-utils";
 
 export async function getMissionRanking(
   missionId: string,
@@ -27,16 +30,7 @@ export async function getMissionRanking(
     }
 
     // 期間に応じた日付フィルタを設定
-    let dateFilter: Date | null = null;
-
-    switch (period) {
-      case "daily":
-        // 日本時間の今日の0時0分を基準にする
-        dateFilter = getJSTMidnightToday();
-        break;
-      default:
-        dateFilter = null;
-    }
+    const dateFilter = getPeriodDateFilter(period);
 
     // シーズン対応のミッション別ランキングを取得
     const { data: rankings, error: rankingsError } = await supabase.rpc(
@@ -44,7 +38,7 @@ export async function getMissionRanking(
       {
         p_mission_id: missionId,
         p_limit: limit,
-        p_start_date: dateFilter?.toISOString() || undefined,
+        p_start_date: dateFilterToISOString(dateFilter),
         p_season_id: targetSeasonId,
       },
     );
@@ -130,16 +124,7 @@ export async function getUserMissionRanking(
     }
 
     // 期間に応じた日付フィルタを設定
-    let dateFilter: Date | null = null;
-
-    switch (period) {
-      case "daily":
-        // 日本時間の今日の0時0分を基準にする
-        dateFilter = getJSTMidnightToday();
-        break;
-      default:
-        dateFilter = null;
-    }
+    const dateFilter = getPeriodDateFilter(period);
 
     // シーズン対応の特定ユーザーのミッションランキングを取得
     const { data: rankings, error: rankingsError } = await supabase.rpc(
@@ -147,7 +132,7 @@ export async function getUserMissionRanking(
       {
         p_mission_id: missionId,
         p_user_id: userId,
-        p_start_date: dateFilter?.toISOString() || undefined,
+        p_start_date: dateFilterToISOString(dateFilter),
         p_season_id: targetSeasonId,
       },
     );

--- a/src/features/ranking/services/get-prefectures-ranking.ts
+++ b/src/features/ranking/services/get-prefectures-ranking.ts
@@ -6,8 +6,11 @@ import {
 } from "@/features/party-membership/services/memberships";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
 import { createClient } from "@/lib/supabase/client";
-import { getJSTMidnightToday } from "@/lib/utils/date-utils";
 import type { RankingPeriod, UserRanking } from "../types/ranking-types";
+import {
+  dateFilterToISOString,
+  getPeriodDateFilter,
+} from "../utils/period-utils";
 
 export async function getPrefecturesRanking(
   prefecture: string,
@@ -27,16 +30,7 @@ export async function getPrefecturesRanking(
     }
 
     // 期間に応じた日付フィルタを設定
-    let dateFilter: Date | null = null;
-
-    switch (period) {
-      case "daily":
-        // 日本時間の今日の0時0分を基準にする
-        dateFilter = getJSTMidnightToday();
-        break;
-      default:
-        dateFilter = null;
-    }
+    const dateFilter = getPeriodDateFilter(period);
 
     // シーズン対応の都道府県別ランキングを取得
     const { data: rankings, error: rankingsError } = await supabase.rpc(
@@ -44,7 +38,7 @@ export async function getPrefecturesRanking(
       {
         p_prefecture: prefecture,
         p_limit: limit,
-        p_start_date: dateFilter?.toISOString() || undefined,
+        p_start_date: dateFilterToISOString(dateFilter),
         p_season_id: targetSeasonId,
       },
     );
@@ -103,16 +97,7 @@ export async function getUserPrefecturesRanking(
     }
 
     // 期間に応じた日付フィルタを設定
-    let dateFilter: Date | null = null;
-
-    switch (period) {
-      case "daily":
-        // 日本時間の今日の0時0分を基準にする
-        dateFilter = getJSTMidnightToday();
-        break;
-      default:
-        dateFilter = null;
-    }
+    const dateFilter = getPeriodDateFilter(period);
 
     // シーズン対応の特定ユーザーの都道府県別ランキングを取得
     const { data: rankings, error: rankingsError } = await supabase.rpc(
@@ -120,7 +105,7 @@ export async function getUserPrefecturesRanking(
       {
         p_prefecture: prefecture,
         p_user_id: userId,
-        p_start_date: dateFilter?.toISOString() || undefined,
+        p_start_date: dateFilterToISOString(dateFilter),
         p_season_id: targetSeasonId,
       },
     );

--- a/src/features/ranking/services/get-ranking.ts
+++ b/src/features/ranking/services/get-ranking.ts
@@ -6,8 +6,11 @@ import {
 } from "@/features/party-membership/services/memberships";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
 import { createClient } from "@/lib/supabase/client";
-import { getJSTMidnightToday } from "@/lib/utils/date-utils";
 import type { RankingPeriod, UserRanking } from "../types/ranking-types";
+import {
+  dateFilterToISOString,
+  getPeriodDateFilter,
+} from "../utils/period-utils";
 
 export interface UserPeriodRanking {
   user_id: string;
@@ -31,14 +34,11 @@ export async function getUserPeriodRanking(
   const supabase = createClient();
 
   // 期間フィルター計算
-  let dateFilter: Date | null = null;
-  if (period === "daily") {
-    dateFilter = getJSTMidnightToday();
-  }
+  const dateFilter = getPeriodDateFilter(period);
 
   const { data, error } = await supabase.rpc("get_user_period_ranking", {
     target_user_id: userId,
-    start_date: dateFilter?.toISOString() || undefined,
+    start_date: dateFilterToISOString(dateFilter),
     p_season_id: seasonId,
   });
 
@@ -83,22 +83,13 @@ export async function getRanking(
     }
 
     // 期間に応じた日付フィルタを設定
-    let dateFilter: Date | null = null;
-
-    switch (period) {
-      case "daily":
-        // 日本時間の今日の0時0分を基準にする
-        dateFilter = getJSTMidnightToday();
-        break;
-      default:
-        dateFilter = null;
-    }
+    const dateFilter = getPeriodDateFilter(period);
 
     // 指定されたシーズンのRPC関数を使用
     const { data: periodRankingData, error: rpcError } = await supabase.rpc(
       "get_period_ranking",
       {
-        p_start_date: dateFilter?.toISOString() || undefined,
+        p_start_date: dateFilterToISOString(dateFilter),
         p_limit: limit,
         p_end_date: undefined,
         p_season_id: targetSeasonId, // 指定されたシーズンIDを使用

--- a/src/features/ranking/utils/period-utils.test.ts
+++ b/src/features/ranking/utils/period-utils.test.ts
@@ -1,0 +1,47 @@
+import { dateFilterToISOString, getPeriodDateFilter } from "./period-utils";
+
+jest.mock("@/lib/utils/date-utils", () => ({
+  getJSTMidnightToday: jest
+    .fn()
+    .mockReturnValue(new Date("2025-01-15T15:00:00.000Z")),
+}));
+
+describe("getPeriodDateFilter", () => {
+  describe("period='daily' の場合", () => {
+    test("getJSTMidnightToday() の結果を返す", () => {
+      const result = getPeriodDateFilter("daily");
+      expect(result).toEqual(new Date("2025-01-15T15:00:00.000Z"));
+    });
+  });
+
+  describe("period='all' の場合", () => {
+    test("null を返す", () => {
+      const result = getPeriodDateFilter("all");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("未知の period の場合", () => {
+    test("null を返す", () => {
+      const result = getPeriodDateFilter("unknown" as "all");
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("dateFilterToISOString", () => {
+  describe("Date オブジェクトが渡された場合", () => {
+    test("ISO文字列を返す", () => {
+      const date = new Date("2025-01-15T15:00:00.000Z");
+      const result = dateFilterToISOString(date);
+      expect(result).toBe("2025-01-15T15:00:00.000Z");
+    });
+  });
+
+  describe("null の場合", () => {
+    test("undefined を返す", () => {
+      const result = dateFilterToISOString(null);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/features/ranking/utils/period-utils.ts
+++ b/src/features/ranking/utils/period-utils.ts
@@ -1,0 +1,23 @@
+import { getJSTMidnightToday } from "@/lib/utils/date-utils";
+import type { RankingPeriod } from "../types/ranking-types";
+
+/**
+ * RankingPeriod から日付フィルタを計算する
+ */
+export function getPeriodDateFilter(period: RankingPeriod): Date | null {
+  switch (period) {
+    case "daily":
+      return getJSTMidnightToday();
+    default:
+      return null;
+  }
+}
+
+/**
+ * 日付フィルタをISO文字列に変換する（RPC パラメータ用）
+ */
+export function dateFilterToISOString(
+  dateFilter: Date | null,
+): string | undefined {
+  return dateFilter?.toISOString() || undefined;
+}


### PR DESCRIPTION
## Summary
- ランキングサービス3ファイル（get-ranking.ts, get-missions-ranking.ts, get-prefectures-ranking.ts）に重複していた期間フィルター計算ロジックを `period-utils.ts` に抽出
- `getPeriodDateFilter(period)`: RankingPeriod から日付フィルタ（Date | null）を計算する共通関数
- `dateFilterToISOString(dateFilter)`: Date | null を RPC パラメータ用の ISO 文字列に変換する共通関数
- 5つのテストケースを追加

## Changes
- **新規**: `src/features/ranking/utils/period-utils.ts` - 共通ユーティリティ関数
- **新規**: `src/features/ranking/utils/period-utils.test.ts` - テスト
- **変更**: `src/features/ranking/services/get-ranking.ts` - 重複コード削除、共通関数利用
- **変更**: `src/features/ranking/services/get-missions-ranking.ts` - 同上
- **変更**: `src/features/ranking/services/get-prefectures-ranking.ts` - 同上

## Test plan
- [x] `npx jest --testPathPattern='period-utils'` - 5テスト全てパス
- [x] `npx tsc --noEmit` - 型エラーなし
- [x] `npx biome check` - lint/format問題なし