### PR TITLE
refactor: extractHashtags を共通ユーティリティに統合

### DIFF
--- a/src/features/tiktok/services/tiktok-video-service.ts
+++ b/src/features/tiktok/services/tiktok-video-service.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
+import { extractHashtags } from "@/lib/utils/text-utils";
 import type {
   TikTokSyncResult,
   TikTokVideo,

--- a/src/features/youtube/services/youtube-video-service.ts
+++ b/src/features/youtube/services/youtube-video-service.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { createAdminClient } from "@/lib/supabase/adminClient";
+import { extractHashtags } from "@/lib/utils/text-utils";
 import { filterTeamMiraiVideos } from "../utils/video-filter";
 import type { YouTubeVideoDetail } from "./youtube-client";
 import {
@@ -17,14 +18,6 @@ export interface YouTubeSyncResult {
   syncedCount?: number;
   skippedCount?: number;
   error?: string;
-}
-
-/**
- * テキストからハッシュタグを抽出する
- */
-function extractHashtags(text: string): string[] {
-  const matches = text.match(/#[\w\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]+/g);
-  return matches || [];
 }
 
 /**

--- a/src/lib/utils/text-utils.test.ts
+++ b/src/lib/utils/text-utils.test.ts
@@ -1,0 +1,81 @@
+import { extractHashtags } from "./text-utils";
+
+describe("extractHashtags", () => {
+  describe("英語ハッシュタグ", () => {
+    it("#hello を抽出する", () => {
+      expect(extractHashtags("Hello #hello world")).toEqual(["#hello"]);
+    });
+
+    it("#TeamMirai を抽出する", () => {
+      expect(extractHashtags("Check out #TeamMirai")).toEqual(["#TeamMirai"]);
+    });
+  });
+
+  describe("日本語ハッシュタグ", () => {
+    it("ひらがなハッシュタグを抽出する", () => {
+      expect(extractHashtags("動画 #チームみらい です")).toEqual([
+        "#チームみらい",
+      ]);
+    });
+
+    it("カタカナハッシュタグを抽出する", () => {
+      expect(extractHashtags("#カタカナ テスト")).toEqual(["#カタカナ"]);
+    });
+
+    it("漢字ハッシュタグを抽出する", () => {
+      expect(extractHashtags("#政治改革 について")).toEqual(["#政治改革"]);
+    });
+  });
+
+  describe("複数タグ混在", () => {
+    it("英語と日本語のハッシュタグを同時に抽出する", () => {
+      const result = extractHashtags("#チームみらい の活動 #teammirai #政治");
+      expect(result).toEqual(["#チームみらい", "#teammirai", "#政治"]);
+    });
+
+    it("テキスト中の複数のハッシュタグを全て抽出する", () => {
+      const result = extractHashtags("#tag1 some text #tag2 more #tag3");
+      expect(result).toEqual(["#tag1", "#tag2", "#tag3"]);
+    });
+  });
+
+  describe("タグなし", () => {
+    it("ハッシュタグがない場合は空配列を返す", () => {
+      expect(extractHashtags("No hashtags here")).toEqual([]);
+    });
+  });
+
+  describe("空文字", () => {
+    it("空文字列の場合は空配列を返す", () => {
+      expect(extractHashtags("")).toEqual([]);
+    });
+  });
+
+  describe("特殊文字の境界", () => {
+    it("スペースでハッシュタグが区切られる", () => {
+      expect(extractHashtags("#hello world")).toEqual(["#hello"]);
+    });
+
+    it("数字を含むハッシュタグを抽出する", () => {
+      expect(extractHashtags("#tag123")).toEqual(["#tag123"]);
+    });
+
+    it("アンダースコアを含むハッシュタグを抽出する", () => {
+      expect(extractHashtags("#team_mirai")).toEqual(["#team_mirai"]);
+    });
+
+    it("#のみの場合はマッチしない", () => {
+      expect(extractHashtags("# alone")).toEqual([]);
+    });
+
+    it("連続するハッシュタグを抽出する", () => {
+      expect(extractHashtags("#tag1#tag2")).toEqual(["#tag1", "#tag2"]);
+    });
+
+    it("ひらがな・カタカナ・漢字混在のタグを抽出する", () => {
+      expect(extractHashtags("#チームみらい応援団")).toEqual([
+        "#チームみらい応援団",
+      ]);
+    });
+  });
+});

--- a/src/lib/utils/text-utils.ts
+++ b/src/lib/utils/text-utils.ts
@@ -1,0 +1,7 @@
+/**
+ * テキストからハッシュタグを抽出する
+ */
+export function extractHashtags(text: string): string[] {
+  const matches = text.match(/#[\w\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]+/g);
+  return matches || [];
+}


### PR DESCRIPTION
## Summary
- `youtube-video-service.ts` と `tiktok-video-service.ts` に重複していた `extractHashtags` 関数を `src/lib/utils/text-utils.ts` に共通化
- 両サービスファイルから private 関数を削除し、共通ユーティリティからインポートするように変更
- 英語/日本語ハッシュタグ、複数タグ混在、空文字、特殊文字境界を含む15件のテストを追加

## Test plan
- [x] `npx jest --testPathPattern="text-utils.test"` で全15テストがパス
- [x] `pnpm run typecheck` がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタ**
  * ハッシュタグ抽出ロジックを共有ユーティリティに統合し、複数のサービス間での一貫性を向上させました。

* **テスト**
  * ハッシュタグ抽出機能の包括的なテストを追加しました。英語、日本語、複数言語に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->