### PR TITLE
refactor: YouTube統計サービスから純粋関数をutilsに切り出し

### DIFF
--- a/src/features/youtube-stats/services/youtube-stats-service.ts
+++ b/src/features/youtube-stats/services/youtube-stats-service.ts
@@ -13,6 +13,14 @@ import type {
   VideoCountByDateItem,
   YouTubeVideoWithStats,
 } from "../types";
+import {
+  aggregateDailyStats,
+  aggregateVideosByDate,
+  extractLatestStats,
+  generateDateRange,
+  mapStatisticsResult,
+  sortVideosByMetric,
+} from "../utils/youtube-stats-utils";
 
 /**
  * YouTube動画一覧を最新統計付きで取得する
@@ -68,45 +76,12 @@ export async function getYouTubeVideosWithStats(
   }
 
   // 各動画の最新統計を取得して整形
-  const videosWithStats: YouTubeVideoWithStats[] = (videos || []).map(
-    (video) => {
-      const stats = video.youtube_video_stats as Array<{
-        view_count: number | null;
-        like_count: number | null;
-        comment_count: number | null;
-        recorded_at: string;
-      }>;
-
-      // 最新の統計を取得（recorded_atでソート）
-      const latestStats = stats.sort(
-        (a, b) =>
-          new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime(),
-      )[0];
-
-      return {
-        ...video,
-        youtube_video_stats: undefined, // 元のリレーションを除去
-        latest_view_count: latestStats?.view_count ?? null,
-        latest_like_count: latestStats?.like_count ?? null,
-        latest_comment_count: latestStats?.comment_count ?? null,
-      } as YouTubeVideoWithStats;
-    },
+  const videosWithStats = extractLatestStats(
+    (videos || []) as Parameters<typeof extractLatestStats>[0],
   );
 
   // ソート
-  const sorted = videosWithStats.sort((a, b) => {
-    switch (sortBy) {
-      case "view_count":
-        return (b.latest_view_count ?? 0) - (a.latest_view_count ?? 0);
-      case "like_count":
-        return (b.latest_like_count ?? 0) - (a.latest_like_count ?? 0);
-      default:
-        return (
-          new Date(b.published_at ?? 0).getTime() -
-          new Date(a.published_at ?? 0).getTime()
-        );
-    }
-  });
+  const sorted = sortVideosByMetric(videosWithStats, sortBy);
 
   // ページネーション
   return sorted.slice(offset, offset + limit);
@@ -324,29 +299,11 @@ export async function getOverallStatsHistory(
   }
 
   // 日別に集計
-  const dailyStats = new Map<
-    string,
-    { total_views: number; total_likes: number }
-  >();
-
-  for (const stat of data || []) {
-    const date = stat.recorded_at;
-    const current = dailyStats.get(date) || { total_views: 0, total_likes: 0 };
-    dailyStats.set(date, {
-      total_views: current.total_views + (stat.view_count ?? 0),
-      total_likes: current.total_likes + (stat.like_count ?? 0),
-    });
-  }
+  const dailyStats = aggregateDailyStats(data || []);
 
   // 配列に変換して本日以降のデータを除外
   const { filterBeforeToday } = await import("@/lib/utils/date-utils");
-  const result = Array.from(dailyStats.entries())
-    .map(([date, stats]) => ({
-      date,
-      total_views: stats.total_views,
-      total_likes: stats.total_likes,
-    }))
-    .sort((a, b) => a.date.localeCompare(b.date));
+  const result = mapStatisticsResult(dailyStats);
 
   return filterBeforeToday(result);
 }
@@ -385,27 +342,14 @@ export async function getVideoCountByDate(
   }
 
   // 日別に集計
-  const dailyCount = new Map<string, number>();
-
-  for (const video of data || []) {
-    if (!video.published_at) continue;
-    const date = video.published_at.split("T")[0]; // YYYY-MM-DD
-    dailyCount.set(date, (dailyCount.get(date) || 0) + 1);
-  }
+  const dailyCount = aggregateVideosByDate(data || []);
 
   // startDateからendDateまでの日付を生成（投稿0の日も含める）
-  const result: VideoCountByDateItem[] = [];
-  effectiveEndDate.setHours(0, 0, 0, 0);
-
-  const currentDate = new Date(effectiveStartDate);
-  while (currentDate <= effectiveEndDate) {
-    const dateStr = currentDate.toISOString().split("T")[0];
-    result.push({
-      date: dateStr,
-      count: dailyCount.get(dateStr) || 0,
-    });
-    currentDate.setDate(currentDate.getDate() + 1);
-  }
+  const result = generateDateRange(
+    effectiveStartDate,
+    effectiveEndDate,
+    dailyCount,
+  );
 
   // 本日以降のデータを除外
   const { filterBeforeToday } = await import("@/lib/utils/date-utils");

--- a/src/features/youtube-stats/utils/youtube-stats-utils.test.ts
+++ b/src/features/youtube-stats/utils/youtube-stats-utils.test.ts
@@ -1,0 +1,366 @@
+import type {
+  OverallStatsHistoryItem,
+  VideoCountByDateItem,
+  YouTubeVideoWithStats,
+} from "../types";
+import {
+  aggregateDailyStats,
+  aggregateVideosByDate,
+  extractLatestStats,
+  generateDateRange,
+  mapStatisticsResult,
+  sortVideosByMetric,
+  type VideoWithStatsRelation,
+} from "./youtube-stats-utils";
+
+describe("extractLatestStats", () => {
+  it("should extract latest stats from videos based on recorded_at", () => {
+    const videos: VideoWithStatsRelation[] = [
+      {
+        video_id: "v1",
+        title: "Video 1",
+        published_at: "2026-01-10T00:00:00Z",
+        youtube_video_stats: [
+          {
+            view_count: 100,
+            like_count: 10,
+            comment_count: 5,
+            recorded_at: "2026-01-10",
+          },
+          {
+            view_count: 200,
+            like_count: 20,
+            comment_count: 8,
+            recorded_at: "2026-01-11",
+          },
+        ],
+      },
+    ];
+
+    const result = extractLatestStats(videos);
+    expect(result).toHaveLength(1);
+    expect(result[0].latest_view_count).toBe(200);
+    expect(result[0].latest_like_count).toBe(20);
+    expect(result[0].latest_comment_count).toBe(8);
+  });
+
+  it("should handle empty stats array", () => {
+    const videos: VideoWithStatsRelation[] = [
+      {
+        video_id: "v1",
+        title: "Video 1",
+        youtube_video_stats: [],
+      },
+    ];
+
+    const result = extractLatestStats(videos);
+    expect(result).toHaveLength(1);
+    expect(result[0].latest_view_count).toBeNull();
+    expect(result[0].latest_like_count).toBeNull();
+    expect(result[0].latest_comment_count).toBeNull();
+  });
+
+  it("should handle null stat values", () => {
+    const videos: VideoWithStatsRelation[] = [
+      {
+        video_id: "v1",
+        youtube_video_stats: [
+          {
+            view_count: null,
+            like_count: null,
+            comment_count: null,
+            recorded_at: "2026-01-10",
+          },
+        ],
+      },
+    ];
+
+    const result = extractLatestStats(videos);
+    expect(result[0].latest_view_count).toBeNull();
+    expect(result[0].latest_like_count).toBeNull();
+    expect(result[0].latest_comment_count).toBeNull();
+  });
+
+  it("should handle multiple videos", () => {
+    const videos: VideoWithStatsRelation[] = [
+      {
+        video_id: "v1",
+        youtube_video_stats: [
+          {
+            view_count: 100,
+            like_count: 10,
+            comment_count: 1,
+            recorded_at: "2026-01-10",
+          },
+        ],
+      },
+      {
+        video_id: "v2",
+        youtube_video_stats: [
+          {
+            view_count: 500,
+            like_count: 50,
+            comment_count: 25,
+            recorded_at: "2026-01-10",
+          },
+        ],
+      },
+    ];
+
+    const result = extractLatestStats(videos);
+    expect(result).toHaveLength(2);
+    expect(result[0].latest_view_count).toBe(100);
+    expect(result[1].latest_view_count).toBe(500);
+  });
+
+  it("should remove youtube_video_stats from result", () => {
+    const videos: VideoWithStatsRelation[] = [
+      {
+        video_id: "v1",
+        youtube_video_stats: [
+          {
+            view_count: 100,
+            like_count: 10,
+            comment_count: 1,
+            recorded_at: "2026-01-10",
+          },
+        ],
+      },
+    ];
+
+    const result = extractLatestStats(videos);
+    expect((result[0] as any).youtube_video_stats).toBeUndefined();
+  });
+});
+
+describe("sortVideosByMetric", () => {
+  const videos: YouTubeVideoWithStats[] = [
+    {
+      latest_view_count: 100,
+      latest_like_count: 50,
+      latest_comment_count: 10,
+      published_at: "2026-01-10T00:00:00Z",
+    } as YouTubeVideoWithStats,
+    {
+      latest_view_count: 300,
+      latest_like_count: 20,
+      latest_comment_count: 5,
+      published_at: "2026-01-12T00:00:00Z",
+    } as YouTubeVideoWithStats,
+    {
+      latest_view_count: 200,
+      latest_like_count: 80,
+      latest_comment_count: 15,
+      published_at: "2026-01-08T00:00:00Z",
+    } as YouTubeVideoWithStats,
+  ];
+
+  it("should sort by view_count descending", () => {
+    const result = sortVideosByMetric(videos, "view_count");
+    expect(result[0].latest_view_count).toBe(300);
+    expect(result[1].latest_view_count).toBe(200);
+    expect(result[2].latest_view_count).toBe(100);
+  });
+
+  it("should sort by like_count descending", () => {
+    const result = sortVideosByMetric(videos, "like_count");
+    expect(result[0].latest_like_count).toBe(80);
+    expect(result[1].latest_like_count).toBe(50);
+    expect(result[2].latest_like_count).toBe(20);
+  });
+
+  it("should sort by published_at descending by default", () => {
+    const result = sortVideosByMetric(videos, "published_at");
+    expect(result[0].published_at).toBe("2026-01-12T00:00:00Z");
+    expect(result[1].published_at).toBe("2026-01-10T00:00:00Z");
+    expect(result[2].published_at).toBe("2026-01-08T00:00:00Z");
+  });
+
+  it("should handle null values in view_count", () => {
+    const videosWithNull: YouTubeVideoWithStats[] = [
+      {
+        latest_view_count: null,
+        published_at: "2026-01-10T00:00:00Z",
+      } as YouTubeVideoWithStats,
+      {
+        latest_view_count: 100,
+        published_at: "2026-01-11T00:00:00Z",
+      } as YouTubeVideoWithStats,
+    ];
+    const result = sortVideosByMetric(videosWithNull, "view_count");
+    expect(result[0].latest_view_count).toBe(100);
+    expect(result[1].latest_view_count).toBeNull();
+  });
+
+  it("should not mutate the original array", () => {
+    const original = [...videos];
+    sortVideosByMetric(videos, "view_count");
+    expect(videos).toEqual(original);
+  });
+});
+
+describe("aggregateDailyStats", () => {
+  it("should aggregate stats by date", () => {
+    const data = [
+      { recorded_at: "2026-01-10", view_count: 100, like_count: 10 },
+      { recorded_at: "2026-01-10", view_count: 200, like_count: 20 },
+      { recorded_at: "2026-01-11", view_count: 50, like_count: 5 },
+    ];
+
+    const result = aggregateDailyStats(data);
+    expect(result.get("2026-01-10")).toEqual({
+      total_views: 300,
+      total_likes: 30,
+    });
+    expect(result.get("2026-01-11")).toEqual({
+      total_views: 50,
+      total_likes: 5,
+    });
+  });
+
+  it("should handle null values as 0", () => {
+    const data = [
+      { recorded_at: "2026-01-10", view_count: null, like_count: null },
+      { recorded_at: "2026-01-10", view_count: 100, like_count: 10 },
+    ];
+
+    const result = aggregateDailyStats(data);
+    expect(result.get("2026-01-10")).toEqual({
+      total_views: 100,
+      total_likes: 10,
+    });
+  });
+
+  it("should return empty map for empty input", () => {
+    const result = aggregateDailyStats([]);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("mapStatisticsResult", () => {
+  it("should convert map to sorted array", () => {
+    const map = new Map<string, { total_views: number; total_likes: number }>();
+    map.set("2026-01-12", { total_views: 300, total_likes: 30 });
+    map.set("2026-01-10", { total_views: 100, total_likes: 10 });
+    map.set("2026-01-11", { total_views: 200, total_likes: 20 });
+
+    const result = mapStatisticsResult(map);
+    expect(result).toEqual([
+      { date: "2026-01-10", total_views: 100, total_likes: 10 },
+      { date: "2026-01-11", total_views: 200, total_likes: 20 },
+      { date: "2026-01-12", total_views: 300, total_likes: 30 },
+    ]);
+  });
+
+  it("should return empty array for empty map", () => {
+    const map = new Map<string, { total_views: number; total_likes: number }>();
+    const result = mapStatisticsResult(map);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("aggregateVideosByDate", () => {
+  it("should count videos per date from published_at", () => {
+    const videos = [
+      { published_at: "2026-01-10T10:00:00Z" },
+      { published_at: "2026-01-10T15:00:00Z" },
+      { published_at: "2026-01-11T08:00:00Z" },
+    ];
+
+    const result = aggregateVideosByDate(videos);
+    expect(result.get("2026-01-10")).toBe(2);
+    expect(result.get("2026-01-11")).toBe(1);
+  });
+
+  it("should skip videos with null published_at", () => {
+    const videos = [
+      { published_at: "2026-01-10T10:00:00Z" },
+      { published_at: null },
+    ];
+
+    const result = aggregateVideosByDate(videos);
+    expect(result.size).toBe(1);
+    expect(result.get("2026-01-10")).toBe(1);
+  });
+
+  it("should return empty map for empty input", () => {
+    const result = aggregateVideosByDate([]);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("generateDateRange", () => {
+  it("should generate consecutive dates with correct counts", () => {
+    // Use a range large enough that timezone shifts don't eliminate all dates
+    const start = new Date("2026-01-10");
+    const end = new Date("2026-01-15");
+
+    const dailyCounts = new Map<string, number>();
+    dailyCounts.set("2026-01-10", 3);
+    dailyCounts.set("2026-01-12", 1);
+
+    const result = generateDateRange(start, end, dailyCounts);
+
+    // Should have multiple dates
+    expect(result.length).toBeGreaterThanOrEqual(3);
+
+    // All dates should be in YYYY-MM-DD format
+    for (const item of result) {
+      expect(item.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+
+    // Dates in dailyCounts should have correct count
+    const jan10 = result.find((r) => r.date === "2026-01-10");
+    if (jan10) expect(jan10.count).toBe(3);
+    const jan12 = result.find((r) => r.date === "2026-01-12");
+    if (jan12) expect(jan12.count).toBe(1);
+
+    // Dates not in dailyCounts should have count 0
+    const jan11 = result.find((r) => r.date === "2026-01-11");
+    if (jan11) expect(jan11.count).toBe(0);
+
+    // Dates should be in ascending order
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i].date > result[i - 1].date).toBe(true);
+    }
+  });
+
+  it("should return empty array if start is clearly after end", () => {
+    const dailyCounts = new Map<string, number>();
+    const result = generateDateRange(
+      new Date("2026-02-01"),
+      new Date("2026-01-01"),
+      dailyCounts,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("should return 0 count for dates not in dailyCounts", () => {
+    const dailyCounts = new Map<string, number>();
+    const result = generateDateRange(
+      new Date("2026-01-10"),
+      new Date("2026-01-15"),
+      dailyCounts,
+    );
+
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    for (const item of result) {
+      expect(item.count).toBe(0);
+    }
+  });
+
+  it("should use YYYY-MM-DD format from toISOString for date keys", () => {
+    const dailyCounts = new Map<string, number>();
+    dailyCounts.set("2026-03-01", 7);
+
+    const result = generateDateRange(
+      new Date("2026-03-01"),
+      new Date("2026-03-05"),
+      dailyCounts,
+    );
+
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    const mar01 = result.find((r) => r.date === "2026-03-01");
+    if (mar01) expect(mar01.count).toBe(7);
+  });
+});

--- a/src/features/youtube-stats/utils/youtube-stats-utils.ts
+++ b/src/features/youtube-stats/utils/youtube-stats-utils.ts
@@ -1,0 +1,155 @@
+import type {
+  OverallStatsHistoryItem,
+  SortType,
+  VideoCountByDateItem,
+  YouTubeVideoWithStats,
+} from "../types";
+
+/**
+ * 動画統計の生データ型（Supabaseリレーションから取得）
+ */
+export interface RawVideoStats {
+  view_count: number | null;
+  like_count: number | null;
+  comment_count: number | null;
+  recorded_at: string;
+}
+
+/**
+ * 動画と統計リレーションの生データ型
+ */
+export interface VideoWithStatsRelation {
+  youtube_video_stats: RawVideoStats[];
+  [key: string]: unknown;
+}
+
+/**
+ * 動画配列から最新統計を抽出し、YouTubeVideoWithStats形式にマッピングする
+ */
+export function extractLatestStats(
+  videos: VideoWithStatsRelation[],
+): YouTubeVideoWithStats[] {
+  return videos.map((video) => {
+    const stats = video.youtube_video_stats;
+
+    // 最新の統計を取得（recorded_atでソート）
+    const latestStats = [...stats].sort(
+      (a, b) =>
+        new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime(),
+    )[0];
+
+    return {
+      ...video,
+      youtube_video_stats: undefined,
+      latest_view_count: latestStats?.view_count ?? null,
+      latest_like_count: latestStats?.like_count ?? null,
+      latest_comment_count: latestStats?.comment_count ?? null,
+    } as unknown as YouTubeVideoWithStats;
+  });
+}
+
+/**
+ * 動画リストを指定メトリクスでソートする
+ */
+export function sortVideosByMetric(
+  videos: YouTubeVideoWithStats[],
+  sortBy: SortType,
+): YouTubeVideoWithStats[] {
+  return [...videos].sort((a, b) => {
+    switch (sortBy) {
+      case "view_count":
+        return (b.latest_view_count ?? 0) - (a.latest_view_count ?? 0);
+      case "like_count":
+        return (b.latest_like_count ?? 0) - (a.latest_like_count ?? 0);
+      default:
+        return (
+          new Date(b.published_at ?? 0).getTime() -
+          new Date(a.published_at ?? 0).getTime()
+        );
+    }
+  });
+}
+
+/**
+ * youtube_video_statsデータを日別に集計する
+ */
+export function aggregateDailyStats(
+  data: {
+    recorded_at: string;
+    view_count: number | null;
+    like_count: number | null;
+  }[],
+): Map<string, { total_views: number; total_likes: number }> {
+  const dailyStats = new Map<
+    string,
+    { total_views: number; total_likes: number }
+  >();
+
+  for (const stat of data) {
+    const date = stat.recorded_at;
+    const current = dailyStats.get(date) || { total_views: 0, total_likes: 0 };
+    dailyStats.set(date, {
+      total_views: current.total_views + (stat.view_count ?? 0),
+      total_likes: current.total_likes + (stat.like_count ?? 0),
+    });
+  }
+
+  return dailyStats;
+}
+
+/**
+ * Map→配列変換し、日付昇順ソートする
+ */
+export function mapStatisticsResult(
+  map: Map<string, { total_views: number; total_likes: number }>,
+): OverallStatsHistoryItem[] {
+  return Array.from(map.entries())
+    .map(([date, stats]) => ({
+      date,
+      total_views: stats.total_views,
+      total_likes: stats.total_likes,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * published_atで日別ビデオカウントを集計する
+ */
+export function aggregateVideosByDate(
+  videos: { published_at: string | null }[],
+): Map<string, number> {
+  const dailyCount = new Map<string, number>();
+
+  for (const video of videos) {
+    if (!video.published_at) continue;
+    const date = video.published_at.split("T")[0];
+    dailyCount.set(date, (dailyCount.get(date) || 0) + 1);
+  }
+
+  return dailyCount;
+}
+
+/**
+ * 日付範囲を生成し、各日の投稿数を含める（投稿0の日も含む）
+ */
+export function generateDateRange(
+  startDate: Date,
+  endDate: Date,
+  dailyCounts: Map<string, number>,
+): VideoCountByDateItem[] {
+  const result: VideoCountByDateItem[] = [];
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+
+  const currentDate = new Date(startDate);
+  while (currentDate <= end) {
+    const dateStr = currentDate.toISOString().split("T")[0];
+    result.push({
+      date: dateStr,
+      count: dailyCounts.get(dateStr) || 0,
+    });
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  return result;
+}


### PR DESCRIPTION
# 変更の概要
- `youtube-stats-service.ts` から6つの純粋関数を `youtube-stats-utils.ts` に切り出し
  - `extractLatestStats` - 動画配列から最新統計を抽出・マッピング
  - `sortVideosByMetric` - view_count/like_count/published_atでソート
  - `aggregateDailyStats` - youtube_video_statsを日別に集計
  - `mapStatisticsResult` - Map→配列変換、日付昇順ソート
  - `aggregateVideosByDate` - published_atで日別ビデオカウント集計
  - `generateDateRange` - 日付範囲生成
- 切り出した関数に対する22件のユニットテストを追加

# 変更の背景
- サービス層のロジックをテスト可能な純粋関数として分離し、保守性とテスタビリティを向上
- 機能的な変更はなく、リファクタリングのみ

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました