### PR TITLE
test: artifact-helpers のユニットテストを追加

### DIFF
--- a/src/features/mission-detail/actions/artifact-helpers.test.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.test.ts
@@ -204,7 +204,7 @@ describe("buildArtifactPayload", () => {
   describe("不明なartifact type", () => {
     test("登録されていないtype → 全フィールドnull", () => {
       const data = baseFormData({
-        requiredArtifactType: "UNKNOWN_TYPE",
+        requiredArtifactType: "UNKNOWN_TYPE" as any,
       });
       const result = buildArtifactPayload("UNKNOWN_TYPE", data);
       expect(result).toEqual(NULL_FIELDS);


### PR DESCRIPTION
## Summary
- `buildArtifactPayload` と `getArtifactTypeLabel` のユニットテストを追加
- 全artifact type (LINK, TEXT, EMAIL, IMAGE, IMAGE_WITH_GEOLOCATION, POSTING, POSTER, QUIZ, YOUTUBE, YOUTUBE_COMMENT) に対するペイロード生成テスト
- type不一致時のnullFieldsフォールバック動作テスト
- 不明なartifact typeの処理テスト
- 全37テストケースが通過

## Test plan
- [x] `npx jest --testPathPattern=artifact-helpers` で全テスト通過確認
- [x] `pnpm run biome:check:write` でフォーマット確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)