### PR TITLE
refactor: YouTube URL ユーティリティをutils/に切り出し

### DIFF
--- a/src/features/youtube/services/sync-comments-core.ts
+++ b/src/features/youtube/services/sync-comments-core.ts
@@ -303,21 +303,8 @@ export async function createYouTubeCommentRecord(
   return { success: true };
 }
 
-/**
- * コメントURLを生成する
- * @param videoId 動画ID
- * @param commentId コメントID
- */
-export function generateCommentUrl(videoId: string, commentId: string): string {
-  return `https://www.youtube.com/watch?v=${videoId}&lc=${commentId}`;
-}
-
-/**
- * YouTube URLからコメントIDを抽出する
- * @param url YouTube URL (例: https://www.youtube.com/watch?v=xxx&lc=yyy)
- */
-export function extractCommentIdFromUrl(url: string): string | null {
-  const pattern = /[?&]lc=([\w-]+)/;
-  const match = url.match(pattern);
-  return match?.[1] || null;
-}
+// URL ユーティリティを再エクスポート
+export {
+  extractCommentIdFromUrl,
+  generateCommentUrl,
+} from "../utils/url-utils";

--- a/src/features/youtube/services/youtube-like-service.ts
+++ b/src/features/youtube/services/youtube-like-service.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
 import { hasTeamMiraiTag } from "../constants/team-mirai";
+import { extractVideoIdFromUrl } from "../utils/url-utils";
 import { fetchVideoDetailsByApiKey } from "./youtube-client";
 
 // コアロジックを再エクスポート
@@ -16,6 +17,9 @@ export {
   syncLikesForUser,
 } from "./sync-likes-core";
 
+// URL ユーティリティを再エクスポート（後方互換性のため）
+export { extractVideoIdFromUrl };
+
 /**
  * いいね同期結果
  */
@@ -23,29 +27,6 @@ export interface SyncLikesResult {
   success: boolean;
   newLikesCount?: number;
   error?: string;
-}
-
-/**
- * YouTube URLから動画IDを抽出する
- * @param url YouTube動画URL
- */
-export function extractVideoIdFromUrl(url: string): string | null {
-  const patterns = [
-    /(?:youtube\.com\/watch\?v=)([\w-]+)/,
-    /(?:youtu\.be\/)([\w-]+)/,
-    /(?:youtube\.com\/embed\/)([\w-]+)/,
-    /(?:youtube\.com\/shorts\/)([\w-]+)/,
-    /(?:youtube\.com\/live\/)([\w-]+)/,
-  ];
-
-  for (const pattern of patterns) {
-    const match = url.match(pattern);
-    if (match?.[1]) {
-      return match[1];
-    }
-  }
-
-  return null;
 }
 
 /**

--- a/src/features/youtube/utils/url-utils.test.ts
+++ b/src/features/youtube/utils/url-utils.test.ts
@@ -1,0 +1,129 @@
+import {
+  extractCommentIdFromUrl,
+  extractVideoIdFromUrl,
+  generateCommentUrl,
+} from "./url-utils";
+
+describe("YouTube URLユーティリティ", () => {
+  describe("extractVideoIdFromUrl", () => {
+    describe("正常系", () => {
+      it("watch URLから動画IDを抽出できる", () => {
+        expect(
+          extractVideoIdFromUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+        ).toBe("dQw4w9WgXcQ");
+      });
+
+      it("追加パラメータ付きwatch URLから動画IDを抽出できる", () => {
+        expect(
+          extractVideoIdFromUrl(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120",
+          ),
+        ).toBe("dQw4w9WgXcQ");
+      });
+
+      it("短縮URLから動画IDを抽出できる", () => {
+        expect(extractVideoIdFromUrl("https://youtu.be/dQw4w9WgXcQ")).toBe(
+          "dQw4w9WgXcQ",
+        );
+      });
+
+      it("埋め込みURLから動画IDを抽出できる", () => {
+        expect(
+          extractVideoIdFromUrl("https://www.youtube.com/embed/dQw4w9WgXcQ"),
+        ).toBe("dQw4w9WgXcQ");
+      });
+
+      it("Shorts URLから動画IDを抽出できる", () => {
+        expect(
+          extractVideoIdFromUrl("https://www.youtube.com/shorts/dQw4w9WgXcQ"),
+        ).toBe("dQw4w9WgXcQ");
+      });
+
+      it("ライブURLから動画IDを抽出できる", () => {
+        expect(
+          extractVideoIdFromUrl("https://www.youtube.com/live/dQw4w9WgXcQ"),
+        ).toBe("dQw4w9WgXcQ");
+      });
+
+      it("ハイフンを含む動画IDを抽出できる", () => {
+        expect(
+          extractVideoIdFromUrl("https://www.youtube.com/watch?v=abc-def_123"),
+        ).toBe("abc-def_123");
+      });
+    });
+
+    describe("異常系", () => {
+      it("不正なURLの場合はnullを返す", () => {
+        expect(extractVideoIdFromUrl("https://example.com/video")).toBeNull();
+      });
+
+      it("空文字の場合はnullを返す", () => {
+        expect(extractVideoIdFromUrl("")).toBeNull();
+      });
+
+      it("YouTube以外のドメインの場合はnullを返す", () => {
+        expect(extractVideoIdFromUrl("https://vimeo.com/123456789")).toBeNull();
+      });
+    });
+  });
+
+  describe("generateCommentUrl", () => {
+    it("動画IDとコメントIDから正しいURLを生成する", () => {
+      expect(generateCommentUrl("videoId123", "commentId456")).toBe(
+        "https://www.youtube.com/watch?v=videoId123&lc=commentId456",
+      );
+    });
+
+    it("ハイフンを含むIDでも正しいURLを生成する", () => {
+      expect(generateCommentUrl("abc-def_123", "Ugx-abc_123")).toBe(
+        "https://www.youtube.com/watch?v=abc-def_123&lc=Ugx-abc_123",
+      );
+    });
+  });
+
+  describe("extractCommentIdFromUrl", () => {
+    describe("正常系", () => {
+      it("lcパラメータからコメントIDを抽出できる", () => {
+        expect(
+          extractCommentIdFromUrl(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&lc=UgxABC123",
+          ),
+        ).toBe("UgxABC123");
+      });
+
+      it("lcが先頭パラメータでも抽出できる", () => {
+        expect(
+          extractCommentIdFromUrl(
+            "https://www.youtube.com/watch?lc=UgxABC123&v=dQw4w9WgXcQ",
+          ),
+        ).toBe("UgxABC123");
+      });
+
+      it("ハイフンを含むコメントIDを抽出できる", () => {
+        expect(
+          extractCommentIdFromUrl(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&lc=Ugx-abc_123",
+          ),
+        ).toBe("Ugx-abc_123");
+      });
+    });
+
+    describe("異常系", () => {
+      it("lcパラメータがない場合はnullを返す", () => {
+        expect(
+          extractCommentIdFromUrl(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          ),
+        ).toBeNull();
+      });
+
+      it("不正なURLの場合はnullを返す", () => {
+        expect(extractCommentIdFromUrl("https://example.com")).toBeNull();
+      });
+
+      it("空文字の場合はnullを返す", () => {
+        expect(extractCommentIdFromUrl("")).toBeNull();
+      });
+    });
+  });
+});

--- a/src/features/youtube/utils/url-utils.ts
+++ b/src/features/youtube/utils/url-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * YouTube URL関連のユーティリティ関数
+ */
+
+/**
+ * YouTube URLから動画IDを抽出する
+ * @param url YouTube動画URL
+ */
+export function extractVideoIdFromUrl(url: string): string | null {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=)([\w-]+)/,
+    /(?:youtu\.be\/)([\w-]+)/,
+    /(?:youtube\.com\/embed\/)([\w-]+)/,
+    /(?:youtube\.com\/shorts\/)([\w-]+)/,
+    /(?:youtube\.com\/live\/)([\w-]+)/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+}
+
+/**
+ * コメントURLを生成する
+ * @param videoId 動画ID
+ * @param commentId コメントID
+ */
+export function generateCommentUrl(videoId: string, commentId: string): string {
+  return `https://www.youtube.com/watch?v=${videoId}&lc=${commentId}`;
+}
+
+/**
+ * YouTube URLからコメントIDを抽出する
+ * @param url YouTube URL (例: https://www.youtube.com/watch?v=xxx&lc=yyy)
+ */
+export function extractCommentIdFromUrl(url: string): string | null {
+  const pattern = /[?&]lc=([\w-]+)/;
+  const match = url.match(pattern);
+  return match?.[1] || null;
+}


### PR DESCRIPTION
## Summary
- `extractVideoIdFromUrl`, `generateCommentUrl`, `extractCommentIdFromUrl` を `services/` から `utils/url-utils.ts` に移動
- 元ファイル（`youtube-like-service.ts`, `sync-comments-core.ts`）からは再エクスポートで後方互換性を維持
- 18件のユニットテストを追加（watch URL, 短縮URL, 埋め込み, Shorts, ライブ, コメントURL生成・抽出, 異常系）

## Test plan
- [x] `npx jest --testPathPattern="url-utils"` で全18テスト通過
- [x] `pnpm run typecheck` 通過
- [x] `pnpm run biome:check:write` 通過
- [x] 既存のインポートパスは再エクスポートにより影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * YouTubeのURL処理機能を集約・一元化することで、コードの保守性と再利用性を向上させました。

* **テスト**
  * YouTubeのURL抽出・生成機能に対する新しい包括的なテストスイートを追加しました。複数のURLフォーマットに対応し、様々なケースをカバーしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->