### PR TITLE
test: party-membership utils のユニットテスト追加

### DIFF
--- a/src/features/party-membership/utils.test.ts
+++ b/src/features/party-membership/utils.test.ts
@@ -1,0 +1,38 @@
+import type { PartyMembership } from "./types";
+import { isPartyBadgeVisible } from "./utils";
+
+const baseMembership: PartyMembership = {
+  user_id: "test-user-id",
+  plan: "standard",
+  badge_visibility: true,
+  metadata: {},
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  synced_at: "2024-01-01T00:00:00Z",
+};
+
+describe("isPartyBadgeVisible", () => {
+  describe("membership が未定義の場合", () => {
+    test("undefined の場合は false を返す", () => {
+      expect(isPartyBadgeVisible(undefined)).toBe(false);
+    });
+
+    test("null の場合は false を返す", () => {
+      expect(isPartyBadgeVisible(null)).toBe(false);
+    });
+  });
+
+  describe("membership が存在する場合", () => {
+    test("badge_visibility が true の場合は true を返す", () => {
+      expect(
+        isPartyBadgeVisible({ ...baseMembership, badge_visibility: true }),
+      ).toBe(true);
+    });
+
+    test("badge_visibility が false の場合は false を返す", () => {
+      expect(
+        isPartyBadgeVisible({ ...baseMembership, badge_visibility: false }),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
`src/features/party-membership/utils.ts` の `isPartyBadgeVisible` 関数に対するユニットテストを追加しました。

## テスト内容
- `isPartyBadgeVisible(undefined)` → false
- `isPartyBadgeVisible(null)` → false
- `isPartyBadgeVisible({ badge_visibility: true, ... })` → true
- `isPartyBadgeVisible({ badge_visibility: false, ... })` → false

## テスト結果
4テスト全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)