### PR TITLE
refactor: YouTube動画レコード変換をutils/に切り出し

### DIFF
--- a/src/features/youtube/services/youtube-video-sync-service.ts
+++ b/src/features/youtube/services/youtube-video-sync-service.ts
@@ -5,6 +5,12 @@
 
 import { google } from "googleapis";
 import { createAdminClient } from "@/lib/supabase/adminClient";
+import {
+  getLatestPublishedAfter,
+  getOldestPublishedBefore,
+  toStatsRecord,
+  toVideoRecord,
+} from "../utils/video-record-utils";
 
 const HASHTAG = "#チームみらい";
 
@@ -186,88 +192,13 @@ export async function getVideoDetails(
   return allDetails;
 }
 
-// 変換関数
-
-export function toVideoRecord(video: YouTubeVideoDetails): YouTubeVideoRecord {
-  return {
-    video_id: video.id,
-    video_url: `https://www.youtube.com/watch?v=${video.id}`,
-    title: video.snippet.title,
-    description: video.snippet.description || null,
-    thumbnail_url:
-      video.snippet.thumbnails.high?.url ||
-      video.snippet.thumbnails.medium?.url ||
-      video.snippet.thumbnails.default?.url ||
-      null,
-    channel_id: video.snippet.channelId,
-    channel_title: video.snippet.channelTitle || null,
-    published_at: video.snippet.publishedAt || null,
-    duration: video.contentDetails?.duration || null,
-    tags: video.snippet.tags || null,
-    is_active: true,
-  };
-}
-
-export function toStatsRecord(
-  videoId: string,
-  video: YouTubeVideoDetails,
-  recordedAt: string,
-): YouTubeVideoStatsRecord {
-  return {
-    video_id: videoId,
-    recorded_at: recordedAt,
-    view_count: video.statistics?.viewCount
-      ? Number.parseInt(video.statistics.viewCount, 10)
-      : null,
-    like_count: video.statistics?.likeCount
-      ? Number.parseInt(video.statistics.likeCount, 10)
-      : null,
-    comment_count: video.statistics?.commentCount
-      ? Number.parseInt(video.statistics.commentCount, 10)
-      : null,
-  };
-}
-
-export function getLatestPublishedAfter(
-  videos: { published_at: string | null }[],
-): string | undefined {
-  if (videos.length === 0) {
-    return undefined;
-  }
-
-  const latestPublishedAt = videos
-    .filter((v) => v.published_at)
-    .map((v) => new Date(v.published_at as string).getTime())
-    .reduce((max, time) => Math.max(max, time), 0);
-
-  if (latestPublishedAt === 0) {
-    return undefined;
-  }
-
-  // 1秒追加して、最新の動画自体は除外する
-  return new Date(latestPublishedAt + 1000).toISOString();
-}
-
-export function getOldestPublishedBefore(
-  videos: { published_at: string | null }[],
-): string | undefined {
-  if (videos.length === 0) {
-    return undefined;
-  }
-
-  const timestamps = videos
-    .filter((v) => v.published_at)
-    .map((v) => new Date(v.published_at as string).getTime());
-
-  if (timestamps.length === 0) {
-    return undefined;
-  }
-
-  const oldestPublishedAt = Math.min(...timestamps);
-
-  // 1秒引いて、最古の動画自体は除外する
-  return new Date(oldestPublishedAt - 1000).toISOString();
-}
+// 変換関数を再エクスポート
+export {
+  getLatestPublishedAfter,
+  getOldestPublishedBefore,
+  toStatsRecord,
+  toVideoRecord,
+} from "../utils/video-record-utils";
 
 // DB操作関数
 

--- a/src/features/youtube/utils/video-record-utils.test.ts
+++ b/src/features/youtube/utils/video-record-utils.test.ts
@@ -1,0 +1,226 @@
+import type { YouTubeVideoDetails } from "../services/youtube-video-sync-service";
+import {
+  getLatestPublishedAfter,
+  getOldestPublishedBefore,
+  toStatsRecord,
+  toVideoRecord,
+} from "./video-record-utils";
+
+const createVideoDetails = (
+  overrides: Partial<YouTubeVideoDetails> = {},
+): YouTubeVideoDetails => ({
+  id: "test-video-id",
+  snippet: {
+    title: "テスト動画",
+    description: "テスト説明文",
+    channelId: "channel-123",
+    channelTitle: "テストチャンネル",
+    publishedAt: "2025-01-01T00:00:00Z",
+    tags: ["tag1", "tag2"],
+    thumbnails: {
+      default: { url: "https://example.com/default.jpg" },
+      medium: { url: "https://example.com/medium.jpg" },
+      high: { url: "https://example.com/high.jpg" },
+    },
+  },
+  contentDetails: {
+    duration: "PT10M30S",
+  },
+  statistics: {
+    viewCount: "12345",
+    likeCount: "678",
+    commentCount: "90",
+  },
+  ...overrides,
+});
+
+describe("YouTube動画レコード変換ユーティリティ", () => {
+  describe("toVideoRecord", () => {
+    it("全フィールドありの場合、正しいレコードに変換する", () => {
+      const video = createVideoDetails();
+      const record = toVideoRecord(video);
+
+      expect(record).toEqual({
+        video_id: "test-video-id",
+        video_url: "https://www.youtube.com/watch?v=test-video-id",
+        title: "テスト動画",
+        description: "テスト説明文",
+        thumbnail_url: "https://example.com/high.jpg",
+        channel_id: "channel-123",
+        channel_title: "テストチャンネル",
+        published_at: "2025-01-01T00:00:00Z",
+        duration: "PT10M30S",
+        tags: ["tag1", "tag2"],
+        is_active: true,
+      });
+    });
+
+    it("optionalフィールドがない場合、nullにフォールバックする", () => {
+      const video = createVideoDetails({
+        snippet: {
+          title: "最小動画",
+          description: "",
+          channelId: "ch-1",
+          channelTitle: "",
+          publishedAt: "",
+          thumbnails: {},
+        },
+        contentDetails: {
+          duration: "",
+        },
+      });
+      const record = toVideoRecord(video);
+
+      expect(record.description).toBeNull();
+      expect(record.thumbnail_url).toBeNull();
+      expect(record.channel_title).toBeNull();
+      expect(record.published_at).toBeNull();
+      expect(record.duration).toBeNull();
+      expect(record.tags).toBeNull();
+    });
+
+    it("thumbnailがhighのみ欠落の場合、mediumにフォールバックする", () => {
+      const video = createVideoDetails({
+        snippet: {
+          title: "動画",
+          description: "説明",
+          channelId: "ch-1",
+          channelTitle: "チャンネル",
+          publishedAt: "2025-01-01T00:00:00Z",
+          thumbnails: {
+            medium: { url: "https://example.com/medium.jpg" },
+            default: { url: "https://example.com/default.jpg" },
+          },
+        },
+      });
+      const record = toVideoRecord(video);
+
+      expect(record.thumbnail_url).toBe("https://example.com/medium.jpg");
+    });
+
+    it("thumbnailがdefaultのみの場合、defaultにフォールバックする", () => {
+      const video = createVideoDetails({
+        snippet: {
+          title: "動画",
+          description: "説明",
+          channelId: "ch-1",
+          channelTitle: "チャンネル",
+          publishedAt: "2025-01-01T00:00:00Z",
+          thumbnails: {
+            default: { url: "https://example.com/default.jpg" },
+          },
+        },
+      });
+      const record = toVideoRecord(video);
+
+      expect(record.thumbnail_url).toBe("https://example.com/default.jpg");
+    });
+  });
+
+  describe("toStatsRecord", () => {
+    it("全統計ありの場合、文字列を数値に変換する", () => {
+      const video = createVideoDetails();
+      const record = toStatsRecord("vid-1", video, "2025-06-01");
+
+      expect(record).toEqual({
+        video_id: "vid-1",
+        recorded_at: "2025-06-01",
+        view_count: 12345,
+        like_count: 678,
+        comment_count: 90,
+      });
+    });
+
+    it("統計がnullの場合、nullを返す", () => {
+      const video = createVideoDetails({
+        statistics: {} as YouTubeVideoDetails["statistics"],
+      });
+      const record = toStatsRecord("vid-1", video, "2025-06-01");
+
+      expect(record.view_count).toBeNull();
+      expect(record.like_count).toBeNull();
+      expect(record.comment_count).toBeNull();
+    });
+
+    it("文字列の数値を正しくパースする", () => {
+      const video = createVideoDetails({
+        statistics: {
+          viewCount: "1000000",
+          likeCount: "0",
+          commentCount: "1",
+        },
+      });
+      const record = toStatsRecord("vid-1", video, "2025-06-01");
+
+      expect(record.view_count).toBe(1000000);
+      expect(record.like_count).toBe(0);
+      expect(record.comment_count).toBe(1);
+    });
+  });
+
+  describe("getLatestPublishedAfter", () => {
+    it("複数動画から最新の公開日+1秒を返す", () => {
+      const videos = [
+        { published_at: "2025-01-01T00:00:00.000Z" },
+        { published_at: "2025-06-15T12:00:00.000Z" },
+        { published_at: "2025-03-10T06:00:00.000Z" },
+      ];
+      const result = getLatestPublishedAfter(videos);
+
+      expect(result).toBe(new Date("2025-06-15T12:00:01.000Z").toISOString());
+    });
+
+    it("空配列の場合はundefinedを返す", () => {
+      expect(getLatestPublishedAfter([])).toBeUndefined();
+    });
+
+    it("全てnullの配列の場合はundefinedを返す", () => {
+      const videos = [{ published_at: null }, { published_at: null }];
+      expect(getLatestPublishedAfter(videos)).toBeUndefined();
+    });
+
+    it("nullと日付が混在する場合、有効な日付のみで最新を求める", () => {
+      const videos = [
+        { published_at: null },
+        { published_at: "2025-04-01T00:00:00.000Z" },
+        { published_at: null },
+      ];
+      const result = getLatestPublishedAfter(videos);
+
+      expect(result).toBe(new Date("2025-04-01T00:00:01.000Z").toISOString());
+    });
+  });
+
+  describe("getOldestPublishedBefore", () => {
+    it("複数動画から最古の公開日-1秒を返す", () => {
+      const videos = [
+        { published_at: "2025-01-01T00:00:00.000Z" },
+        { published_at: "2025-06-15T12:00:00.000Z" },
+        { published_at: "2025-03-10T06:00:00.000Z" },
+      ];
+      const result = getOldestPublishedBefore(videos);
+
+      expect(result).toBe(new Date("2024-12-31T23:59:59.000Z").toISOString());
+    });
+
+    it("空配列の場合はundefinedを返す", () => {
+      expect(getOldestPublishedBefore([])).toBeUndefined();
+    });
+
+    it("全てnullの配列の場合はundefinedを返す", () => {
+      const videos = [{ published_at: null }, { published_at: null }];
+      expect(getOldestPublishedBefore(videos)).toBeUndefined();
+    });
+
+    it("nullと日付が混在する場合、有効な日付のみで最古を求める", () => {
+      const videos = [
+        { published_at: null },
+        { published_at: "2025-08-20T00:00:00.000Z" },
+        { published_at: null },
+      ];
+      const result = getOldestPublishedBefore(videos);
+
+      expect(result).toBe(new Date("2025-08-19T23:59:59.000Z").toISOString());
+    });
+  });
+});

--- a/src/features/youtube/utils/video-record-utils.ts
+++ b/src/features/youtube/utils/video-record-utils.ts
@@ -1,0 +1,102 @@
+/**
+ * YouTube動画レコード変換ユーティリティ
+ */
+
+import type {
+  YouTubeVideoDetails,
+  YouTubeVideoRecord,
+  YouTubeVideoStatsRecord,
+} from "../services/youtube-video-sync-service";
+
+/**
+ * YouTubeVideoDetails を DB保存用の YouTubeVideoRecord に変換する
+ */
+export function toVideoRecord(video: YouTubeVideoDetails): YouTubeVideoRecord {
+  return {
+    video_id: video.id,
+    video_url: `https://www.youtube.com/watch?v=${video.id}`,
+    title: video.snippet.title,
+    description: video.snippet.description || null,
+    thumbnail_url:
+      video.snippet.thumbnails.high?.url ||
+      video.snippet.thumbnails.medium?.url ||
+      video.snippet.thumbnails.default?.url ||
+      null,
+    channel_id: video.snippet.channelId,
+    channel_title: video.snippet.channelTitle || null,
+    published_at: video.snippet.publishedAt || null,
+    duration: video.contentDetails?.duration || null,
+    tags: video.snippet.tags || null,
+    is_active: true,
+  };
+}
+
+/**
+ * YouTubeVideoDetails を統計スナップショットレコードに変換する
+ */
+export function toStatsRecord(
+  videoId: string,
+  video: YouTubeVideoDetails,
+  recordedAt: string,
+): YouTubeVideoStatsRecord {
+  return {
+    video_id: videoId,
+    recorded_at: recordedAt,
+    view_count: video.statistics?.viewCount
+      ? Number.parseInt(video.statistics.viewCount, 10)
+      : null,
+    like_count: video.statistics?.likeCount
+      ? Number.parseInt(video.statistics.likeCount, 10)
+      : null,
+    comment_count: video.statistics?.commentCount
+      ? Number.parseInt(video.statistics.commentCount, 10)
+      : null,
+  };
+}
+
+/**
+ * 動画配列から最新の公開日時+1秒を返す（差分同期の publishedAfter 用）
+ */
+export function getLatestPublishedAfter(
+  videos: { published_at: string | null }[],
+): string | undefined {
+  if (videos.length === 0) {
+    return undefined;
+  }
+
+  const latestPublishedAt = videos
+    .filter((v) => v.published_at)
+    .map((v) => new Date(v.published_at as string).getTime())
+    .reduce((max, time) => Math.max(max, time), 0);
+
+  if (latestPublishedAt === 0) {
+    return undefined;
+  }
+
+  // 1秒追加して、最新の動画自体は除外する
+  return new Date(latestPublishedAt + 1000).toISOString();
+}
+
+/**
+ * 動画配列から最古の公開日時-1秒を返す（バックフィルの publishedBefore 用）
+ */
+export function getOldestPublishedBefore(
+  videos: { published_at: string | null }[],
+): string | undefined {
+  if (videos.length === 0) {
+    return undefined;
+  }
+
+  const timestamps = videos
+    .filter((v) => v.published_at)
+    .map((v) => new Date(v.published_at as string).getTime());
+
+  if (timestamps.length === 0) {
+    return undefined;
+  }
+
+  const oldestPublishedAt = Math.min(...timestamps);
+
+  // 1秒引いて、最古の動画自体は除外する
+  return new Date(oldestPublishedAt - 1000).toISOString();
+}


### PR DESCRIPTION
## Summary
- `toVideoRecord`, `toStatsRecord`, `getLatestPublishedAfter`, `getOldestPublishedBefore` を `services/youtube-video-sync-service.ts` から `utils/video-record-utils.ts` に移動
- 元ファイルからは再エクスポートで後方互換性を維持
- 15件のユニットテストを追加（レコード変換、統計変換、公開日時の境界計算、空配列・null配列の異常系）

## Test plan
- [x] `npx jest --testPathPattern="video-record-utils"` で全15テスト通過
- [x] `pnpm run typecheck` 通過
- [x] `pnpm run biome:check:write` 通過
- [x] 既存のインポートパスは再エクスポートにより影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)