### PR TITLE
refactor: ポスターボード統計集計ロジックをutilsに切り出し

### DIFF
--- a/src/features/map-poster/utils/stats-aggregation.test.ts
+++ b/src/features/map-poster/utils/stats-aggregation.test.ts
@@ -1,0 +1,173 @@
+import type { Database } from "@/lib/types/supabase";
+import {
+  aggregateBoardStats,
+  aggregateBoardsByPrefecture,
+  type BoardStatsRow,
+} from "./stats-aggregation";
+
+type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
+
+const ALL_STATUSES: BoardStatus[] = [
+  "not_yet",
+  "not_yet_dangerous",
+  "reserved",
+  "done",
+  "error_wrong_place",
+  "error_damaged",
+  "error_wrong_poster",
+  "other",
+];
+
+describe("aggregateBoardStats", () => {
+  it("returns empty stats for empty data", () => {
+    const result = aggregateBoardStats([]);
+
+    expect(result.stats).toEqual({});
+    expect(result.total).toBe(0);
+    expect(result.completed).toBe(0);
+  });
+
+  it("aggregates a single row correctly", () => {
+    const data: BoardStatsRow[] = [
+      { prefecture: "東京都", status: "done", count: 10 },
+    ];
+
+    const result = aggregateBoardStats(data);
+
+    expect(result.stats["東京都"].done).toBe(10);
+    expect(result.total).toBe(10);
+    expect(result.completed).toBe(10);
+  });
+
+  it("aggregates multiple prefectures", () => {
+    const data: BoardStatsRow[] = [
+      { prefecture: "東京都", status: "done", count: 10 },
+      { prefecture: "東京都", status: "not_yet", count: 20 },
+      { prefecture: "大阪府", status: "reserved", count: 5 },
+    ];
+
+    const result = aggregateBoardStats(data);
+
+    expect(result.stats["東京都"].done).toBe(10);
+    expect(result.stats["東京都"].not_yet).toBe(20);
+    expect(result.stats["大阪府"].reserved).toBe(5);
+    expect(result.total).toBe(35);
+    expect(result.completed).toBe(10);
+  });
+
+  it("initializes all status fields to zero", () => {
+    const data: BoardStatsRow[] = [
+      { prefecture: "北海道", status: "done", count: 3 },
+    ];
+
+    const result = aggregateBoardStats(data);
+
+    for (const status of ALL_STATUSES) {
+      expect(typeof result.stats["北海道"][status]).toBe("number");
+    }
+    expect(result.stats["北海道"].done).toBe(3);
+    expect(result.stats["北海道"].not_yet).toBe(0);
+    expect(result.stats["北海道"].reserved).toBe(0);
+  });
+
+  it("only counts 'done' status as completed", () => {
+    const data: BoardStatsRow[] = [
+      { prefecture: "東京都", status: "done", count: 5 },
+      { prefecture: "東京都", status: "reserved", count: 10 },
+      { prefecture: "東京都", status: "not_yet", count: 15 },
+    ];
+
+    const result = aggregateBoardStats(data);
+
+    expect(result.completed).toBe(5);
+    expect(result.total).toBe(30);
+  });
+
+  it("handles all status types", () => {
+    const data: BoardStatsRow[] = ALL_STATUSES.map((status, i) => ({
+      prefecture: "東京都",
+      status,
+      count: i + 1,
+    }));
+
+    const result = aggregateBoardStats(data);
+
+    for (let i = 0; i < ALL_STATUSES.length; i++) {
+      expect(result.stats["東京都"][ALL_STATUSES[i]]).toBe(i + 1);
+    }
+    // Total = 1+2+3+4+5+6+7+8 = 36
+    expect(result.total).toBe(36);
+    // "done" is at index 3, so count = 4
+    expect(result.completed).toBe(4);
+  });
+});
+
+describe("aggregateBoardsByPrefecture", () => {
+  it("returns empty stats for empty array", () => {
+    const result = aggregateBoardsByPrefecture([]);
+
+    expect(result.stats).toEqual({});
+    expect(result.total).toBe(0);
+    expect(result.completed).toBe(0);
+  });
+
+  it("aggregates a single board correctly", () => {
+    const boards: { prefecture: string; status: BoardStatus }[] = [
+      { prefecture: "東京都", status: "done" },
+    ];
+
+    const result = aggregateBoardsByPrefecture(boards);
+
+    expect(result.stats["東京都"].done).toBe(1);
+    expect(result.total).toBe(1);
+    expect(result.completed).toBe(1);
+  });
+
+  it("aggregates multiple boards across prefectures", () => {
+    const boards: { prefecture: string; status: BoardStatus }[] = [
+      { prefecture: "東京都", status: "done" },
+      { prefecture: "東京都", status: "done" },
+      { prefecture: "東京都", status: "not_yet" },
+      { prefecture: "大阪府", status: "reserved" },
+      { prefecture: "大阪府", status: "not_yet" },
+    ];
+
+    const result = aggregateBoardsByPrefecture(boards);
+
+    expect(result.stats["東京都"].done).toBe(2);
+    expect(result.stats["東京都"].not_yet).toBe(1);
+    expect(result.stats["大阪府"].reserved).toBe(1);
+    expect(result.stats["大阪府"].not_yet).toBe(1);
+    expect(result.total).toBe(5);
+    expect(result.completed).toBe(2);
+  });
+
+  it("initializes all status fields to zero", () => {
+    const boards: { prefecture: string; status: BoardStatus }[] = [
+      { prefecture: "福岡県", status: "not_yet" },
+    ];
+
+    const result = aggregateBoardsByPrefecture(boards);
+
+    for (const status of ALL_STATUSES) {
+      expect(typeof result.stats["福岡県"][status]).toBe("number");
+    }
+    expect(result.stats["福岡県"].not_yet).toBe(1);
+    expect(result.stats["福岡県"].done).toBe(0);
+  });
+
+  it("correctly counts total and completed", () => {
+    const boards: { prefecture: string; status: BoardStatus }[] = [
+      { prefecture: "東京都", status: "done" },
+      { prefecture: "東京都", status: "reserved" },
+      { prefecture: "大阪府", status: "done" },
+      { prefecture: "大阪府", status: "error_damaged" },
+      { prefecture: "北海道", status: "not_yet" },
+    ];
+
+    const result = aggregateBoardsByPrefecture(boards);
+
+    expect(result.total).toBe(5);
+    expect(result.completed).toBe(2);
+  });
+});

--- a/src/features/map-poster/utils/stats-aggregation.ts
+++ b/src/features/map-poster/utils/stats-aggregation.ts
@@ -1,0 +1,78 @@
+import type { Database } from "@/lib/types/supabase";
+
+type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
+type PrefectureStats = Record<string, Record<BoardStatus, number>>;
+
+/**
+ * RPC結果の行の型
+ */
+export interface BoardStatsRow {
+  prefecture: string;
+  status: string;
+  count: number;
+}
+
+const EMPTY_STATUS_RECORD: Record<BoardStatus, number> = {
+  not_yet: 0,
+  not_yet_dangerous: 0,
+  reserved: 0,
+  done: 0,
+  error_wrong_place: 0,
+  error_damaged: 0,
+  error_wrong_poster: 0,
+  other: 0,
+};
+
+/**
+ * ボード統計データの行配列を都道府県×ステータス別に集計する
+ */
+export function aggregateBoardStats(data: BoardStatsRow[]): {
+  stats: PrefectureStats;
+  total: number;
+  completed: number;
+} {
+  const stats: PrefectureStats = {};
+  let total = 0;
+  let completed = 0;
+
+  for (const row of data) {
+    if (!stats[row.prefecture]) {
+      stats[row.prefecture] = { ...EMPTY_STATUS_RECORD };
+    }
+    stats[row.prefecture][row.status as BoardStatus] = row.count;
+    total += row.count;
+    if (row.status === "done") {
+      completed += row.count;
+    }
+  }
+
+  return { stats, total, completed };
+}
+
+/**
+ * 個別ボードの配列を都道府県×ステータス別に集計する（フォールバック用）
+ */
+export function aggregateBoardsByPrefecture(
+  boards: { prefecture: string; status: BoardStatus }[],
+): {
+  stats: PrefectureStats;
+  total: number;
+  completed: number;
+} {
+  const stats: PrefectureStats = {};
+  let total = 0;
+  let completed = 0;
+
+  for (const board of boards) {
+    if (!stats[board.prefecture]) {
+      stats[board.prefecture] = { ...EMPTY_STATUS_RECORD };
+    }
+    stats[board.prefecture][board.status]++;
+    total++;
+    if (board.status === "done") {
+      completed++;
+    }
+  }
+
+  return { stats, total, completed };
+}


### PR DESCRIPTION
# 変更の概要
- `getPosterBoardStats` サービス内の統計集計ロジック（都道府県×ステータス別カウント）を純粋関数として `utils/stats-aggregation.ts` に切り出し
- `aggregateBoardStats` (RPC結果用) と `aggregateBoardsByPrefecture` (フォールバック用) の2関数を提供
- 元のサービスファイルは新しいutilからimportする形に修正
- 切り出した関数に対する包括的なテストを追加（11テストケース、カバレッジ100%）

# 変更の背景
- サービスファイルからDB非依存の純粋ロジックを分離し、テスタビリティと保守性を向上
- テストケース: 空データ、単一行、複数都道府県、全ステータス種、合計値検証

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました