### PR TITLE
test: map-poster 選挙区・都道府県定数のテスト追加

### DIFF
--- a/src/features/map-poster/constants/poster-district-shugin-2026.test.ts
+++ b/src/features/map-poster/constants/poster-district-shugin-2026.test.ts
@@ -1,0 +1,92 @@
+import {
+  getDistrictDefaultZoom,
+  isValidDistrict,
+  JP_TO_EN_DISTRICT,
+  POSTER_DISTRICT_MAP,
+  VALID_EN_DISTRICTS,
+  VALID_JP_DISTRICTS,
+} from "./poster-district-shugin-2026";
+
+describe("getDistrictDefaultZoom", () => {
+  test("returns correct zoom for chiba-5", () => {
+    expect(getDistrictDefaultZoom("chiba-5")).toBe(13);
+  });
+
+  test("returns correct zoom for tokyo-2", () => {
+    expect(getDistrictDefaultZoom("tokyo-2")).toBe(13);
+  });
+
+  test("returns correct zoom for kyoto-2", () => {
+    expect(getDistrictDefaultZoom("kyoto-2")).toBe(13);
+  });
+
+  test("returns a number for every district key", () => {
+    for (const key of VALID_EN_DISTRICTS) {
+      expect(typeof getDistrictDefaultZoom(key)).toBe("number");
+    }
+  });
+});
+
+describe("isValidDistrict", () => {
+  test("returns true for valid district key chiba-5", () => {
+    expect(isValidDistrict("chiba-5")).toBe(true);
+  });
+
+  test("returns true for valid district key tokyo-7", () => {
+    expect(isValidDistrict("tokyo-7")).toBe(true);
+  });
+
+  test("returns true for valid district key tokyo-26", () => {
+    expect(isValidDistrict("tokyo-26")).toBe(true);
+  });
+
+  test("returns false for invalid district key", () => {
+    expect(isValidDistrict("osaka-1")).toBe(false);
+  });
+
+  test("returns false for empty string", () => {
+    expect(isValidDistrict("")).toBe(false);
+  });
+
+  test("returns false for undefined cast to string", () => {
+    expect(isValidDistrict("undefined")).toBe(false);
+  });
+
+  test("returns true for all defined district keys", () => {
+    for (const key of VALID_EN_DISTRICTS) {
+      expect(isValidDistrict(key)).toBe(true);
+    }
+  });
+});
+
+describe("POSTER_DISTRICT_MAP", () => {
+  test("all districts have required properties", () => {
+    for (const [, district] of Object.entries(POSTER_DISTRICT_MAP)) {
+      expect(district).toHaveProperty("jp");
+      expect(district).toHaveProperty("prefecture");
+      expect(district).toHaveProperty("center");
+      expect(district).toHaveProperty("defaultZoom");
+      expect(district.center).toHaveLength(2);
+    }
+  });
+});
+
+describe("JP_TO_EN_DISTRICT", () => {
+  test("maps Japanese name to English key correctly", () => {
+    expect(JP_TO_EN_DISTRICT["千葉5区"]).toBe("chiba-5");
+    expect(JP_TO_EN_DISTRICT["東京2区"]).toBe("tokyo-2");
+    expect(JP_TO_EN_DISTRICT["京都2区"]).toBe("kyoto-2");
+  });
+
+  test("returns undefined for invalid Japanese name", () => {
+    expect(JP_TO_EN_DISTRICT["大阪1区"]).toBeUndefined();
+  });
+});
+
+describe("VALID_JP_DISTRICTS / VALID_EN_DISTRICTS", () => {
+  test("both arrays have same length as POSTER_DISTRICT_MAP", () => {
+    const mapLength = Object.keys(POSTER_DISTRICT_MAP).length;
+    expect(VALID_JP_DISTRICTS).toHaveLength(mapLength);
+    expect(VALID_EN_DISTRICTS).toHaveLength(mapLength);
+  });
+});

--- a/src/features/map-poster/constants/poster-prefectures.test.ts
+++ b/src/features/map-poster/constants/poster-prefectures.test.ts
@@ -1,0 +1,72 @@
+import {
+  getPrefectureDefaultZoom,
+  JP_TO_EN_PREFECTURE,
+  POSTER_PREFECTURE_MAP,
+  VALID_EN_PREFECTURES,
+  VALID_JP_PREFECTURES,
+} from "./poster-prefectures";
+
+describe("getPrefectureDefaultZoom", () => {
+  test("returns correct zoom for tokyo", () => {
+    expect(getPrefectureDefaultZoom("tokyo")).toBe(12);
+  });
+
+  test("returns correct zoom for hokkaido", () => {
+    expect(getPrefectureDefaultZoom("hokkaido")).toBe(8);
+  });
+
+  test("returns correct zoom for osaka", () => {
+    expect(getPrefectureDefaultZoom("osaka")).toBe(12);
+  });
+
+  test("returns correct zoom for kanagawa", () => {
+    expect(getPrefectureDefaultZoom("kanagawa")).toBe(11);
+  });
+
+  test("returns a number for every prefecture key", () => {
+    for (const key of VALID_EN_PREFECTURES) {
+      expect(typeof getPrefectureDefaultZoom(key)).toBe("number");
+    }
+  });
+});
+
+describe("POSTER_PREFECTURE_MAP", () => {
+  test("all prefectures have required properties", () => {
+    for (const [, pref] of Object.entries(POSTER_PREFECTURE_MAP)) {
+      expect(pref).toHaveProperty("jp");
+      expect(pref).toHaveProperty("center");
+      expect(pref).toHaveProperty("defaultZoom");
+      expect(pref.center).toHaveLength(2);
+    }
+  });
+
+  test("all center coordinates are valid lat/lng ranges", () => {
+    for (const [, pref] of Object.entries(POSTER_PREFECTURE_MAP)) {
+      const [lat, lng] = pref.center;
+      expect(lat).toBeGreaterThanOrEqual(-90);
+      expect(lat).toBeLessThanOrEqual(90);
+      expect(lng).toBeGreaterThanOrEqual(-180);
+      expect(lng).toBeLessThanOrEqual(180);
+    }
+  });
+});
+
+describe("JP_TO_EN_PREFECTURE", () => {
+  test("maps Japanese name to English key correctly", () => {
+    expect(JP_TO_EN_PREFECTURE["東京都"]).toBe("tokyo");
+    expect(JP_TO_EN_PREFECTURE["北海道"]).toBe("hokkaido");
+    expect(JP_TO_EN_PREFECTURE["大阪府"]).toBe("osaka");
+  });
+
+  test("returns undefined for invalid Japanese name", () => {
+    expect(JP_TO_EN_PREFECTURE["沖縄県"]).toBeUndefined();
+  });
+});
+
+describe("VALID_JP_PREFECTURES / VALID_EN_PREFECTURES", () => {
+  test("both arrays have same length as POSTER_PREFECTURE_MAP", () => {
+    const mapLength = Object.keys(POSTER_PREFECTURE_MAP).length;
+    expect(VALID_JP_PREFECTURES).toHaveLength(mapLength);
+    expect(VALID_EN_PREFECTURES).toHaveLength(mapLength);
+  });
+});


### PR DESCRIPTION
# 変更の概要
- `getDistrictDefaultZoom` / `isValidDistrict` のユニットテスト追加（選挙区キーのバリデーションとズームレベル取得）
- `getPrefectureDefaultZoom` のユニットテスト追加（都道府県キーのズームレベル取得）
- `POSTER_DISTRICT_MAP` / `POSTER_PREFECTURE_MAP` の構造検証テスト
- `JP_TO_EN_DISTRICT` / `JP_TO_EN_PREFECTURE` の逆引きマッピング検証テスト

# 変更の背景
- テストカバレッジ向上のため、map-poster機能の定数・ヘルパー関数のテストを追加

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [x] CLAの内容を読み、同意しました