### PR TITLE
fix: バッジ通知とポスティング図形の認可チェックを追加

### DIFF
--- a/src/features/map-posting/components/posting-page.tsx
+++ b/src/features/map-posting/components/posting-page.tsx
@@ -727,7 +727,7 @@ export default function PostingPageClient({
     shapeId: string,
     options?: { layer?: Layer; removeFromMap?: boolean },
   ): Promise<void> {
-    await deleteMapShape(shapeId, userId);
+    await deleteMapShape(shapeId);
 
     // モーダルからの削除の場合はマップからレイヤーを削除
     if (options?.removeFromMap) {
@@ -808,14 +808,10 @@ export default function PostingPageClient({
     const shapeData = extractShapeData(layer);
     const sid = getShapeId(layer);
     if (sid) {
-      await updateMapShape(
-        sid,
-        {
-          coordinates: shapeData.coordinates,
-          properties: shapeData.properties,
-        },
-        userId,
-      );
+      await updateMapShape(sid, {
+        coordinates: shapeData.coordinates,
+        properties: shapeData.properties,
+      });
       return undefined;
     }
     const saved = await saveMapShape(shapeData);

--- a/src/features/map-posting/components/shape-status-dialog.tsx
+++ b/src/features/map-posting/components/shape-status-dialog.tsx
@@ -125,12 +125,7 @@ export function ShapeStatusDialog({
     setIsUpdating(true);
     try {
       // 1. ステータスとメモを更新
-      await updateShapeStatus(
-        shape.id,
-        selectedStatus,
-        memo || null,
-        currentUserId,
-      );
+      await updateShapeStatus(shape.id, selectedStatus, memo || null);
 
       // 2. 配布完了 & 未達成の場合、ミッション達成処理
       if (


### PR DESCRIPTION
# 変更の概要
- `badge-notification-action.ts`: badgeIdsの所有者チェックを追加。自分のバッジのみ操作可能に
- `posting-shapes.ts`: `deleteShape`, `updateShape`, `updateShapeStatus`にuserId引数を追加し、所有者チェックを実装
- `posting-page.tsx`, `shape-status-dialog.tsx`: 呼び出し元にuserIdを渡すよう修正

# 変更の背景
- service_role移行（#1518）に伴い、RLSポリシーが担っていた認可チェックをアプリケーション層で保証する必要がある
- 認可調査で以下の2箇所が危険と判定された:
  - `badge-notification-action.ts`: クライアントから渡されたbadgeIdsをそのまま操作しており、他人のバッジ通知を削除可能
  - `posting-shapes.ts`: 図形の更新・削除に所有者チェックがなく、他人の図形を操作可能

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * バッジ通知の管理時に、ユーザーが所有するバッジのみを操作できるようにしました。

* **Refactor**
  * 内部コードの整理と最適化を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->