### PR TITLE
refactor: extract chunk utility to lib/utils/array-utils

### DIFF
--- a/src/features/map-posting/services/posting-shapes.ts
+++ b/src/features/map-posting/services/posting-shapes.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/client";
+import { chunk } from "@/lib/utils/array-utils";
 import type { PostingShapeStatus } from "../config/status-config";
 import type { MapShape, ShapeMissionStatus } from "../types/posting-types";
 import {
@@ -106,17 +107,6 @@ export async function deleteShape(id: string) {
 
 // URLパラメータ長制限を回避するためのバッチサイズ
 const BATCH_SIZE = 200;
-
-/**
- * 配列をバッチに分割するヘルパー関数
- */
-function chunk<T>(array: T[], size: number): T[][] {
-  const chunks: T[][] = [];
-  for (let i = 0; i < array.length; i += size) {
-    chunks.push(array.slice(i, i + size));
-  }
-  return chunks;
-}
 
 export async function loadShapes(eventId: string) {
   const { data, error } = await supabase

--- a/src/lib/utils/array-utils.test.ts
+++ b/src/lib/utils/array-utils.test.ts
@@ -1,0 +1,36 @@
+import { chunk } from "./array-utils";
+
+describe("chunk", () => {
+  it("should return empty array for empty input", () => {
+    expect(chunk([], 3)).toEqual([]);
+  });
+
+  it("should return the whole array as a single chunk when array length is less than size", () => {
+    expect(chunk([1, 2], 5)).toEqual([[1, 2]]);
+  });
+
+  it("should split array evenly when length is divisible by size", () => {
+    expect(chunk([1, 2, 3, 4, 5, 6], 3)).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+  });
+
+  it("should handle remainder when length is not divisible by size", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("should return each element as its own chunk when size is 1", () => {
+    expect(chunk(["a", "b", "c"], 1)).toEqual([["a"], ["b"], ["c"]]);
+  });
+
+  it("should return a single chunk when array has one element", () => {
+    expect(chunk([42], 3)).toEqual([[42]]);
+  });
+
+  it("should work with generic types", () => {
+    const objects = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const result = chunk(objects, 2);
+    expect(result).toEqual([[{ id: 1 }, { id: 2 }], [{ id: 3 }]]);
+  });
+});

--- a/src/lib/utils/array-utils.ts
+++ b/src/lib/utils/array-utils.ts
@@ -1,0 +1,10 @@
+/**
+ * 配列を指定されたサイズのチャンクに分割する
+ */
+export function chunk<T>(array: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+}


### PR DESCRIPTION
# 変更の概要
- `posting-shapes.ts` 内のプライベート `chunk` 関数を `src/lib/utils/array-utils.ts` に切り出し
- 元ファイルからは新しいユーティリティをimportするよう変更
- `chunk` 関数の包括的なユニットテストを追加

# 変更の背景
- 配列チャンク分割は汎用的なユーティリティであり、複数箇所で再利用可能
- `src/lib/utils/supabase-utils.ts` にも同様の `chunkArray` 関数が存在しており、将来的な統合の基盤となる
- テストカバレッジ向上

# テスト内容
- 空配列
- 配列がチャンクサイズより小さい場合
- ちょうど割り切れる場合
- 余りがある場合
- サイズ1
- 単一要素配列
- ジェネリック型(オブジェクト配列)

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました