### PR TITLE
refactor: 都道府県対抗ランキング変換ロジックをutilsに切り出し

### DIFF
--- a/src/features/prefecture-team/services/get-prefecture-team-ranking.ts
+++ b/src/features/prefecture-team/services/get-prefecture-team-ranking.ts
@@ -1,22 +1,15 @@
 import "server-only";
 
-import {
-  calculateXpPerCapita,
-  PREFECTURE_POPULATIONS,
-} from "@/lib/constants/prefecture-populations";
 import { getCurrentSeasonId } from "@/lib/services/seasons";
 import { createClient } from "@/lib/supabase/client";
 import type {
   PrefectureTeamRanking,
   UserPrefectureContribution,
 } from "../types/prefecture-team-types";
-
-// RPC関数の戻り値の型定義
-interface PrefectureTeamRankingRow {
-  prefecture: string;
-  total_xp: number;
-  user_count: number;
-}
+import {
+  type PrefectureTeamRankingRow,
+  transformToXpPerCapitaRanking,
+} from "../utils/ranking-transform";
 
 interface UserPrefectureContributionRow {
   prefecture: string;
@@ -57,22 +50,7 @@ export async function getPrefectureTeamRanking(
       return [];
     }
 
-    // 人口比XPを計算してランキングを生成
-    const rankingWithXpPerCapita = data
-      .filter((item) => PREFECTURE_POPULATIONS[item.prefecture])
-      .map((item) => ({
-        prefecture: item.prefecture,
-        totalXp: item.total_xp,
-        userCount: item.user_count,
-        xpPerCapita: calculateXpPerCapita(item.total_xp, item.prefecture),
-      }))
-      .sort((a, b) => b.xpPerCapita - a.xpPerCapita)
-      .map((item, index) => ({
-        ...item,
-        rank: index + 1,
-      }));
-
-    return rankingWithXpPerCapita;
+    return transformToXpPerCapitaRanking(data);
   } catch (error) {
     console.error("Prefecture team ranking service error:", error);
     throw error;

--- a/src/features/prefecture-team/utils/ranking-transform.test.ts
+++ b/src/features/prefecture-team/utils/ranking-transform.test.ts
@@ -1,0 +1,116 @@
+import {
+  type PrefectureTeamRankingRow,
+  transformToXpPerCapitaRanking,
+} from "./ranking-transform";
+
+describe("transformToXpPerCapitaRanking", () => {
+  it("returns empty array for empty data", () => {
+    expect(transformToXpPerCapitaRanking([])).toEqual([]);
+  });
+
+  it("transforms a single prefecture correctly", () => {
+    const data: PrefectureTeamRankingRow[] = [
+      { prefecture: "東京都", total_xp: 10000, user_count: 50 },
+    ];
+
+    const result = transformToXpPerCapitaRanking(data);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].prefecture).toBe("東京都");
+    expect(result[0].totalXp).toBe(10000);
+    expect(result[0].userCount).toBe(50);
+    expect(result[0].rank).toBe(1);
+    expect(typeof result[0].xpPerCapita).toBe("number");
+    expect(result[0].xpPerCapita).toBeGreaterThan(0);
+  });
+
+  it("filters out unknown prefectures", () => {
+    const data: PrefectureTeamRankingRow[] = [
+      { prefecture: "東京都", total_xp: 10000, user_count: 50 },
+      { prefecture: "不明", total_xp: 5000, user_count: 10 },
+      { prefecture: "海外", total_xp: 3000, user_count: 5 },
+    ];
+
+    const result = transformToXpPerCapitaRanking(data);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].prefecture).toBe("東京都");
+  });
+
+  it("sorts by xpPerCapita in descending order", () => {
+    const data: PrefectureTeamRankingRow[] = [
+      // 東京都 population ~14,178,000 => lower per-capita
+      { prefecture: "東京都", total_xp: 100000, user_count: 500 },
+      // 鳥取県 population ~531,000 => higher per-capita with same XP
+      { prefecture: "鳥取県", total_xp: 100000, user_count: 200 },
+    ];
+
+    const result = transformToXpPerCapitaRanking(data);
+
+    expect(result).toHaveLength(2);
+    // 鳥取県 should rank first (smaller population => higher per-capita)
+    expect(result[0].prefecture).toBe("鳥取県");
+    expect(result[1].prefecture).toBe("東京都");
+    expect(result[0].xpPerCapita).toBeGreaterThan(result[1].xpPerCapita);
+  });
+
+  it("assigns correct rank numbers", () => {
+    const data: PrefectureTeamRankingRow[] = [
+      { prefecture: "東京都", total_xp: 100000, user_count: 500 },
+      { prefecture: "鳥取県", total_xp: 100000, user_count: 200 },
+      { prefecture: "大阪府", total_xp: 50000, user_count: 300 },
+    ];
+
+    const result = transformToXpPerCapitaRanking(data);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].rank).toBe(1);
+    expect(result[1].rank).toBe(2);
+    expect(result[2].rank).toBe(3);
+  });
+
+  it("handles multiple prefectures with varying data", () => {
+    const data: PrefectureTeamRankingRow[] = [
+      { prefecture: "北海道", total_xp: 50000, user_count: 100 },
+      { prefecture: "沖縄県", total_xp: 30000, user_count: 80 },
+      { prefecture: "愛知県", total_xp: 70000, user_count: 200 },
+      { prefecture: "福岡県", total_xp: 40000, user_count: 120 },
+    ];
+
+    const result = transformToXpPerCapitaRanking(data);
+
+    expect(result).toHaveLength(4);
+    // All should have sequential ranks
+    for (let i = 0; i < result.length; i++) {
+      expect(result[i].rank).toBe(i + 1);
+    }
+    // Should be sorted descending by xpPerCapita
+    for (let i = 0; i < result.length - 1; i++) {
+      expect(result[i].xpPerCapita).toBeGreaterThanOrEqual(
+        result[i + 1].xpPerCapita,
+      );
+    }
+  });
+
+  it("preserves totalXp and userCount in output", () => {
+    const data: PrefectureTeamRankingRow[] = [
+      { prefecture: "神奈川県", total_xp: 99999, user_count: 42 },
+    ];
+
+    const result = transformToXpPerCapitaRanking(data);
+
+    expect(result[0].totalXp).toBe(99999);
+    expect(result[0].userCount).toBe(42);
+  });
+
+  it("handles items where all entries are unknown prefectures", () => {
+    const data: PrefectureTeamRankingRow[] = [
+      { prefecture: "不明", total_xp: 5000, user_count: 10 },
+      { prefecture: "未設定", total_xp: 3000, user_count: 5 },
+    ];
+
+    const result = transformToXpPerCapitaRanking(data);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/features/prefecture-team/utils/ranking-transform.ts
+++ b/src/features/prefecture-team/utils/ranking-transform.ts
@@ -1,0 +1,36 @@
+import {
+  calculateXpPerCapita,
+  PREFECTURE_POPULATIONS,
+} from "@/lib/constants/prefecture-populations";
+import type { PrefectureTeamRanking } from "../types/prefecture-team-types";
+
+/**
+ * RPC関数の戻り値の型定義
+ */
+export interface PrefectureTeamRankingRow {
+  prefecture: string;
+  total_xp: number;
+  user_count: number;
+}
+
+/**
+ * RPC結果を人口あたりXPランキングに変換する
+ * 不明な都道府県を除外し、人口比XPで降順ソートしてランク付けする
+ */
+export function transformToXpPerCapitaRanking(
+  data: PrefectureTeamRankingRow[],
+): PrefectureTeamRanking[] {
+  return data
+    .filter((item) => PREFECTURE_POPULATIONS[item.prefecture])
+    .map((item) => ({
+      prefecture: item.prefecture,
+      totalXp: item.total_xp,
+      userCount: item.user_count,
+      xpPerCapita: calculateXpPerCapita(item.total_xp, item.prefecture),
+    }))
+    .sort((a, b) => b.xpPerCapita - a.xpPerCapita)
+    .map((item, index) => ({
+      ...item,
+      rank: index + 1,
+    }));
+}


### PR DESCRIPTION
# 変更の概要
- `getPrefectureTeamRanking` サービス内のランキング変換ロジック（filter→map→sort→rank）を純粋関数 `transformToXpPerCapitaRanking` として `utils/ranking-transform.ts` に切り出し
- 元のサービスファイルは新しいutilからimportする形に修正
- 切り出した関数に対する包括的なテストを追加（8テストケース、カバレッジ100%）

# 変更の背景
- サービスファイルからDB非依存の純粋ロジックを分離し、テスタビリティと保守性を向上
- テストケース: 空データ、1都道府県、複数都道府県、不明都道府県の除外、ソート順、ランク付け

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました