### PR TITLE
refactor: filterTeamMiraiVideos をutils/に移動 + テスト追加

### DIFF
--- a/src/features/youtube/constants/team-mirai.test.ts
+++ b/src/features/youtube/constants/team-mirai.test.ts
@@ -1,0 +1,121 @@
+import { hasTeamMiraiTag } from "./team-mirai";
+
+describe("hasTeamMiraiTag", () => {
+  describe("タグでのマッチ", () => {
+    it("タグに「チームみらい」が含まれている場合trueを返す", () => {
+      expect(hasTeamMiraiTag(["チームみらい"])).toBe(true);
+    });
+
+    it("タグに「teammirai」が含まれている場合trueを返す", () => {
+      expect(hasTeamMiraiTag(["teammirai"])).toBe(true);
+    });
+
+    it("タグに「team mirai」が含まれている場合trueを返す", () => {
+      expect(hasTeamMiraiTag(["team mirai"])).toBe(true);
+    });
+
+    it("タグの大文字小文字を区別しない", () => {
+      expect(hasTeamMiraiTag(["TeamMirai"])).toBe(true);
+      expect(hasTeamMiraiTag(["TEAMMIRAI"])).toBe(true);
+      expect(hasTeamMiraiTag(["TEAM MIRAI"])).toBe(true);
+    });
+
+    it("タグの部分一致でもtrueを返す", () => {
+      expect(hasTeamMiraiTag(["#チームみらい応援"])).toBe(true);
+    });
+
+    it("関係ないタグのみの場合falseを返す", () => {
+      expect(hasTeamMiraiTag(["政治", "日本"])).toBe(false);
+    });
+  });
+
+  describe("タイトルでのマッチ", () => {
+    it("タイトルに「チームみらい」が含まれている場合trueを返す", () => {
+      expect(hasTeamMiraiTag(undefined, "チームみらいの活動報告")).toBe(true);
+    });
+
+    it("タイトルに「teammirai」が含まれている場合trueを返す", () => {
+      expect(hasTeamMiraiTag(undefined, "TeamMirai Activity")).toBe(true);
+    });
+
+    it("タイトルに「team mirai」が含まれている場合trueを返す", () => {
+      expect(hasTeamMiraiTag(undefined, "Team Mirai video")).toBe(true);
+    });
+  });
+
+  describe("説明文でのマッチ", () => {
+    it("説明文に「チームみらい」が含まれている場合trueを返す", () => {
+      expect(
+        hasTeamMiraiTag(undefined, undefined, "この動画はチームみらいについて"),
+      ).toBe(true);
+    });
+
+    it("説明文に「teammirai」が含まれている場合trueを返す", () => {
+      expect(hasTeamMiraiTag(undefined, undefined, "Support teammirai!")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("チャンネル名でのマッチ", () => {
+    it("チャンネル名に「チームみらい」が含まれている場合trueを返す", () => {
+      expect(
+        hasTeamMiraiTag(undefined, undefined, undefined, "チームみらい公式"),
+      ).toBe(true);
+    });
+
+    it("チャンネル名に「teammirai」が含まれている場合trueを返す", () => {
+      expect(
+        hasTeamMiraiTag(undefined, undefined, undefined, "TeamMirai Official"),
+      ).toBe(true);
+    });
+  });
+
+  describe("マッチしないケース", () => {
+    it("全てundefinedの場合falseを返す", () => {
+      expect(hasTeamMiraiTag(undefined)).toBe(false);
+    });
+
+    it("全てnull/undefinedの場合falseを返す", () => {
+      expect(hasTeamMiraiTag(undefined, null, null, null)).toBe(false);
+    });
+
+    it("空のタグ配列の場合falseを返す", () => {
+      expect(hasTeamMiraiTag([])).toBe(false);
+    });
+
+    it("関係ない内容のみの場合falseを返す", () => {
+      expect(
+        hasTeamMiraiTag(
+          ["政治", "日本"],
+          "普通の動画",
+          "普通の説明",
+          "普通のチャンネル",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("複数フィールドの組み合わせ", () => {
+    it("タグではマッチしないがタイトルでマッチする場合trueを返す", () => {
+      expect(hasTeamMiraiTag(["無関係"], "チームみらい動画")).toBe(true);
+    });
+
+    it("タグとタイトルではマッチしないが説明文でマッチする場合trueを返す", () => {
+      expect(
+        hasTeamMiraiTag(["無関係"], "普通のタイトル", "チームみらいの説明"),
+      ).toBe(true);
+    });
+
+    it("タグ、タイトル、説明文ではマッチしないがチャンネル名でマッチする場合trueを返す", () => {
+      expect(
+        hasTeamMiraiTag(
+          ["無関係"],
+          "普通のタイトル",
+          "普通の説明",
+          "チームみらい公式",
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/features/youtube/services/youtube-video-service.ts
+++ b/src/features/youtube/services/youtube-video-service.ts
@@ -1,15 +1,13 @@
 import "server-only";
 
 import { createAdminClient } from "@/lib/supabase/adminClient";
+import { filterTeamMiraiVideos } from "../utils/video-filter";
 import type { YouTubeVideoDetail } from "./youtube-client";
 import {
   fetchChannelInfo,
   fetchUserUploadedVideos,
   fetchVideoDetails,
 } from "./youtube-client";
-
-// #チームみらい を検出する正規表現
-const TEAM_MIRAI_REGEX = /#(チームみらい|teammirai)/i;
 
 /**
  * YouTube同期結果
@@ -19,25 +17,6 @@ export interface YouTubeSyncResult {
   syncedCount?: number;
   skippedCount?: number;
   error?: string;
-}
-
-/**
- * #チームみらい 動画をフィルタリングする
- */
-export function filterTeamMiraiVideos(
-  videos: YouTubeVideoDetail[],
-): YouTubeVideoDetail[] {
-  return videos.filter((video) => {
-    const description = video.snippet.description || "";
-    const title = video.snippet.title || "";
-    const tags = video.snippet.tags || [];
-
-    return (
-      TEAM_MIRAI_REGEX.test(description) ||
-      TEAM_MIRAI_REGEX.test(title) ||
-      tags.some((tag) => TEAM_MIRAI_REGEX.test(tag))
-    );
-  });
 }
 
 /**

--- a/src/features/youtube/utils/video-filter.test.ts
+++ b/src/features/youtube/utils/video-filter.test.ts
@@ -1,0 +1,103 @@
+import type { YouTubeVideoDetail } from "../services/youtube-client";
+import { filterTeamMiraiVideos, TEAM_MIRAI_REGEX } from "./video-filter";
+
+const createVideo = (
+  overrides: Partial<{
+    title: string;
+    description: string;
+    tags: string[];
+  }> = {},
+): YouTubeVideoDetail => ({
+  id: "video-1",
+  snippet: {
+    publishedAt: "2025-01-01T00:00:00Z",
+    channelId: "channel-1",
+    channelTitle: "test channel",
+    title: overrides.title ?? "普通の動画",
+    description: overrides.description ?? "普通の説明",
+    thumbnails: {},
+    tags: overrides.tags,
+  },
+  contentDetails: { duration: "PT10M" },
+  statistics: {},
+});
+
+describe("TEAM_MIRAI_REGEX", () => {
+  it("#チームみらい にマッチする", () => {
+    expect(TEAM_MIRAI_REGEX.test("#チームみらい")).toBe(true);
+  });
+
+  it("#teammirai にマッチする", () => {
+    expect(TEAM_MIRAI_REGEX.test("#teammirai")).toBe(true);
+  });
+
+  it("#TeamMirai (大文字混在)にマッチする", () => {
+    expect(TEAM_MIRAI_REGEX.test("#TeamMirai")).toBe(true);
+  });
+
+  it("ハッシュタグなしの場合マッチしない", () => {
+    expect(TEAM_MIRAI_REGEX.test("チームみらい")).toBe(false);
+  });
+});
+
+describe("filterTeamMiraiVideos", () => {
+  it("説明文に#チームみらいを含む動画をフィルタする", () => {
+    const videos = [
+      createVideo({ description: "活動報告 #チームみらい" }),
+      createVideo({ description: "関係ない動画" }),
+    ];
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+    expect(result[0].snippet.description).toBe("活動報告 #チームみらい");
+  });
+
+  it("タイトルに#チームみらいを含む動画をフィルタする", () => {
+    const videos = [
+      createVideo({ title: "#チームみらい 活動報告" }),
+      createVideo({ title: "無関係" }),
+    ];
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+    expect(result[0].snippet.title).toBe("#チームみらい 活動報告");
+  });
+
+  it("タグに#チームみらいを含む動画をフィルタする", () => {
+    const videos = [
+      createVideo({ tags: ["#チームみらい", "政治"] }),
+      createVideo({ tags: ["関係ない"] }),
+    ];
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+  });
+
+  it("タグに#teammirai(大小文字無視)を含む動画をフィルタする", () => {
+    const videos = [createVideo({ tags: ["#TeamMirai"] })];
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+  });
+
+  it("マッチする動画がない場合は空配列を返す", () => {
+    const videos = [
+      createVideo({ title: "無関係", description: "無関係", tags: ["無関係"] }),
+    ];
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(0);
+  });
+
+  it("空配列を渡した場合は空配列を返す", () => {
+    const result = filterTeamMiraiVideos([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("タイトル、説明文、タグの複数でマッチしても重複しない", () => {
+    const videos = [
+      createVideo({
+        title: "#チームみらい",
+        description: "#チームみらい 説明",
+        tags: ["#チームみらい"],
+      }),
+    ];
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/features/youtube/utils/video-filter.ts
+++ b/src/features/youtube/utils/video-filter.ts
@@ -1,0 +1,23 @@
+import type { YouTubeVideoDetail } from "../services/youtube-client";
+
+// #チームみらい を検出する正規表現
+export const TEAM_MIRAI_REGEX = /#(チームみらい|teammirai)/i;
+
+/**
+ * #チームみらい 動画をフィルタリングする
+ */
+export function filterTeamMiraiVideos(
+  videos: YouTubeVideoDetail[],
+): YouTubeVideoDetail[] {
+  return videos.filter((video) => {
+    const description = video.snippet.description || "";
+    const title = video.snippet.title || "";
+    const tags = video.snippet.tags || [];
+
+    return (
+      TEAM_MIRAI_REGEX.test(description) ||
+      TEAM_MIRAI_REGEX.test(title) ||
+      tags.some((tag) => TEAM_MIRAI_REGEX.test(tag))
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- `filterTeamMiraiVideos` と `TEAM_MIRAI_REGEX` を `youtube-video-service.ts` から `utils/video-filter.ts` に移動し、テスト可能な純粋関数として独立させた
- `hasTeamMiraiTag` のユニットテスト(タグ/タイトル/説明文/チャンネル名のマッチ、大小文字区別なし、全てundefined/null)を追加
- `filterTeamMiraiVideos` のユニットテスト(マッチあり/なし/空配列/タイトルマッチ/説明文マッチ/タグマッチ)を追加

## Test plan
- [x] `npx jest --testPathPattern="(team-mirai|video-filter)\.test"` で全31テストがパス
- [x] `pnpm run typecheck` がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)