### PR TITLE
refactor: ポスターボード統計をutils/に切り出し

### DIFF
--- a/src/features/map-poster/utils/poster-stats.test.ts
+++ b/src/features/map-poster/utils/poster-stats.test.ts
@@ -1,0 +1,77 @@
+import type { Database } from "@/lib/types/supabase";
+import { countBoardsByStatus, createEmptyStatusCounts } from "./poster-stats";
+
+type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
+
+describe("poster-stats", () => {
+  describe("createEmptyStatusCounts", () => {
+    it("全ステータスキーが0で初期化されたオブジェクトを返す", () => {
+      const result = createEmptyStatusCounts();
+
+      const expectedStatuses: BoardStatus[] = [
+        "not_yet",
+        "not_yet_dangerous",
+        "reserved",
+        "done",
+        "error_wrong_place",
+        "error_damaged",
+        "error_wrong_poster",
+        "other",
+      ];
+
+      for (const status of expectedStatuses) {
+        expect(result[status]).toBe(0);
+      }
+      expect(Object.keys(result)).toHaveLength(expectedStatuses.length);
+    });
+  });
+
+  describe("countBoardsByStatus", () => {
+    it("複数ステータスが混在する場合、正しくカウントする", () => {
+      const boards: { status: BoardStatus }[] = [
+        { status: "done" },
+        { status: "done" },
+        { status: "not_yet" },
+        { status: "reserved" },
+        { status: "done" },
+        { status: "error_damaged" },
+        { status: "not_yet" },
+      ];
+
+      const result = countBoardsByStatus(boards);
+
+      expect(result.done).toBe(3);
+      expect(result.not_yet).toBe(2);
+      expect(result.reserved).toBe(1);
+      expect(result.error_damaged).toBe(1);
+      expect(result.not_yet_dangerous).toBe(0);
+      expect(result.error_wrong_place).toBe(0);
+      expect(result.error_wrong_poster).toBe(0);
+      expect(result.other).toBe(0);
+    });
+
+    it("全て同じステータスの場合、そのステータスのみカウントされる", () => {
+      const boards: { status: BoardStatus }[] = [
+        { status: "reserved" },
+        { status: "reserved" },
+        { status: "reserved" },
+      ];
+
+      const result = countBoardsByStatus(boards);
+
+      expect(result.reserved).toBe(3);
+      expect(result.done).toBe(0);
+      expect(result.not_yet).toBe(0);
+    });
+
+    it("空配列の場合、全ステータスが0のオブジェクトを返す", () => {
+      const boards: { status: BoardStatus }[] = [];
+
+      const result = countBoardsByStatus(boards);
+
+      const allZero = Object.values(result).every((count) => count === 0);
+      expect(allZero).toBe(true);
+      expect(Object.keys(result)).toHaveLength(8);
+    });
+  });
+});

--- a/src/features/map-poster/utils/poster-stats.ts
+++ b/src/features/map-poster/utils/poster-stats.ts
@@ -1,0 +1,32 @@
+import type { Database } from "@/lib/types/supabase";
+
+type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
+
+/**
+ * 全ステータスの値が0のステータスカウントオブジェクトを生成する
+ */
+export function createEmptyStatusCounts(): Record<BoardStatus, number> {
+  return {
+    not_yet: 0,
+    not_yet_dangerous: 0,
+    reserved: 0,
+    done: 0,
+    error_wrong_place: 0,
+    error_damaged: 0,
+    error_wrong_poster: 0,
+    other: 0,
+  };
+}
+
+/**
+ * boards配列からstatus別のカウントを集計する
+ */
+export function countBoardsByStatus(
+  boards: { status: BoardStatus }[],
+): Record<BoardStatus, number> {
+  const counts = createEmptyStatusCounts();
+  for (const board of boards) {
+    counts[board.status] += 1;
+  }
+  return counts;
+}


### PR DESCRIPTION
## Summary
- `createEmptyStatusCounts`と`countBoardsByStatus`を`poster-boards.ts`から`utils/poster-stats.ts`に抽出
- 6箇所に重複していたステータスカウント初期化オブジェクト(Record<BoardStatus, number>の全ゼロ)を共通関数呼び出しに置き換え
- 4件のユニットテストを追加（全ステータスキーが0、複数ステータス混在、全て同じ、空配列）

## Test plan
- [x] `npx jest --testPathPattern=poster-stats` - 4テスト全てパス
- [x] `pnpm run typecheck` - 型エラーなし
- [x] `pnpm run biome:check:write` - フォーマット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)