### PR TITLE
test: filterTeamMiraiVideos, isTokenExpired, parseIdTokenのテストを追加

### DIFF
--- a/src/features/tiktok/services/tiktok-video-service.ts
+++ b/src/features/tiktok/services/tiktok-video-service.ts
@@ -14,23 +14,8 @@ import {
   buildTikTokVideoInsertData,
   buildTikTokVideoUpdateData,
 } from "../utils/data-builders";
+import { filterTeamMiraiVideos } from "../utils/video-filters";
 import { fetchVideoList } from "./tiktok-client";
-
-// #チームみらい を検出する正規表現
-const TEAM_MIRAI_REGEX = /#(チームみらい|teammirai)/i;
-
-/**
- * #チームみらい 動画をフィルタリングする
- */
-export function filterTeamMiraiVideos(
-  videos: TikTokVideoFromAPI[],
-): TikTokVideoFromAPI[] {
-  return videos.filter((video) => {
-    const description = video.video_description || "";
-    const title = video.title || "";
-    return TEAM_MIRAI_REGEX.test(description) || TEAM_MIRAI_REGEX.test(title);
-  });
-}
 
 /**
  * TikTok動画をDBに保存する（service_role使用）

--- a/src/features/tiktok/utils/video-filters.test.ts
+++ b/src/features/tiktok/utils/video-filters.test.ts
@@ -1,0 +1,81 @@
+import type { TikTokVideoFromAPI } from "../types";
+import { filterTeamMiraiVideos } from "./video-filters";
+
+function makeVideo(
+  overrides: Partial<TikTokVideoFromAPI> = {},
+): TikTokVideoFromAPI {
+  return {
+    id: "v1",
+    create_time: 1700000000,
+    share_url: "https://tiktok.com/v1",
+    duration: 30,
+    ...overrides,
+  };
+}
+
+describe("filterTeamMiraiVideos", () => {
+  it("should return videos with #チームみらい in description", () => {
+    const videos = [
+      makeVideo({ video_description: "素敵な動画 #チームみらい です" }),
+      makeVideo({ id: "v2", video_description: "関係ない動画" }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("v1");
+  });
+
+  it("should return videos with #チームみらい in title", () => {
+    const videos = [makeVideo({ title: "#チームみらい の活動報告" })];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+  });
+
+  it("should match #teammirai case-insensitively", () => {
+    const videos = [
+      makeVideo({ video_description: "#TeamMirai video" }),
+      makeVideo({ id: "v2", title: "#TEAMMIRAI" }),
+      makeVideo({ id: "v3", video_description: "#teammirai" }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(3);
+  });
+
+  it("should return empty array when no videos match", () => {
+    const videos = [
+      makeVideo({ video_description: "普通の動画" }),
+      makeVideo({ id: "v2", title: "関係ない動画" }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should return empty array for empty input", () => {
+    const result = filterTeamMiraiVideos([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should handle videos with undefined description and title", () => {
+    const videos = [
+      makeVideo({ video_description: undefined, title: undefined }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should match when both description and title contain the hashtag", () => {
+    const videos = [
+      makeVideo({
+        video_description: "#チームみらい",
+        title: "#チームみらい",
+      }),
+    ];
+
+    const result = filterTeamMiraiVideos(videos);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/features/tiktok/utils/video-filters.ts
+++ b/src/features/tiktok/utils/video-filters.ts
@@ -1,0 +1,17 @@
+import type { TikTokVideoFromAPI } from "../types";
+
+// #チームみらい を検出する正規表現
+const TEAM_MIRAI_REGEX = /#(チームみらい|teammirai)/i;
+
+/**
+ * #チームみらい 動画をフィルタリングする
+ */
+export function filterTeamMiraiVideos(
+  videos: TikTokVideoFromAPI[],
+): TikTokVideoFromAPI[] {
+  return videos.filter((video) => {
+    const description = video.video_description || "";
+    const title = video.title || "";
+    return TEAM_MIRAI_REGEX.test(description) || TEAM_MIRAI_REGEX.test(title);
+  });
+}

--- a/src/features/youtube/services/google-auth.test.ts
+++ b/src/features/youtube/services/google-auth.test.ts
@@ -1,0 +1,37 @@
+import { isTokenExpired } from "./google-auth";
+
+describe("isTokenExpired", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should return true when the token has expired (past date)", () => {
+    jest.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+    expect(isTokenExpired("2025-01-14T12:00:00Z")).toBe(true);
+  });
+
+  it("should return false when the token is still valid (future date)", () => {
+    jest.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+    expect(isTokenExpired("2025-01-16T12:00:00Z")).toBe(false);
+  });
+
+  it("should return false when the token expires at exactly the current time", () => {
+    // new Date(tokenExpiresAt) < new Date() => equal is NOT less-than => false
+    jest.setSystemTime(new Date("2025-01-15T12:00:00.000Z"));
+    expect(isTokenExpired("2025-01-15T12:00:00.000Z")).toBe(false);
+  });
+
+  it("should return true when the token expired one second ago", () => {
+    jest.setSystemTime(new Date("2025-01-15T12:00:01.000Z"));
+    expect(isTokenExpired("2025-01-15T12:00:00.000Z")).toBe(true);
+  });
+
+  it("should return false when the token expires one second from now", () => {
+    jest.setSystemTime(new Date("2025-01-15T11:59:59.000Z"));
+    expect(isTokenExpired("2025-01-15T12:00:00.000Z")).toBe(false);
+  });
+});

--- a/src/features/youtube/services/youtube-client.test.ts
+++ b/src/features/youtube/services/youtube-client.test.ts
@@ -1,0 +1,86 @@
+import { parseIdToken, YouTubeAPIError } from "./youtube-client";
+
+describe("parseIdToken", () => {
+  // Helper to create a valid JWT-like token
+  function makeToken(payload: Record<string, unknown>): string {
+    const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString(
+      "base64url",
+    );
+    const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const signature = "fake-signature";
+    return `${header}.${body}.${signature}`;
+  }
+
+  it("should parse a valid id_token with all fields", () => {
+    const payload = {
+      iss: "https://accounts.google.com",
+      sub: "1234567890",
+      aud: "client-id.apps.googleusercontent.com",
+      exp: 1700000000,
+      iat: 1699999000,
+      email: "user@example.com",
+      email_verified: true,
+      name: "Test User",
+      picture: "https://example.com/photo.jpg",
+    };
+
+    const token = makeToken(payload);
+    const result = parseIdToken(token);
+
+    expect(result.sub).toBe("1234567890");
+    expect(result.iss).toBe("https://accounts.google.com");
+    expect(result.email).toBe("user@example.com");
+    expect(result.name).toBe("Test User");
+  });
+
+  it("should parse a minimal valid id_token with only sub", () => {
+    const payload = {
+      iss: "https://accounts.google.com",
+      sub: "minimal-sub",
+      aud: "client-id",
+      exp: 1700000000,
+      iat: 1699999000,
+    };
+
+    const token = makeToken(payload);
+    const result = parseIdToken(token);
+
+    expect(result.sub).toBe("minimal-sub");
+    expect(result.email).toBeUndefined();
+  });
+
+  it("should throw YouTubeAPIError for token with fewer than 3 parts", () => {
+    expect(() => parseIdToken("only-one-part")).toThrow(YouTubeAPIError);
+    expect(() => parseIdToken("only-one-part")).toThrow(
+      "Invalid id_token format",
+    );
+  });
+
+  it("should throw YouTubeAPIError for token with 2 parts", () => {
+    expect(() => parseIdToken("part1.part2")).toThrow(YouTubeAPIError);
+  });
+
+  it("should throw YouTubeAPIError for empty string", () => {
+    expect(() => parseIdToken("")).toThrow(YouTubeAPIError);
+  });
+
+  it("should throw YouTubeAPIError when sub claim is missing", () => {
+    const payload = {
+      iss: "https://accounts.google.com",
+      aud: "client-id",
+      exp: 1700000000,
+      iat: 1699999000,
+    };
+
+    const token = makeToken(payload);
+    expect(() => parseIdToken(token)).toThrow(YouTubeAPIError);
+    expect(() => parseIdToken(token)).toThrow(
+      "id_token does not contain sub claim",
+    );
+  });
+
+  it("should throw YouTubeAPIError for malformed base64 payload", () => {
+    const token = "header.!!!invalid-base64!!!.signature";
+    expect(() => parseIdToken(token)).toThrow(YouTubeAPIError);
+  });
+});


### PR DESCRIPTION
## Summary
- `filterTeamMiraiVideos` を `services/tiktok-video-service.ts` から `utils/video-filters.ts` に切り出し、`jest.mock` なしでテスト可能にした
- `isTokenExpired` (google-auth) のテストを追加
- `parseIdToken` (youtube-client) のテストを追加

Resolves #2013 のレビューコメント対応

## Test plan
- [x] `video-filters.test.ts`: 7テスト全パス（jest.mockなし）
- [x] `google-auth.test.ts`: 5テスト全パス
- [x] `youtube-client.test.ts`: 7テスト全パス
- [x] TypeScript型チェック通過
- [x] Biome lint/format通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)