### PR TITLE
test: isUUID, metrics validators, getPartyPlanConfig のテスト追加

### DIFF
--- a/src/features/metrics/services/get-metrics.test.ts
+++ b/src/features/metrics/services/get-metrics.test.ts
@@ -77,65 +77,199 @@ describe("get-metrics", () => {
     return { thresholdISO, capturedGteIsoRef };
   };
 
-  // validation関数は独立しているため、単体でテスト実施。正常系はfetch系で確認されるため、異常系のみ確認
-  describe("validateDonationData / validateSupporterData", () => {
-    it("異常系: データがnullの場合、falseを返す", () => {
-      const resultDonation = validateDonationData(null);
-      expect(resultDonation).toBe(false);
-
-      const resultSupporter = validateSupporterData(null);
-      expect(resultSupporter).toBe(false);
+  describe("validateSupporterData", () => {
+    it("正常系: 有効なデータの場合、trueを返す", () => {
+      expect(
+        validateSupporterData({
+          totalCount: 1000,
+          last24hCount: 50,
+          updatedAt: "2024-06-01T12:00:00Z",
+        }),
+      ).toBe(true);
     });
 
-    it("異常系: 必須フィールドが欠落している場合、falseを返す", () => {
-      const invalidData = {
-        last24hCount: 2,
-        updatedAt: new Date().toISOString(),
-      };
-      const resultDonation = validateDonationData(invalidData);
-      expect(resultDonation).toBe(false);
-
-      const resultSupporter = validateSupporterData(invalidData);
-      expect(resultSupporter).toBe(false);
+    it("正常系: カウントがゼロの場合、trueを返す", () => {
+      expect(
+        validateSupporterData({
+          totalCount: 0,
+          last24hCount: 0,
+          updatedAt: "2024-01-01T00:00:00Z",
+        }),
+      ).toBe(true);
     });
 
-    it("異常系: フィールドの型が不正な場合、falseを返す", () => {
-      const invalidData = {
-        totalCount: "10", // 型が文字列
-        last24hCount: 2,
-        updatedAt: new Date().toISOString(),
-      };
-      const resultDonation = validateDonationData(invalidData);
-      expect(resultDonation).toBe(false);
-
-      const resultSupporter = validateSupporterData(invalidData);
-      expect(resultSupporter).toBe(false);
+    it("異常系: nullの場合、falseを返す", () => {
+      expect(validateSupporterData(null)).toBe(false);
     });
 
-    it("異常系: フィールドの値が負の値の場合、falseを返す", () => {
-      const invalidData = {
-        totalCount: 2,
-        last24hCount: -10, // 負の値
-        updatedAt: new Date().toISOString(),
-      };
-      const resultDonation = validateDonationData(invalidData);
-      expect(resultDonation).toBe(false);
+    it("異常系: undefinedの場合、falseを返す", () => {
+      expect(validateSupporterData(undefined)).toBe(false);
+    });
 
-      const resultSupporter = validateSupporterData(invalidData);
-      expect(resultSupporter).toBe(false);
+    it("異常系: 文字列の場合、falseを返す", () => {
+      expect(validateSupporterData("string")).toBe(false);
+    });
+
+    it("異常系: totalCountが欠落している場合、falseを返す", () => {
+      expect(
+        validateSupporterData({
+          last24hCount: 2,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: last24hCountが欠落している場合、falseを返す", () => {
+      expect(
+        validateSupporterData({
+          totalCount: 10,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: updatedAtが欠落している場合、falseを返す", () => {
+      expect(validateSupporterData({ totalCount: 10, last24hCount: 2 })).toBe(
+        false,
+      );
+    });
+
+    it("異常系: totalCountが文字列の場合、falseを返す", () => {
+      expect(
+        validateSupporterData({
+          totalCount: "10",
+          last24hCount: 2,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: totalCountが負の場合、falseを返す", () => {
+      expect(
+        validateSupporterData({
+          totalCount: -1,
+          last24hCount: 2,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: last24hCountが負の場合、falseを返す", () => {
+      expect(
+        validateSupporterData({
+          totalCount: 10,
+          last24hCount: -1,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
     });
 
     it("異常系: updatedAtが無効な日付形式の場合、falseを返す", () => {
-      const invalidData = {
-        totalCount: 10,
-        last24hCount: 2,
-        updatedAt: "invalid-date", // 無効な日付
-      };
-      const resultDonation = validateDonationData(invalidData);
-      expect(resultDonation).toBe(false);
+      expect(
+        validateSupporterData({
+          totalCount: 10,
+          last24hCount: 2,
+          updatedAt: "invalid-date",
+        }),
+      ).toBe(false);
+    });
+  });
 
-      const resultSupporter = validateSupporterData(invalidData);
-      expect(resultSupporter).toBe(false);
+  describe("validateDonationData", () => {
+    it("正常系: 有効なデータの場合、trueを返す", () => {
+      expect(
+        validateDonationData({
+          totalAmount: 500000,
+          last24hAmount: 10000,
+          updatedAt: "2024-06-01T12:00:00Z",
+        }),
+      ).toBe(true);
+    });
+
+    it("正常系: 金額がゼロの場合、trueを返す", () => {
+      expect(
+        validateDonationData({
+          totalAmount: 0,
+          last24hAmount: 0,
+          updatedAt: "2024-01-01T00:00:00Z",
+        }),
+      ).toBe(true);
+    });
+
+    it("異常系: nullの場合、falseを返す", () => {
+      expect(validateDonationData(null)).toBe(false);
+    });
+
+    it("異常系: undefinedの場合、falseを返す", () => {
+      expect(validateDonationData(undefined)).toBe(false);
+    });
+
+    it("異常系: 数値の場合、falseを返す", () => {
+      expect(validateDonationData(42)).toBe(false);
+    });
+
+    it("異常系: totalAmountが欠落している場合、falseを返す", () => {
+      expect(
+        validateDonationData({
+          last24hAmount: 200,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: last24hAmountが欠落している場合、falseを返す", () => {
+      expect(
+        validateDonationData({
+          totalAmount: 1000,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: updatedAtが欠落している場合、falseを返す", () => {
+      expect(
+        validateDonationData({ totalAmount: 1000, last24hAmount: 200 }),
+      ).toBe(false);
+    });
+
+    it("異常系: totalAmountが文字列の場合、falseを返す", () => {
+      expect(
+        validateDonationData({
+          totalAmount: "500000",
+          last24hAmount: 200,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: totalAmountが負の場合、falseを返す", () => {
+      expect(
+        validateDonationData({
+          totalAmount: -1,
+          last24hAmount: 200,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: last24hAmountが負の場合、falseを返す", () => {
+      expect(
+        validateDonationData({
+          totalAmount: 1000,
+          last24hAmount: -1,
+          updatedAt: new Date().toISOString(),
+        }),
+      ).toBe(false);
+    });
+
+    it("異常系: updatedAtが無効な日付形式の場合、falseを返す", () => {
+      expect(
+        validateDonationData({
+          totalAmount: 1000,
+          last24hAmount: 200,
+          updatedAt: "not-a-date",
+        }),
+      ).toBe(false);
     });
   });
 

--- a/src/features/mission-detail/services/mission-detail.test.ts
+++ b/src/features/mission-detail/services/mission-detail.test.ts
@@ -1,0 +1,76 @@
+jest.mock("nanoid", () => ({
+  nanoid: () => "mock-id",
+}));
+jest.mock("@/lib/supabase/client");
+
+import { isUUID } from "./mission-detail";
+
+describe("isUUID", () => {
+  describe("valid UUIDs", () => {
+    test("standard UUIDv4 lowercase", () => {
+      expect(isUUID("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+    });
+
+    test("standard UUIDv4 uppercase", () => {
+      expect(isUUID("550E8400-E29B-41D4-A716-446655440000")).toBe(true);
+    });
+
+    test("UUIDv4 mixed case", () => {
+      expect(isUUID("550e8400-E29B-41d4-A716-446655440000")).toBe(true);
+    });
+
+    test("UUIDv1", () => {
+      expect(isUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")).toBe(true);
+    });
+
+    test("UUIDv3", () => {
+      expect(isUUID("a3bb189e-8bf9-3888-9912-ace4e6543002")).toBe(true);
+    });
+
+    test("UUIDv5", () => {
+      expect(isUUID("886313e1-3b8a-5372-9b90-0c9aee199e5d")).toBe(true);
+    });
+  });
+
+  describe("invalid UUIDs", () => {
+    test("empty string", () => {
+      expect(isUUID("")).toBe(false);
+    });
+
+    test("random string", () => {
+      expect(isUUID("not-a-uuid")).toBe(false);
+    });
+
+    test("too short", () => {
+      expect(isUUID("550e8400-e29b-41d4-a716")).toBe(false);
+    });
+
+    test("too long", () => {
+      expect(isUUID("550e8400-e29b-41d4-a716-446655440000-extra")).toBe(false);
+    });
+
+    test("invalid characters (g)", () => {
+      expect(isUUID("550e8400-e29b-41d4-a716-44665544000g")).toBe(false);
+    });
+
+    test("missing hyphens", () => {
+      expect(isUUID("550e8400e29b41d4a716446655440000")).toBe(false);
+    });
+
+    test("invalid version digit (0)", () => {
+      expect(isUUID("550e8400-e29b-01d4-a716-446655440000")).toBe(false);
+    });
+
+    test("invalid version digit (6)", () => {
+      expect(isUUID("550e8400-e29b-61d4-a716-446655440000")).toBe(false);
+    });
+
+    test("invalid variant (0 in variant position)", () => {
+      expect(isUUID("550e8400-e29b-41d4-0716-446655440000")).toBe(false);
+    });
+
+    test("slug-like string", () => {
+      expect(isUUID("my-mission-slug")).toBe(false);
+    });
+  });
+});

--- a/src/features/party-membership/constants/plans.test.ts
+++ b/src/features/party-membership/constants/plans.test.ts
@@ -1,0 +1,56 @@
+import { getPartyPlanConfig, PARTY_PLAN_CONFIG } from "./plans";
+
+describe("getPartyPlanConfig", () => {
+  describe("valid plan names", () => {
+    test("returns starter plan config", () => {
+      const config = getPartyPlanConfig("starter");
+      expect(config).toEqual({
+        label: "スタータープラン",
+        imageSrc: "/img/party-member-badge/starter.svg",
+      });
+    });
+
+    test("returns regular plan config", () => {
+      const config = getPartyPlanConfig("regular");
+      expect(config).toEqual({
+        label: "レギュラープラン",
+        imageSrc: "/img/party-member-badge/regular.svg",
+      });
+    });
+
+    test("returns premium plan config", () => {
+      const config = getPartyPlanConfig("premium");
+      expect(config).toEqual({
+        label: "プレミアムプラン",
+        imageSrc: "/img/party-member-badge/premium.svg",
+      });
+    });
+  });
+
+  describe("invalid plan names", () => {
+    test("returns undefined for unknown plan", () => {
+      const config = getPartyPlanConfig("unknown" as any);
+      expect(config).toBeUndefined();
+    });
+
+    test("returns undefined for empty string", () => {
+      const config = getPartyPlanConfig("" as any);
+      expect(config).toBeUndefined();
+    });
+  });
+
+  describe("PARTY_PLAN_CONFIG", () => {
+    test("has exactly 3 plans", () => {
+      expect(Object.keys(PARTY_PLAN_CONFIG)).toHaveLength(3);
+    });
+
+    test("all plans have label and imageSrc", () => {
+      for (const [, config] of Object.entries(PARTY_PLAN_CONFIG)) {
+        expect(config).toHaveProperty("label");
+        expect(config).toHaveProperty("imageSrc");
+        expect(typeof config.label).toBe("string");
+        expect(typeof config.imageSrc).toBe("string");
+      }
+    });
+  });
+});


### PR DESCRIPTION
# 変更の概要
- `isUUID` 関数のユニットテストを追加（有効/無効なUUID形式の検証）
- `validateSupporterData` / `validateDonationData` の既存テストを拡張（正常系・各フィールドの欠損・型不正・負値・無効日付）
- `getPartyPlanConfig` 関数のユニットテストを追加（全プラン取得、不正プラン名）

# 変更の背景
- テストカバレッジ向上のため、純粋関数のユニットテストを追加
- 既存の metrics バリデーションテストは異常系のみだったため、正常系を含む網羅的なテストに拡充

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [x] CLAの内容を読み、同意しました