### PR TITLE
refactor: getPeriodStartDate/getPeriodEndDate を共通ユーティリティに統合

### DIFF
--- a/src/features/action-stats/types/index.ts
+++ b/src/features/action-stats/types/index.ts
@@ -1,10 +1,9 @@
-// 期間フィルター型はyoutube-statsから再利用
-export type { PeriodType } from "@/features/youtube-stats/types";
+export type { PeriodType } from "@/lib/utils/period-date-utils";
 export {
   getPeriodEndDate,
   getPeriodStartDate,
   PERIOD_OPTIONS,
-} from "@/features/youtube-stats/types";
+} from "@/lib/utils/period-date-utils";
 
 export interface ActionStatsSummary {
   totalActions: number;

--- a/src/features/tiktok-stats/types/index.ts
+++ b/src/features/tiktok-stats/types/index.ts
@@ -1,5 +1,12 @@
 import type { Tables } from "@/lib/types/supabase";
 
+export type { PeriodType } from "@/lib/utils/period-date-utils";
+export {
+  getPeriodEndDate,
+  getPeriodStartDate,
+  PERIOD_OPTIONS,
+} from "@/lib/utils/period-date-utils";
+
 export type TikTokVideo = Tables<"tiktok_videos">;
 export type TikTokVideoStats = Tables<"tiktok_video_stats">;
 
@@ -46,53 +53,3 @@ export const SORT_OPTIONS: { value: SortType; label: string }[] = [
   { value: "view_count", label: "再生数順" },
   { value: "like_count", label: "いいね順" },
 ];
-
-export type PeriodType =
-  | "30"
-  | "90"
-  | "180"
-  | "365"
-  | "this_year"
-  | "all_time"
-  | "custom";
-
-export const PERIOD_OPTIONS: { value: PeriodType; label: string }[] = [
-  { value: "30", label: "過去30日" },
-  { value: "90", label: "過去90日" },
-  { value: "180", label: "過去6ヶ月" },
-  { value: "365", label: "過去1年" },
-  { value: "this_year", label: "今年" },
-  { value: "all_time", label: "全期間" },
-  { value: "custom", label: "カスタム" },
-];
-
-export function getPeriodStartDate(
-  period: PeriodType,
-  customStart?: string,
-): Date | null {
-  if (period === "custom" && customStart) {
-    return new Date(customStart);
-  }
-  if (period === "this_year") {
-    const year = new Date().getFullYear();
-    return new Date(`${year}-01-01`);
-  }
-  if (period === "all_time") {
-    return null;
-  }
-  if (period === "custom") {
-    const year = new Date().getFullYear();
-    return new Date(`${year}-01-01`);
-  }
-  const days = Number.parseInt(period, 10);
-  const date = new Date();
-  date.setDate(date.getDate() - days);
-  return date;
-}
-
-export function getPeriodEndDate(customEnd?: string): Date | null {
-  if (customEnd) {
-    return new Date(customEnd);
-  }
-  return null;
-}

--- a/src/features/youtube-stats/types/index.ts
+++ b/src/features/youtube-stats/types/index.ts
@@ -1,5 +1,12 @@
 import type { Tables } from "@/lib/types/supabase";
 
+export type { PeriodType } from "@/lib/utils/period-date-utils";
+export {
+  getPeriodEndDate,
+  getPeriodStartDate,
+  PERIOD_OPTIONS,
+} from "@/lib/utils/period-date-utils";
+
 export type YouTubeVideo = Tables<"youtube_videos">;
 export type YouTubeVideoStats = Tables<"youtube_video_stats">;
 
@@ -43,55 +50,3 @@ export const SORT_OPTIONS: { value: SortType; label: string }[] = [
   { value: "view_count", label: "再生数順" },
   { value: "like_count", label: "いいね順" },
 ];
-
-export type PeriodType =
-  | "30"
-  | "90"
-  | "180"
-  | "365"
-  | "this_year"
-  | "all_time"
-  | "custom";
-
-export const PERIOD_OPTIONS: { value: PeriodType; label: string }[] = [
-  { value: "30", label: "過去30日" },
-  { value: "90", label: "過去90日" },
-  { value: "180", label: "過去6ヶ月" },
-  { value: "365", label: "過去1年" },
-  { value: "this_year", label: "今年" },
-  { value: "all_time", label: "全期間" },
-  { value: "custom", label: "カスタム" },
-];
-
-export function getPeriodStartDate(
-  period: PeriodType,
-  customStart?: string,
-): Date | null {
-  if (period === "custom" && customStart) {
-    return new Date(customStart);
-  }
-  if (period === "this_year") {
-    // 今年の1月1日
-    const year = new Date().getFullYear();
-    return new Date(`${year}-01-01`);
-  }
-  if (period === "all_time") {
-    return null; // 全期間は開始日なし
-  }
-  if (period === "custom") {
-    // カスタムで開始日未指定の場合は今年の1月1日
-    const year = new Date().getFullYear();
-    return new Date(`${year}-01-01`);
-  }
-  const days = Number.parseInt(period, 10);
-  const date = new Date();
-  date.setDate(date.getDate() - days);
-  return date;
-}
-
-export function getPeriodEndDate(customEnd?: string): Date | null {
-  if (customEnd) {
-    return new Date(customEnd);
-  }
-  return null;
-}

--- a/src/lib/utils/period-date-utils.test.ts
+++ b/src/lib/utils/period-date-utils.test.ts
@@ -1,0 +1,71 @@
+import { getPeriodEndDate, getPeriodStartDate } from "./period-date-utils";
+
+describe("getPeriodStartDate", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("日数指定の期間", () => {
+    test("period='30' の場合、30日前の日付を返す", () => {
+      const result = getPeriodStartDate("30");
+      const expected = new Date("2025-06-15T12:00:00Z");
+      expected.setDate(expected.getDate() - 30);
+      expect(result).toEqual(expected);
+    });
+
+    test("period='90' の場合、90日前の日付を返す", () => {
+      const result = getPeriodStartDate("90");
+      const expected = new Date("2025-06-15T12:00:00Z");
+      expected.setDate(expected.getDate() - 90);
+      expect(result).toEqual(expected);
+    });
+
+    test("period='365' の場合、365日前の日付を返す", () => {
+      const result = getPeriodStartDate("365");
+      const expected = new Date("2025-06-15T12:00:00Z");
+      expected.setDate(expected.getDate() - 365);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("特殊な期間タイプ", () => {
+    test("period='this_year' の場合、今年の1月1日を返す", () => {
+      const result = getPeriodStartDate("this_year");
+      expect(result).toEqual(new Date("2025-01-01"));
+    });
+
+    test("period='all_time' の場合、null を返す", () => {
+      const result = getPeriodStartDate("all_time");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("カスタム期間", () => {
+    test("period='custom' で customStart 指定時、その日付を返す", () => {
+      const result = getPeriodStartDate("custom", "2025-03-01");
+      expect(result).toEqual(new Date("2025-03-01"));
+    });
+
+    test("period='custom' で customStart 未指定時、今年の1月1日を返す", () => {
+      const result = getPeriodStartDate("custom");
+      expect(result).toEqual(new Date("2025-01-01"));
+    });
+  });
+});
+
+describe("getPeriodEndDate", () => {
+  test("customEnd 指定時、その日付を返す", () => {
+    const result = getPeriodEndDate("2025-12-31");
+    expect(result).toEqual(new Date("2025-12-31"));
+  });
+
+  test("customEnd 未指定時、null を返す", () => {
+    const result = getPeriodEndDate();
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/utils/period-date-utils.ts
+++ b/src/lib/utils/period-date-utils.ts
@@ -1,0 +1,55 @@
+export type PeriodType =
+  | "30"
+  | "90"
+  | "180"
+  | "365"
+  | "this_year"
+  | "all_time"
+  | "custom";
+
+export const PERIOD_OPTIONS: { value: PeriodType; label: string }[] = [
+  { value: "30", label: "過去30日" },
+  { value: "90", label: "過去90日" },
+  { value: "180", label: "過去6ヶ月" },
+  { value: "365", label: "過去1年" },
+  { value: "this_year", label: "今年" },
+  { value: "all_time", label: "全期間" },
+  { value: "custom", label: "カスタム" },
+];
+
+/**
+ * 期間タイプから開始日を計算する
+ */
+export function getPeriodStartDate(
+  period: PeriodType,
+  customStart?: string,
+): Date | null {
+  if (period === "custom" && customStart) {
+    return new Date(customStart);
+  }
+  if (period === "this_year") {
+    const year = new Date().getFullYear();
+    return new Date(`${year}-01-01`);
+  }
+  if (period === "all_time") {
+    return null;
+  }
+  if (period === "custom") {
+    const year = new Date().getFullYear();
+    return new Date(`${year}-01-01`);
+  }
+  const days = Number.parseInt(period, 10);
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+/**
+ * カスタム終了日から終了日を取得する
+ */
+export function getPeriodEndDate(customEnd?: string): Date | null {
+  if (customEnd) {
+    return new Date(customEnd);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- `getPeriodStartDate`, `getPeriodEndDate`, `PeriodType`, `PERIOD_OPTIONS` を `src/lib/utils/period-date-utils.ts` に集約
- `youtube-stats/types/index.ts`, `tiktok-stats/types/index.ts`, `action-stats/types/index.ts` の重複コードを re-export に変更
- 共通ユーティリティのユニットテストを追加 (9テストケース)

## Changes
- **新規**: `src/lib/utils/period-date-utils.ts` - 期間日付計算の共通ユーティリティ
- **新規**: `src/lib/utils/period-date-utils.test.ts` - テスト (9ケース全パス)
- **変更**: `src/features/youtube-stats/types/index.ts` - 重複定義を re-export に置換
- **変更**: `src/features/tiktok-stats/types/index.ts` - 重複定義を re-export に置換
- **変更**: `src/features/action-stats/types/index.ts` - youtube-stats 経由から直接 re-export に変更

## Test plan
- [x] `npx jest --testPathPattern='period-date-utils'` - 9テスト全パス
- [x] `npx tsc --noEmit` - TypeScriptエラーなし
- [x] Biome チェックパス