### PR TITLE
refactor: クイズ採点ロジックをutils/に切り出し

### DIFF
--- a/src/features/mission-detail/utils/quiz-grader.test.ts
+++ b/src/features/mission-detail/utils/quiz-grader.test.ts
@@ -1,0 +1,215 @@
+import {
+  gradeQuizAnswers,
+  type QuizAnswer,
+  type QuizQuestion,
+  type QuizQuestionRow,
+  transformQuizRow,
+} from "./quiz-grader";
+
+describe("quiz-grader", () => {
+  describe("transformQuizRow", () => {
+    it("正常なDBの行データをQuizQuestion型に変換する", () => {
+      const row: QuizQuestionRow = {
+        id: "q1",
+        question: "日本の首都は？",
+        option1: "大阪",
+        option2: "東京",
+        option3: "京都",
+        option4: "名古屋",
+        correct_answer: 2,
+        explanation: "東京が日本の首都です",
+        quiz_categories: { name: "地理" },
+      };
+
+      const result = transformQuizRow(row);
+
+      expect(result).toEqual({
+        id: "q1",
+        question: "日本の首都は？",
+        options: ["大阪", "東京", "京都", "名古屋"],
+        correct_answer: 2,
+        explanation: "東京が日本の首都です",
+        category: "地理",
+      });
+    });
+
+    it("quiz_categoriesが配列の場合、最初のカテゴリ名を使用する", () => {
+      const row: QuizQuestionRow = {
+        id: "q2",
+        question: "テスト問題",
+        option1: "A",
+        option2: "B",
+        option3: "C",
+        option4: "D",
+        correct_answer: 1,
+        explanation: "説明",
+        quiz_categories: [{ name: "カテゴリ1" }, { name: "カテゴリ2" }],
+      };
+
+      const result = transformQuizRow(row);
+
+      expect(result.category).toBe("カテゴリ1");
+    });
+
+    it("quiz_categoriesがnullの場合、'その他'を返す", () => {
+      const row: QuizQuestionRow = {
+        id: "q3",
+        question: "テスト問題",
+        option1: "A",
+        option2: "B",
+        option3: "C",
+        option4: "D",
+        correct_answer: 1,
+        explanation: "説明",
+        quiz_categories: null,
+      };
+
+      const result = transformQuizRow(row);
+
+      expect(result.category).toBe("その他");
+    });
+
+    it("explanationがnullの場合、nullをそのまま返す", () => {
+      const row: QuizQuestionRow = {
+        id: "q4",
+        question: "テスト問題",
+        option1: "A",
+        option2: "B",
+        option3: "C",
+        option4: "D",
+        correct_answer: 1,
+        explanation: null,
+        quiz_categories: { name: "テスト" },
+      };
+
+      const result = transformQuizRow(row);
+
+      expect(result.explanation).toBeNull();
+    });
+  });
+
+  describe("gradeQuizAnswers", () => {
+    const questions: QuizQuestion[] = [
+      {
+        id: "q1",
+        question: "問題1",
+        options: ["A", "B", "C", "D"],
+        correct_answer: 1,
+        explanation: "解説1",
+      },
+      {
+        id: "q2",
+        question: "問題2",
+        options: ["A", "B", "C", "D"],
+        correct_answer: 2,
+        explanation: "解説2",
+      },
+      {
+        id: "q3",
+        question: "問題3",
+        options: ["A", "B", "C", "D"],
+        correct_answer: 3,
+        explanation: "解説3",
+      },
+      {
+        id: "q4",
+        question: "問題4",
+        options: ["A", "B", "C", "D"],
+        correct_answer: 4,
+        explanation: "解説4",
+      },
+      {
+        id: "q5",
+        question: "問題5",
+        options: ["A", "B", "C", "D"],
+        correct_answer: 1,
+        explanation: null,
+      },
+    ];
+
+    it("全問正解の場合、スコア100で合格", () => {
+      const answers: QuizAnswer[] = [
+        { questionId: "q1", selectedAnswer: 1 },
+        { questionId: "q2", selectedAnswer: 2 },
+        { questionId: "q3", selectedAnswer: 3 },
+        { questionId: "q4", selectedAnswer: 4 },
+        { questionId: "q5", selectedAnswer: 1 },
+      ];
+
+      const result = gradeQuizAnswers(questions, answers);
+
+      expect(result.score).toBe(100);
+      expect(result.passed).toBe(true);
+      expect(result.correctAnswers).toBe(5);
+      expect(result.totalQuestions).toBe(5);
+      expect(result.results.every((r) => r.correct)).toBe(true);
+    });
+
+    it("全問不正解の場合、スコア0で不合格", () => {
+      const answers: QuizAnswer[] = [
+        { questionId: "q1", selectedAnswer: 2 },
+        { questionId: "q2", selectedAnswer: 1 },
+        { questionId: "q3", selectedAnswer: 1 },
+        { questionId: "q4", selectedAnswer: 1 },
+        { questionId: "q5", selectedAnswer: 2 },
+      ];
+
+      const result = gradeQuizAnswers(questions, answers);
+
+      expect(result.score).toBe(0);
+      expect(result.passed).toBe(false);
+      expect(result.correctAnswers).toBe(0);
+      expect(result.results.every((r) => !r.correct)).toBe(true);
+    });
+
+    it("部分正解の場合（80%正解でも全問正解でなければ不合格）", () => {
+      const answers: QuizAnswer[] = [
+        { questionId: "q1", selectedAnswer: 1 },
+        { questionId: "q2", selectedAnswer: 2 },
+        { questionId: "q3", selectedAnswer: 3 },
+        { questionId: "q4", selectedAnswer: 4 },
+        { questionId: "q5", selectedAnswer: 2 }, // 不正解
+      ];
+
+      const result = gradeQuizAnswers(questions, answers);
+
+      expect(result.score).toBe(80);
+      expect(result.passed).toBe(false);
+      expect(result.correctAnswers).toBe(4);
+      expect(result.totalQuestions).toBe(5);
+    });
+
+    it("空の回答配列の場合、スコア0で不合格", () => {
+      const answers: QuizAnswer[] = [];
+
+      const result = gradeQuizAnswers(questions, answers);
+
+      expect(result.score).toBe(0);
+      expect(result.passed).toBe(false);
+      expect(result.correctAnswers).toBe(0);
+      expect(result.totalQuestions).toBe(5);
+      expect(result.results).toHaveLength(0);
+    });
+
+    it("存在しないquestionIdの回答は不正解として扱う", () => {
+      const answers: QuizAnswer[] = [
+        { questionId: "nonexistent", selectedAnswer: 1 },
+      ];
+
+      const result = gradeQuizAnswers(questions, answers);
+
+      expect(result.results[0].correct).toBe(false);
+      expect(result.results[0].explanation).toBe("");
+      expect(result.results[0].correctAnswer).toBe(0);
+    });
+
+    it("explanationがnullの問題は空文字列で返す", () => {
+      const answers: QuizAnswer[] = [{ questionId: "q5", selectedAnswer: 1 }];
+
+      const result = gradeQuizAnswers(questions, answers);
+
+      expect(result.results[0].correct).toBe(true);
+      expect(result.results[0].explanation).toBe("");
+    });
+  });
+});

--- a/src/features/mission-detail/utils/quiz-grader.ts
+++ b/src/features/mission-detail/utils/quiz-grader.ts
@@ -1,0 +1,107 @@
+// クイズ用の型定義
+export interface QuizQuestion {
+  id: string;
+  question: string;
+  options: string[];
+  correct_answer: number;
+  explanation: string | null;
+  category?: string;
+}
+
+// DB行データの型定義
+export interface QuizQuestionRow {
+  id: string;
+  question: string;
+  option1: string;
+  option2: string;
+  option3: string;
+  option4: string;
+  correct_answer: number;
+  explanation: string | null;
+  quiz_categories: { name: string } | { name: string }[] | null;
+}
+
+/**
+ * DBの行データをQuizQuestion型に変換する
+ * option1〜option4の個別カラムをoptions配列に変換し、カテゴリ名を抽出する
+ */
+export function transformQuizRow(row: QuizQuestionRow): QuizQuestion {
+  const category = Array.isArray(row.quiz_categories)
+    ? row.quiz_categories[0]
+    : row.quiz_categories;
+  return {
+    id: row.id,
+    question: row.question,
+    options: [row.option1, row.option2, row.option3, row.option4],
+    correct_answer: row.correct_answer,
+    explanation: row.explanation,
+    category: category?.name || "その他",
+  };
+}
+
+// 回答の型定義
+export interface QuizAnswer {
+  questionId: string;
+  selectedAnswer: number;
+}
+
+// 採点結果の型定義
+export interface QuizAnswerResult {
+  questionId: string;
+  correct: boolean;
+  explanation: string;
+  selectedAnswer: number;
+  correctAnswer: number;
+}
+
+export interface QuizGradeResult {
+  score: number;
+  passed: boolean;
+  correctAnswers: number;
+  totalQuestions: number;
+  results: QuizAnswerResult[];
+}
+
+/**
+ * クイズの回答を正解と照合し、スコア・合否を計算する
+ * 全問正解が合格条件
+ */
+export function gradeQuizAnswers(
+  questions: QuizQuestion[],
+  answers: QuizAnswer[],
+): QuizGradeResult {
+  const results = answers.map((answer) => {
+    const question = questions.find((q) => q.id === answer.questionId);
+    if (!question) {
+      return {
+        questionId: answer.questionId,
+        correct: false,
+        explanation: "",
+        selectedAnswer: answer.selectedAnswer,
+        correctAnswer: 0,
+      };
+    }
+
+    const isCorrect = question.correct_answer === answer.selectedAnswer;
+    return {
+      questionId: answer.questionId,
+      correct: isCorrect,
+      explanation: question.explanation || "",
+      selectedAnswer: answer.selectedAnswer,
+      correctAnswer: question.correct_answer,
+    };
+  });
+
+  const correctCount = results.filter((r) => r.correct).length;
+  const totalQuestions = questions.length;
+  const score = Math.round((correctCount / totalQuestions) * 100);
+  const passed = correctCount === totalQuestions;
+
+  return {
+    score,
+    passed,
+    correctAnswers: correctCount,
+    totalQuestions,
+    results,
+  };
+}


### PR DESCRIPTION
## Summary
- `transformQuizRow`と`gradeQuizAnswers`の純粋関数ロジックを`quiz-actions.ts`から`utils/quiz-grader.ts`に抽出
- 元のServer Actionからはimportに変更し、動作は変更なし
- 10件のユニットテストを追加（正常変換、カテゴリ配列/null、全問正解/不正解/部分正解、空回答、存在しないID）

## Test plan
- [x] `npx jest --testPathPattern=quiz-grader` - 10テスト全てパス
- [x] `pnpm run typecheck` - 型エラーなし
- [x] `pnpm run biome:check:write` - フォーマット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)