### PR TITLE
docs: Phase 4にPRコメント確認手順を追加

### DIFF
--- a/.claude/skills/parallel-pr/SKILL.md
+++ b/.claude/skills/parallel-pr/SKILL.md
@@ -105,10 +105,22 @@ for pr in {PR番号リスト}; do
 done
 ```
 
+```bash
+# 全PRのコメントを確認（CodeRabbitやレビューアからのフィードバック）
+for pr in {PR番号リスト}; do
+  echo "=== PR #$pr comments ==="
+  gh pr view $pr --comments
+done
+```
+
 CI失敗時の対応:
 - **flaky RLSテスト**: `gh run rerun <run-id> --failed` で再実行
 - **TypeScript型エラー**: worktreeで直接修正してpush
 - **Biomeエラー**: worktreeで `pnpm run biome:check:write` して再push
+
+PRコメント対応:
+- **CodeRabbitの指摘**: 重要な指摘はworktreeで修正してpush
+- **軽微な指摘（nitpick等）**: マージ後に対応するか、必要に応じて対応
 
 ### Phase 5: クリーンアップ
 


### PR DESCRIPTION
# 変更の概要
- `/parallel-pr` スキルのPhase 4に、PRコメント確認の手順を追加
- `gh pr view --comments` コマンドを追加
- CodeRabbitの指摘への対応ガイドラインを追加

# 変更の背景
- 並列PR作成後、CIの確認だけでなくPRコメント（CodeRabbitやレビューアからのフィードバック）も確認する必要がある
- 確認手順を明文化することで、対応漏れを防ぐ

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました