### PR TITLE
test: add tests for parseIdToken, isTokenExpired, filterTeamMiraiVideos

### DIFF
--- a/src/features/tiktok/services/tiktok-video-service.test.ts
+++ b/src/features/tiktok/services/tiktok-video-service.test.ts
@@ -1,0 +1,89 @@
+jest.mock("server-only", () => ({}));
+jest.mock("@/features/tiktok-stats/utils/stats-utils", () => ({}));
+jest.mock("@/lib/supabase/adminClient", () => ({}));
+jest.mock("@/lib/supabase/client", () => ({}));
+jest.mock("@/lib/utils/text-utils", () => ({}));
+jest.mock("../utils/data-builders", () => ({}));
+jest.mock("./tiktok-client", () => ({}));
+
+import type { TikTokVideoFromAPI } from "../types";
+import { filterTeamMiraiVideos } from "./tiktok-video-service";
+
+function makeVideo(
+  overrides: Partial<TikTokVideoFromAPI> = {},
+): TikTokVideoFromAPI {
+  return {
+    id: "v1",
+    create_time: 1700000000,
+    share_url: "https://tiktok.com/v1",
+    duration: 30,
+    ...overrides,
+  };
+}
+
+describe("filterTeamMiraiVideos", () => {
+  it("should return videos with #チームみらい in description", () => {
+    const videos = [
+      makeVideo({ video_description: "素敵な動画 #チームみらい です" }),
+      makeVideo({ id: "v2", video_description: "関係ない動画" }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("v1");
+  });
+
+  it("should return videos with #チームみらい in title", () => {
+    const videos = [makeVideo({ title: "#チームみらい の活動報告" })];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+  });
+
+  it("should match #teammirai case-insensitively", () => {
+    const videos = [
+      makeVideo({ video_description: "#TeamMirai video" }),
+      makeVideo({ id: "v2", title: "#TEAMMIRAI" }),
+      makeVideo({ id: "v3", video_description: "#teammirai" }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(3);
+  });
+
+  it("should return empty array when no videos match", () => {
+    const videos = [
+      makeVideo({ video_description: "普通の動画" }),
+      makeVideo({ id: "v2", title: "関係ない動画" }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should return empty array for empty input", () => {
+    const result = filterTeamMiraiVideos([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should handle videos with undefined description and title", () => {
+    const videos = [
+      makeVideo({ video_description: undefined, title: undefined }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should match when both description and title contain the hashtag", () => {
+    const videos = [
+      makeVideo({
+        video_description: "#チームみらい",
+        title: "#チームみらい",
+      }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/features/youtube/services/google-auth.test.ts
+++ b/src/features/youtube/services/google-auth.test.ts
@@ -1,0 +1,37 @@
+import { isTokenExpired } from "./google-auth";
+
+describe("isTokenExpired", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should return true when the token has expired (past date)", () => {
+    jest.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+    expect(isTokenExpired("2025-01-14T12:00:00Z")).toBe(true);
+  });
+
+  it("should return false when the token is still valid (future date)", () => {
+    jest.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+    expect(isTokenExpired("2025-01-16T12:00:00Z")).toBe(false);
+  });
+
+  it("should return false when the token expires at exactly the current time", () => {
+    // new Date(tokenExpiresAt) < new Date() => equal is NOT less-than => false
+    jest.setSystemTime(new Date("2025-01-15T12:00:00.000Z"));
+    expect(isTokenExpired("2025-01-15T12:00:00.000Z")).toBe(false);
+  });
+
+  it("should return true when the token expired one second ago", () => {
+    jest.setSystemTime(new Date("2025-01-15T12:00:01.000Z"));
+    expect(isTokenExpired("2025-01-15T12:00:00.000Z")).toBe(true);
+  });
+
+  it("should return false when the token expires one second from now", () => {
+    jest.setSystemTime(new Date("2025-01-15T11:59:59.000Z"));
+    expect(isTokenExpired("2025-01-15T12:00:00.000Z")).toBe(false);
+  });
+});

--- a/src/features/youtube/services/youtube-client.test.ts
+++ b/src/features/youtube/services/youtube-client.test.ts
@@ -1,0 +1,90 @@
+import { parseIdToken, YouTubeAPIError } from "./youtube-client";
+
+describe("parseIdToken", () => {
+  // Helper to create a valid JWT-like token
+  function makeToken(payload: Record<string, unknown>): string {
+    const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString(
+      "base64url",
+    );
+    const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const signature = "fake-signature";
+    return `${header}.${body}.${signature}`;
+  }
+
+  it("should parse a valid id_token with all fields", () => {
+    const payload = {
+      iss: "https://accounts.google.com",
+      sub: "1234567890",
+      aud: "client-id.apps.googleusercontent.com",
+      exp: 1700000000,
+      iat: 1699999000,
+      email: "user@example.com",
+      email_verified: true,
+      name: "Test User",
+      picture: "https://example.com/photo.jpg",
+    };
+
+    const token = makeToken(payload);
+    const result = parseIdToken(token);
+
+    expect(result.sub).toBe("1234567890");
+    expect(result.iss).toBe("https://accounts.google.com");
+    expect(result.email).toBe("user@example.com");
+    expect(result.name).toBe("Test User");
+  });
+
+  it("should parse a minimal valid id_token with only sub", () => {
+    const payload = {
+      iss: "https://accounts.google.com",
+      sub: "minimal-sub",
+      aud: "client-id",
+      exp: 1700000000,
+      iat: 1699999000,
+    };
+
+    const token = makeToken(payload);
+    const result = parseIdToken(token);
+
+    expect(result.sub).toBe("minimal-sub");
+    expect(result.email).toBeUndefined();
+  });
+
+  it("should throw YouTubeAPIError for token with fewer than 3 parts", () => {
+    expect(() => parseIdToken("only-one-part")).toThrow(YouTubeAPIError);
+    expect(() => parseIdToken("only-one-part")).toThrow(
+      "Invalid id_token format",
+    );
+  });
+
+  it("should throw YouTubeAPIError for token with more than 3 parts", () => {
+    expect(() => parseIdToken("a.b.c.d")).toThrow(YouTubeAPIError);
+    expect(() => parseIdToken("a.b.c.d")).toThrow("Invalid id_token format");
+  });
+
+  it("should throw YouTubeAPIError when sub claim is missing", () => {
+    const payload = {
+      iss: "https://accounts.google.com",
+      aud: "client-id",
+      exp: 1700000000,
+      iat: 1699999000,
+    };
+
+    const token = makeToken(payload);
+    expect(() => parseIdToken(token)).toThrow(YouTubeAPIError);
+    expect(() => parseIdToken(token)).toThrow(
+      "id_token does not contain sub claim",
+    );
+  });
+
+  it("should throw YouTubeAPIError for invalid base64 payload", () => {
+    // Create a token where the payload is not valid JSON
+    const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString(
+      "base64url",
+    );
+    const invalidPayload = Buffer.from("not-json{{{").toString("base64url");
+    const token = `${header}.${invalidPayload}.signature`;
+
+    expect(() => parseIdToken(token)).toThrow(YouTubeAPIError);
+    expect(() => parseIdToken(token)).toThrow("Failed to parse id_token");
+  });
+});


### PR DESCRIPTION
# 変更の概要
- YouTube/TikTok関連のヘルパー関数にユニットテストを追加

# 変更の背景
- テストカバレッジ向上のため、純粋関数のユニットテストを追加
- 対象関数:
  - `parseIdToken` (src/features/youtube/services/youtube-client.ts): JWT id_tokenのBase64URLデコード
  - `isTokenExpired` (src/features/youtube/services/google-auth.ts): トークン有効期限チェック
  - `filterTeamMiraiVideos` (src/features/tiktok/services/tiktok-video-service.ts): #チームみらい動画フィルタリング

# テスト内容
- **parseIdToken**: 有効トークンパース、不正フォーマット(パート不足/過多)、sub claim欠損、不正base64
- **isTokenExpired**: 期限切れ(過去日)、有効(未来日)、境界値(ちょうど現在時刻)、1秒差
- **filterTeamMiraiVideos**: description/titleマッチ、大小文字無視(#TeamMirai)、空配列、undefined対応

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました