### PR TITLE
refactor: checkLevelUpNotificationからレベルアップ判定ロジックを切り出し

### DIFF
--- a/src/features/user-level/services/level-up-notification.ts
+++ b/src/features/user-level/services/level-up-notification.ts
@@ -3,7 +3,10 @@ import "server-only";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import type { LevelUpNotification } from "../types/level-types";
-import { totalXp } from "../utils/level-calculator";
+import {
+  buildLevelUpNotificationData,
+  shouldShowLevelUpNotification,
+} from "../utils/level-up-helpers";
 
 /**
  * レベルアップ通知をチェックし、必要に応じて通知データを返す
@@ -30,24 +33,17 @@ export async function checkLevelUpNotification(
     return { shouldNotify: false };
   }
 
-  // 現在のレベルと最後に通知されたレベルを比較
-  const currentLevel = userLevel.level;
-  const lastNotifiedLevel = userLevel.last_notified_level || 1;
-
-  // レベルが上がっている場合は通知する
-  if (currentLevel > lastNotifiedLevel) {
-    // 次のレベルまでのポイントを計算
-    const nextLevelPoints = totalXp(currentLevel + 1);
-    const pointsToNextLevel = nextLevelPoints - userLevel.xp;
-
-    return {
-      shouldNotify: true,
-      levelUp: {
-        previousLevel: lastNotifiedLevel,
-        newLevel: currentLevel,
-        pointsToNextLevel: Math.max(0, pointsToNextLevel),
-      },
-    };
+  if (
+    shouldShowLevelUpNotification(
+      userLevel.level,
+      userLevel.last_notified_level,
+    )
+  ) {
+    return buildLevelUpNotificationData(
+      userLevel.level,
+      userLevel.last_notified_level,
+      userLevel.xp,
+    );
   }
 
   return { shouldNotify: false };

--- a/src/features/user-level/utils/level-up-helpers.test.ts
+++ b/src/features/user-level/utils/level-up-helpers.test.ts
@@ -1,0 +1,77 @@
+import { totalXp } from "./level-calculator";
+import {
+  buildLevelUpNotificationData,
+  shouldShowLevelUpNotification,
+} from "./level-up-helpers";
+
+describe("shouldShowLevelUpNotification", () => {
+  it("レベルが上がっている場合はtrueを返す", () => {
+    expect(shouldShowLevelUpNotification(3, 2)).toBe(true);
+  });
+
+  it("レベルが同じ場合はfalseを返す", () => {
+    expect(shouldShowLevelUpNotification(2, 2)).toBe(false);
+  });
+
+  it("レベルが下がっている場合はfalseを返す", () => {
+    expect(shouldShowLevelUpNotification(1, 2)).toBe(false);
+  });
+
+  it("lastNotifiedLevelがnullの場合は1として扱う", () => {
+    expect(shouldShowLevelUpNotification(2, null)).toBe(true);
+    expect(shouldShowLevelUpNotification(1, null)).toBe(false);
+  });
+
+  it("大きなレベル差でもtrueを返す", () => {
+    expect(shouldShowLevelUpNotification(10, 1)).toBe(true);
+  });
+});
+
+describe("buildLevelUpNotificationData", () => {
+  it("レベルアップ通知データを正しく構築する", () => {
+    const result = buildLevelUpNotificationData(3, 2, 100);
+
+    expect(result.shouldNotify).toBe(true);
+    expect(result.levelUp).toBeDefined();
+    expect(result.levelUp?.previousLevel).toBe(2);
+    expect(result.levelUp?.newLevel).toBe(3);
+  });
+
+  it("pointsToNextLevelが正しく計算される", () => {
+    const currentLevel = 3;
+    const xp = 100;
+    const expectedNextLevelXp = totalXp(currentLevel + 1);
+    const expectedPointsToNext = Math.max(0, expectedNextLevelXp - xp);
+
+    const result = buildLevelUpNotificationData(currentLevel, 2, xp);
+
+    expect(result.levelUp?.pointsToNextLevel).toBe(expectedPointsToNext);
+  });
+
+  it("XPが次のレベルを超えている場合はpointsToNextLevelが0になる", () => {
+    const currentLevel = 2;
+    const xp = 999999;
+
+    const result = buildLevelUpNotificationData(currentLevel, 1, xp);
+
+    expect(result.levelUp?.pointsToNextLevel).toBe(0);
+  });
+
+  it("lastNotifiedLevelがnullの場合はpreviousLevelが1になる", () => {
+    const result = buildLevelUpNotificationData(5, null, 500);
+
+    expect(result.levelUp?.previousLevel).toBe(1);
+    expect(result.levelUp?.newLevel).toBe(5);
+  });
+
+  it("レベル1から2への遷移で正しいデータを返す", () => {
+    const xp = 50;
+    const result = buildLevelUpNotificationData(2, 1, xp);
+
+    expect(result.shouldNotify).toBe(true);
+    expect(result.levelUp?.previousLevel).toBe(1);
+    expect(result.levelUp?.newLevel).toBe(2);
+    const expectedPoints = Math.max(0, totalXp(3) - xp);
+    expect(result.levelUp?.pointsToNextLevel).toBe(expectedPoints);
+  });
+});

--- a/src/features/user-level/utils/level-up-helpers.ts
+++ b/src/features/user-level/utils/level-up-helpers.ts
@@ -1,0 +1,35 @@
+import type { LevelUpNotification } from "../types/level-types";
+import { totalXp } from "./level-calculator";
+
+/**
+ * レベルアップ通知を表示すべきか判定する
+ */
+export function shouldShowLevelUpNotification(
+  currentLevel: number,
+  lastNotifiedLevel: number | null,
+): boolean {
+  const effectiveLastNotified = lastNotifiedLevel || 1;
+  return currentLevel > effectiveLastNotified;
+}
+
+/**
+ * レベルアップ通知データを構築する
+ */
+export function buildLevelUpNotificationData(
+  currentLevel: number,
+  lastNotifiedLevel: number | null,
+  xp: number,
+): LevelUpNotification {
+  const effectiveLastNotified = lastNotifiedLevel || 1;
+  const nextLevelPoints = totalXp(currentLevel + 1);
+  const pointsToNextLevel = Math.max(0, nextLevelPoints - xp);
+
+  return {
+    shouldNotify: true,
+    levelUp: {
+      previousLevel: effectiveLastNotified,
+      newLevel: currentLevel,
+      pointsToNextLevel,
+    },
+  };
+}


### PR DESCRIPTION
# 変更の概要
- `checkLevelUpNotification`からレベルアップ判定と通知データ構築の純粋ロジックを切り出し
- `shouldShowLevelUpNotification`と`buildLevelUpNotificationData`を`src/features/user-level/utils/level-up-helpers.ts`に配置
- 元の`checkLevelUpNotification`はDB取得後に純粋関数を呼び出す形に変更
- テストカバレッジ100%（10テストケース）

# 変更の背景
- テスト容易性の向上: 純粋関数として切り出すことでDBモック不要のユニットテストが可能に
- 責務の分離: データ取得とビジネスロジック判定の責務を明確に分離

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました