### PR TITLE
refactor: OGP画像のタイトル整形・投票ミッション判定をヘルパーに切り出し

### DIFF
--- a/src/app/api/missions/[slug]/og/og-helpers.test.ts
+++ b/src/app/api/missions/[slug]/og/og-helpers.test.ts
@@ -1,0 +1,68 @@
+import { formatTitleWithLineBreaks, isVotingMission } from "./og-helpers";
+
+describe("formatTitleWithLineBreaks", () => {
+  it("returns title unchanged when no brackets present", () => {
+    expect(formatTitleWithLineBreaks("テスト")).toBe("テスト");
+  });
+
+  it("inserts line break before full-width brackets", () => {
+    expect(formatTitleWithLineBreaks("ミッション（初級）")).toBe(
+      "ミッション\n（初級）",
+    );
+  });
+
+  it("inserts line break before half-width brackets", () => {
+    expect(formatTitleWithLineBreaks("Mission(beginner)")).toBe(
+      "Mission\n(beginner)",
+    );
+  });
+
+  it("handles multiple full-width brackets", () => {
+    expect(formatTitleWithLineBreaks("タイトル（A）と（B）")).toBe(
+      "タイトル\n（A）と\n（B）",
+    );
+  });
+
+  it("handles multiple half-width brackets", () => {
+    expect(formatTitleWithLineBreaks("Title(A)and(B)")).toBe(
+      "Title\n(A)and\n(B)",
+    );
+  });
+
+  it("handles mixed bracket types", () => {
+    expect(formatTitleWithLineBreaks("タイトル（A）and(B)")).toBe(
+      "タイトル\n（A）and\n(B)",
+    );
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(formatTitleWithLineBreaks("")).toBe("");
+  });
+});
+
+describe("isVotingMission", () => {
+  it("returns true for early-vote", () => {
+    expect(isVotingMission("early-vote")).toBe(true);
+  });
+
+  it("returns true for absent-vote", () => {
+    expect(isVotingMission("absent-vote")).toBe(true);
+  });
+
+  it("returns true for overseas-vote", () => {
+    expect(isVotingMission("overseas-vote")).toBe(true);
+  });
+
+  it("returns false for non-voting slug", () => {
+    expect(isVotingMission("some-other-mission")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isVotingMission("")).toBe(false);
+  });
+
+  it("returns false for partial match", () => {
+    expect(isVotingMission("early-vote-extra")).toBe(false);
+    expect(isVotingMission("vote")).toBe(false);
+  });
+});

--- a/src/app/api/missions/[slug]/og/og-helpers.ts
+++ b/src/app/api/missions/[slug]/og/og-helpers.ts
@@ -1,0 +1,16 @@
+/**
+ * タイトルの括弧前に改行を挿入する
+ * 全角括弧（）と半角括弧()の両方に対応
+ */
+export function formatTitleWithLineBreaks(title: string): string {
+  return title.replace(/（/g, "\n（").replace(/\(/g, "\n(");
+}
+
+const VOTING_MISSION_SLUGS = ["early-vote", "absent-vote", "overseas-vote"];
+
+/**
+ * 投票系ミッションかどうかを判定する
+ */
+export function isVotingMission(slug: string): boolean {
+  return VOTING_MISSION_SLUGS.includes(slug);
+}


### PR DESCRIPTION
# 変更の概要
- OGP画像生成ルート (`route.tsx`) から純粋関数を `og-helpers.ts` に切り出し
  - `formatTitleWithLineBreaks(title)` - タイトルの括弧前に改行を挿入（全角・半角対応）
  - `isVotingMission(slug)` - 投票系ミッション（early-vote, absent-vote, overseas-vote）の判定
- 元のルートファイルは新しいヘルパーからimportする形に修正
- 切り出した関数に対する包括的なテストを追加（13テストケース）

# 変更の背景
- ルートハンドラからDB非依存の純粋ロジックを分離し、テスタビリティと保守性を向上
- テストケース: 括弧なし、全角括弧、半角括弧、複数括弧、混合、空文字列、各投票slug、非投票slug、部分一致

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました