### PR TITLE
test: calculateAge, cn, getLabelIconWidth のテスト追加

### DIFF
--- a/src/features/map-posting/utils/posting-label.test.ts
+++ b/src/features/map-posting/utils/posting-label.test.ts
@@ -1,0 +1,42 @@
+import { getLabelIconWidth } from "./posting-label";
+
+describe("getLabelIconWidth", () => {
+  it("returns minimum width of 50 for single digit numbers", () => {
+    expect(getLabelIconWidth(1)).toBe(50);
+    expect(getLabelIconWidth(9)).toBe(50);
+  });
+
+  it("returns 50 for two digit numbers", () => {
+    // 30 + 2 * 10 = 50
+    expect(getLabelIconWidth(10)).toBe(50);
+    expect(getLabelIconWidth(99)).toBe(50);
+  });
+
+  it("returns 60 for three digit numbers", () => {
+    // 30 + 3 * 10 = 60
+    expect(getLabelIconWidth(100)).toBe(60);
+    expect(getLabelIconWidth(999)).toBe(60);
+  });
+
+  it("returns 70 for four digit numbers", () => {
+    // 30 + 4 * 10 = 70
+    expect(getLabelIconWidth(1000)).toBe(70);
+    expect(getLabelIconWidth(9999)).toBe(70);
+  });
+
+  it("returns 80 for five digit numbers", () => {
+    // 30 + 5 * 10 = 80
+    expect(getLabelIconWidth(10000)).toBe(80);
+  });
+
+  it("enforces minimum width of 50", () => {
+    // For 1 digit: 30 + 1 * 10 = 40, but Math.max(50, 40) = 50
+    expect(getLabelIconWidth(5)).toBeGreaterThanOrEqual(50);
+  });
+
+  it("scales linearly with digit count above minimum", () => {
+    const width3 = getLabelIconWidth(100); // 3 digits
+    const width4 = getLabelIconWidth(1000); // 4 digits
+    expect(width4 - width3).toBe(10);
+  });
+});

--- a/src/features/map-posting/utils/posting-label.ts
+++ b/src/features/map-posting/utils/posting-label.ts
@@ -4,7 +4,7 @@
  */
 
 // Calculate dynamic icon width based on digit count
-function getLabelIconWidth(postingCount: number): number {
+export function getLabelIconWidth(postingCount: number): number {
   const digits = postingCount.toString().length;
   // Base width + extra per digit + padding for "枚"
   return Math.max(50, 30 + digits * 10);

--- a/src/lib/utils/utils.test.ts
+++ b/src/lib/utils/utils.test.ts
@@ -28,7 +28,27 @@ describe("utils", () => {
 
     it("should handle empty inputs", () => {
       const result = cn();
-      expect(typeof result).toBe("string");
+      expect(result).toBe("");
+    });
+
+    it("should return a single class as-is", () => {
+      expect(cn("p-4")).toBe("p-4");
+    });
+
+    it("should merge conflicting Tailwind classes (last wins)", () => {
+      expect(cn("p-2", "p-4")).toBe("p-4");
+    });
+
+    it("should merge conflicting Tailwind text size classes", () => {
+      expect(cn("text-sm", "text-lg")).toBe("text-lg");
+    });
+
+    it("should handle undefined and null values", () => {
+      expect(cn("base", undefined, null, "extra")).toBe("base extra");
+    });
+
+    it("should handle array inputs", () => {
+      expect(cn(["p-2", "m-2"])).toBe("p-2 m-2");
     });
   });
 
@@ -88,6 +108,25 @@ describe("utils", () => {
     it("should handle leap year birthdate", () => {
       const age = calculateAge("1992-02-29");
       expect(age).toBe(32);
+    });
+
+    it("should return 0 for a baby born this year before today", () => {
+      expect(calculateAge("2024-01-01")).toBe(0);
+    });
+
+    it("should return 0 for a baby born today", () => {
+      expect(calculateAge("2024-06-15")).toBe(0);
+    });
+
+    it("should handle leap year birthday before it occurs in non-leap year", () => {
+      jest.setSystemTime(new Date("2025-02-28"));
+      // Born Feb 29, 2000. Feb 29 doesn't exist in 2025.
+      // Month is same (1), but day 28 < 29, so age is decremented
+      expect(calculateAge("2000-02-29")).toBe(24);
+    });
+
+    it("should handle birthday tomorrow", () => {
+      expect(calculateAge("1990-06-16")).toBe(33);
     });
   });
 });


### PR DESCRIPTION
# 変更の概要
- `src/lib/utils/utils.test.ts` を拡張: `cn` と `calculateAge` のテストケースを追加
  - cn: Tailwindクラスのマージ(p-2 + p-4 -> p-4)、配列入力、null/undefined処理
  - calculateAge: 0歳、うるう年のエッジケース(非うるう年の2/28)、誕生日が明日のケース
- `src/features/map-posting/utils/posting-label.test.ts` を新規作成: `getLabelIconWidth` テスト
  - 1桁~5桁の数値に対する幅計算
  - 最小幅50の保証
  - 桁数に対する線形スケーリング
- `getLabelIconWidth` をテスト可能にするためexportに変更

# 変更の背景
- テストカバレッジ向上のため、コアユーティリティ関数のテストを強化
- 既存11テストに加え16テスト追加で合計27テストケース

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました