### PR TITLE
refactor: ranking系のSupabaseアクセスをservice_role経由に変更

### DIFF
--- a/src/features/prefecture-team/services/get-prefecture-team-ranking.ts
+++ b/src/features/prefecture-team/services/get-prefecture-team-ranking.ts
@@ -5,7 +5,7 @@ import {
   PREFECTURE_POPULATIONS,
 } from "@/lib/constants/prefecture-populations";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
-import { createClient } from "@/lib/supabase/client";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import type {
   PrefectureTeamRanking,
   UserPrefectureContribution,
@@ -32,7 +32,7 @@ export async function getPrefectureTeamRanking(
   seasonId?: string,
 ): Promise<PrefectureTeamRanking[]> {
   try {
-    const supabase = createClient();
+    const supabase = await createAdminClient();
 
     const targetSeasonId = seasonId || (await getCurrentSeasonId());
 
@@ -87,7 +87,7 @@ export async function getUserPrefectureContribution(
   seasonId?: string,
 ): Promise<UserPrefectureContribution | null> {
   try {
-    const supabase = createClient();
+    const supabase = await createAdminClient();
 
     const targetSeasonId = seasonId || (await getCurrentSeasonId());
 

--- a/src/features/ranking/services/get-missions-ranking.test.ts
+++ b/src/features/ranking/services/get-missions-ranking.test.ts
@@ -3,7 +3,7 @@ import {
   getPartyMembershipMap,
 } from "@/features/party-membership/services/memberships";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
-import { createClient } from "@/lib/supabase/client";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import { getJSTMidnightToday } from "@/lib/utils/date-utils";
 import {
   getMissionRanking,
@@ -15,8 +15,8 @@ import {
 } from "./get-missions-ranking";
 
 // Supabaseクライアントをモック
-jest.mock("@/lib/supabase/client", () => ({
-  createClient: jest.fn(),
+jest.mock("@/lib/supabase/adminClient", () => ({
+  createAdminClient: jest.fn(),
 }));
 
 // seasonsサービスをモック
@@ -36,7 +36,7 @@ describe("missionsRanking service", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (createClient as jest.Mock).mockReturnValue(mockSupabase);
+    (createAdminClient as jest.Mock).mockResolvedValue(mockSupabase);
     (getCurrentSeasonId as jest.Mock).mockResolvedValue("test-season-id");
     (getPartyMembershipMap as jest.Mock).mockResolvedValue({});
     (getPartyMembership as jest.Mock).mockResolvedValue(null);

--- a/src/features/ranking/services/get-missions-ranking.ts
+++ b/src/features/ranking/services/get-missions-ranking.ts
@@ -5,7 +5,7 @@ import {
   getPartyMembershipMap,
 } from "@/features/party-membership/services/memberships";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
-import { createClient } from "@/lib/supabase/client";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import type { RankingPeriod, UserMissionRanking } from "../types/ranking-types";
 import {
   dateFilterToISOString,
@@ -20,7 +20,7 @@ export async function getMissionRanking(
   seasonId?: string,
 ): Promise<UserMissionRanking[]> {
   try {
-    const supabase = createClient();
+    const supabase = await createAdminClient();
 
     // seasonIdが指定されている場合はそれを使用、そうでなければ現在のシーズン
     const targetSeasonId = seasonId || (await getCurrentSeasonId());
@@ -105,7 +105,7 @@ export async function getUserMissionRanking(
   period: RankingPeriod = "all",
 ): Promise<UserMissionRanking | null> {
   try {
-    const supabase = createClient();
+    const supabase = await createAdminClient();
 
     // seasonIdが指定されている場合はそれを使用、そうでなければ現在のシーズン
     const targetSeasonId = seasonId || (await getCurrentSeasonId());
@@ -163,7 +163,7 @@ export async function getUserMissionRanking(
 }
 
 export async function getUserPostingCount(userId: string): Promise<number> {
-  const supabase = createClient();
+  const supabase = await createAdminClient();
   const { data, error } = await supabase.rpc("get_user_posting_count", {
     target_user_id: userId,
   });
@@ -188,7 +188,7 @@ export async function getUserPostingCountByMission(
   missionId: string,
   seasonId?: string,
 ): Promise<number> {
-  const supabase = createClient();
+  const supabase = await createAdminClient();
 
   // seasonIdが指定されている場合はそれを使用、そうでなければ現在のシーズン
   const targetSeasonId = seasonId || (await getCurrentSeasonId());
@@ -226,7 +226,7 @@ export async function getUserPostingCountByMission(
 export async function getTopUsersPostingCount(
   userIds: string[],
 ): Promise<{ user_id: string; posting_count: number }[]> {
-  const supabase = createClient();
+  const supabase = await createAdminClient();
   const { data, error } = await supabase.rpc("get_top_users_posting_count", {
     user_ids: userIds,
   });
@@ -247,7 +247,7 @@ export async function getTopUsersPostingCountByMission(
   missionId: string,
   seasonId?: string,
 ): Promise<{ user_id: string; posting_count: number }[]> {
-  const supabase = createClient();
+  const supabase = await createAdminClient();
 
   // seasonIdが指定されている場合はそれを使用、そうでなければ現在のシーズン
   const targetSeasonId = seasonId || (await getCurrentSeasonId());

--- a/src/features/ranking/services/get-prefectures-ranking.test.ts
+++ b/src/features/ranking/services/get-prefectures-ranking.test.ts
@@ -2,7 +2,7 @@ import {
   getPartyMembership,
   getPartyMembershipMap,
 } from "@/features/party-membership/services/memberships";
-import { createClient } from "@/lib/supabase/client";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import { getJSTMidnightToday } from "@/lib/utils/date-utils";
 
 // Mock dateUtils
@@ -17,8 +17,8 @@ import {
 } from "./get-prefectures-ranking";
 
 // Supabaseクライアントをモック
-jest.mock("@/lib/supabase/client", () => ({
-  createClient: jest.fn(),
+jest.mock("@/lib/supabase/adminClient", () => ({
+  createAdminClient: jest.fn(),
 }));
 
 // seasonsサービスをモック
@@ -38,7 +38,7 @@ describe("prefecturesRanking service", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (createClient as jest.Mock).mockReturnValue(mockSupabase);
+    (createAdminClient as jest.Mock).mockResolvedValue(mockSupabase);
     (getCurrentSeasonId as jest.Mock).mockResolvedValue("test-season-id");
     (getPartyMembershipMap as jest.Mock).mockResolvedValue({});
     (getPartyMembership as jest.Mock).mockResolvedValue(null);

--- a/src/features/ranking/services/get-prefectures-ranking.ts
+++ b/src/features/ranking/services/get-prefectures-ranking.ts
@@ -5,7 +5,7 @@ import {
   getPartyMembershipMap,
 } from "@/features/party-membership/services/memberships";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
-import { createClient } from "@/lib/supabase/client";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import type { RankingPeriod, UserRanking } from "../types/ranking-types";
 import {
   dateFilterToISOString,
@@ -20,7 +20,7 @@ export async function getPrefecturesRanking(
   seasonId?: string,
 ): Promise<UserRanking[]> {
   try {
-    const supabase = createClient();
+    const supabase = await createAdminClient();
 
     // seasonIdが指定されている場合はそれを使用、そうでなければ現在のシーズン
     const targetSeasonId = seasonId || (await getCurrentSeasonId());
@@ -85,7 +85,7 @@ export async function getUserPrefecturesRanking(
   period: RankingPeriod = "all",
 ): Promise<UserRanking | null> {
   try {
-    const supabase = createClient();
+    const supabase = await createAdminClient();
 
     // seasonIdが指定されている場合はそれを使用、そうでなければ現在のシーズン
     const targetSeasonId = seasonId || (await getCurrentSeasonId());

--- a/src/features/ranking/services/get-ranking.test.ts
+++ b/src/features/ranking/services/get-ranking.test.ts
@@ -1,11 +1,11 @@
 import { getPartyMembershipMap } from "@/features/party-membership/services/memberships";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
-import { createClient } from "@/lib/supabase/client";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import { getRanking } from "./get-ranking";
 
 // Supabaseクライアントをモック
-jest.mock("@/lib/supabase/client", () => ({
-  createClient: jest.fn(),
+jest.mock("@/lib/supabase/adminClient", () => ({
+  createAdminClient: jest.fn(),
 }));
 
 // seasonsサービスをモック
@@ -25,7 +25,7 @@ describe("ranking service", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (createClient as jest.Mock).mockReturnValue(mockSupabase);
+    (createAdminClient as jest.Mock).mockResolvedValue(mockSupabase);
     (getCurrentSeasonId as jest.Mock).mockResolvedValue("test-season-id");
     (getPartyMembershipMap as jest.Mock).mockResolvedValue({});
   });

--- a/src/features/ranking/services/get-ranking.ts
+++ b/src/features/ranking/services/get-ranking.ts
@@ -5,7 +5,7 @@ import {
   getPartyMembershipMap,
 } from "@/features/party-membership/services/memberships";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
-import { createClient } from "@/lib/supabase/client";
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import type { RankingPeriod, UserRanking } from "../types/ranking-types";
 import {
   dateFilterToISOString,
@@ -32,7 +32,7 @@ export async function getUserPeriodRanking(
   seasonId: string,
   period: RankingPeriod = "all",
 ): Promise<UserPeriodRanking | null> {
-  const supabase = createClient();
+  const supabase = await createAdminClient();
 
   // 期間フィルター計算
   const dateFilter = getPeriodDateFilter(period);
@@ -73,7 +73,7 @@ export async function getRanking(
   seasonId?: string,
 ): Promise<UserRanking[]> {
   try {
-    const supabase = createClient();
+    const supabase = await createAdminClient();
 
     // seasonIdが指定されている場合はそれを使用、そうでなければ現在のシーズン
     const targetSeasonId = seasonId || (await getCurrentSeasonId());


### PR DESCRIPTION
## 概要

ranking系・prefecture-team系のサービスファイルで使用していた `createClient`（anon key）を `createAdminClient`（service_role key）に置き換えました。

## 背景

Issue #1518: サーバーサイドのサービス層からのSupabaseアクセスをservice_role経由に統一するリファクタリングの一環です。

## 変更内容

以下のファイルで `createClient` → `createAdminClient` に置き換え:

- `src/features/ranking/services/get-ranking.ts`
- `src/features/ranking/services/get-missions-ranking.ts`
- `src/features/ranking/services/get-prefectures-ranking.ts`
- `src/features/prefecture-team/services/get-prefecture-team-ranking.ts`

対応するテストファイルのモックも `createClient` → `createAdminClient` に更新:

- `src/features/ranking/services/get-ranking.test.ts`
- `src/features/ranking/services/get-missions-ranking.test.ts`
- `src/features/ranking/services/get-prefectures-ranking.test.ts`

## 確認事項

- [x] TypeScript型チェック通過
- [x] ユニットテスト全42件通過
- [x] Biomeチェック通過
- [x] フロントエンドの変更なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ランキング機能の内部データベース接続処理を更新し、より堅牢な接続管理を実装しました。

* **Tests**
  * 更新されたデータベース接続処理に対応するテストの修正を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->