### PR TITLE
refactor: アクション統計・達成集計の純粋関数をutilsに切り出し

### DIFF
--- a/src/features/action-stats/services/action-stats-service.ts
+++ b/src/features/action-stats/services/action-stats-service.ts
@@ -7,6 +7,10 @@ import type {
   DailyActiveUsersItem,
   MissionActionRanking,
 } from "../types";
+import {
+  mapMissionRankingResults,
+  transformActionStatsResult,
+} from "../utils/stats-transform";
 
 /**
  * アクション統計サマリーを取得する（RPC使用）
@@ -33,13 +37,7 @@ export async function getActionStatsSummary(
     };
   }
 
-  const result = data?.[0];
-  return {
-    totalActions: Number(result?.total_actions ?? 0),
-    activeUsers: Number(result?.active_users ?? 0),
-    dailyActionsIncrease: Number(result?.daily_actions_increase ?? 0),
-    dailyUsersIncrease: Number(result?.daily_users_increase ?? 0),
-  };
+  return transformActionStatsResult(data?.[0]);
 }
 
 /**
@@ -129,21 +127,5 @@ export async function getMissionActionRanking(
     return [];
   }
 
-  return (data ?? []).map(
-    (item: {
-      mission_id: string;
-      mission_title: string;
-      mission_slug: string;
-      icon_url: string | null;
-      action_count: number;
-      is_hidden: boolean;
-    }) => ({
-      missionId: item.mission_id,
-      missionTitle: item.mission_title,
-      missionSlug: item.mission_slug,
-      iconUrl: item.icon_url,
-      actionCount: Number(item.action_count),
-      isHidden: item.is_hidden,
-    }),
-  );
+  return mapMissionRankingResults(data ?? []);
 }

--- a/src/features/action-stats/utils/stats-transform.test.ts
+++ b/src/features/action-stats/utils/stats-transform.test.ts
@@ -1,0 +1,149 @@
+import {
+  mapMissionRankingResults,
+  type RawMissionRankingItem,
+  transformActionStatsResult,
+} from "./stats-transform";
+
+describe("transformActionStatsResult", () => {
+  it("should transform a valid result", () => {
+    const result = transformActionStatsResult({
+      total_actions: 100,
+      active_users: 50,
+      daily_actions_increase: 10,
+      daily_users_increase: 5,
+    });
+
+    expect(result).toEqual({
+      totalActions: 100,
+      activeUsers: 50,
+      dailyActionsIncrease: 10,
+      dailyUsersIncrease: 5,
+    });
+  });
+
+  it("should handle null/undefined result", () => {
+    expect(transformActionStatsResult(null)).toEqual({
+      totalActions: 0,
+      activeUsers: 0,
+      dailyActionsIncrease: 0,
+      dailyUsersIncrease: 0,
+    });
+
+    expect(transformActionStatsResult(undefined)).toEqual({
+      totalActions: 0,
+      activeUsers: 0,
+      dailyActionsIncrease: 0,
+      dailyUsersIncrease: 0,
+    });
+  });
+
+  it("should handle null fields in result", () => {
+    const result = transformActionStatsResult({
+      total_actions: null,
+      active_users: null,
+      daily_actions_increase: null,
+      daily_users_increase: null,
+    });
+
+    expect(result).toEqual({
+      totalActions: 0,
+      activeUsers: 0,
+      dailyActionsIncrease: 0,
+      dailyUsersIncrease: 0,
+    });
+  });
+
+  it("should handle string number values from RPC", () => {
+    const result = transformActionStatsResult({
+      total_actions: "150",
+      active_users: "30",
+      daily_actions_increase: "12",
+      daily_users_increase: "3",
+    });
+
+    expect(result).toEqual({
+      totalActions: 150,
+      activeUsers: 30,
+      dailyActionsIncrease: 12,
+      dailyUsersIncrease: 3,
+    });
+  });
+
+  it("should handle partial result with missing fields", () => {
+    const result = transformActionStatsResult({
+      total_actions: 50,
+    });
+
+    expect(result).toEqual({
+      totalActions: 50,
+      activeUsers: 0,
+      dailyActionsIncrease: 0,
+      dailyUsersIncrease: 0,
+    });
+  });
+});
+
+describe("mapMissionRankingResults", () => {
+  it("should map raw ranking items to MissionActionRanking", () => {
+    const data: RawMissionRankingItem[] = [
+      {
+        mission_id: "m1",
+        mission_title: "Mission 1",
+        mission_slug: "mission-1",
+        icon_url: "https://example.com/icon.png",
+        action_count: 100,
+        is_hidden: false,
+      },
+      {
+        mission_id: "m2",
+        mission_title: "Mission 2",
+        mission_slug: "mission-2",
+        icon_url: null,
+        action_count: 50,
+        is_hidden: true,
+      },
+    ];
+
+    const result = mapMissionRankingResults(data);
+
+    expect(result).toEqual([
+      {
+        missionId: "m1",
+        missionTitle: "Mission 1",
+        missionSlug: "mission-1",
+        iconUrl: "https://example.com/icon.png",
+        actionCount: 100,
+        isHidden: false,
+      },
+      {
+        missionId: "m2",
+        missionTitle: "Mission 2",
+        missionSlug: "mission-2",
+        iconUrl: null,
+        actionCount: 50,
+        isHidden: true,
+      },
+    ]);
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(mapMissionRankingResults([])).toEqual([]);
+  });
+
+  it("should convert action_count to number", () => {
+    const data: RawMissionRankingItem[] = [
+      {
+        mission_id: "m1",
+        mission_title: "Mission 1",
+        mission_slug: "mission-1",
+        icon_url: null,
+        action_count: 42,
+        is_hidden: false,
+      },
+    ];
+
+    const result = mapMissionRankingResults(data);
+    expect(result[0].actionCount).toBe(42);
+    expect(typeof result[0].actionCount).toBe("number");
+  });
+});

--- a/src/features/action-stats/utils/stats-transform.ts
+++ b/src/features/action-stats/utils/stats-transform.ts
@@ -1,0 +1,48 @@
+import type { ActionStatsSummary, MissionActionRanking } from "../types";
+
+/**
+ * RPC結果をActionStatsSummary型に変換する
+ */
+export function transformActionStatsResult(
+  result:
+    | {
+        total_actions?: number | string | null;
+        active_users?: number | string | null;
+        daily_actions_increase?: number | string | null;
+        daily_users_increase?: number | string | null;
+      }
+    | undefined
+    | null,
+): ActionStatsSummary {
+  return {
+    totalActions: Number(result?.total_actions ?? 0),
+    activeUsers: Number(result?.active_users ?? 0),
+    dailyActionsIncrease: Number(result?.daily_actions_increase ?? 0),
+    dailyUsersIncrease: Number(result?.daily_users_increase ?? 0),
+  };
+}
+
+/**
+ * RPC結果のミッション別ランキングデータをMissionActionRanking型に変換する
+ */
+export interface RawMissionRankingItem {
+  mission_id: string;
+  mission_title: string;
+  mission_slug: string;
+  icon_url: string | null;
+  action_count: number;
+  is_hidden: boolean;
+}
+
+export function mapMissionRankingResults(
+  data: RawMissionRankingItem[],
+): MissionActionRanking[] {
+  return data.map((item) => ({
+    missionId: item.mission_id,
+    missionTitle: item.mission_title,
+    missionSlug: item.mission_slug,
+    iconUrl: item.icon_url,
+    actionCount: Number(item.action_count),
+    isHidden: item.is_hidden,
+  }));
+}

--- a/src/features/user-achievements/utils/achievement-aggregation.test.ts
+++ b/src/features/user-achievements/utils/achievement-aggregation.test.ts
@@ -1,0 +1,150 @@
+import {
+  aggregateAchievementCounts,
+  buildAchievementMap,
+  type RawAchievementRecord,
+} from "./achievement-aggregation";
+
+describe("aggregateAchievementCounts", () => {
+  it("should aggregate achievements by mission", () => {
+    const data: RawAchievementRecord[] = [
+      {
+        mission_id: "m1",
+        missions: {
+          id: "m1",
+          slug: "mission-1",
+          title: "Mission 1",
+          max_achievement_count: null,
+        },
+      },
+      {
+        mission_id: "m1",
+        missions: {
+          id: "m1",
+          slug: "mission-1",
+          title: "Mission 1",
+          max_achievement_count: null,
+        },
+      },
+      {
+        mission_id: "m2",
+        missions: {
+          id: "m2",
+          slug: "mission-2",
+          title: "Mission 2",
+          max_achievement_count: null,
+        },
+      },
+    ];
+
+    const result = aggregateAchievementCounts(data);
+
+    expect(result).toHaveLength(2);
+    const m1 = result.find((r) => r.mission_id === "m1");
+    const m2 = result.find((r) => r.mission_id === "m2");
+    expect(m1?.achievement_count).toBe(2);
+    expect(m1?.mission_slug).toBe("mission-1");
+    expect(m1?.mission_title).toBe("Mission 1");
+    expect(m2?.achievement_count).toBe(1);
+  });
+
+  it("should skip records with null mission_id", () => {
+    const data: RawAchievementRecord[] = [
+      {
+        mission_id: null,
+        missions: {
+          id: "m1",
+          slug: "mission-1",
+          title: "Mission 1",
+          max_achievement_count: null,
+        },
+      },
+      {
+        mission_id: "m1",
+        missions: {
+          id: "m1",
+          slug: "mission-1",
+          title: "Mission 1",
+          max_achievement_count: null,
+        },
+      },
+    ];
+
+    const result = aggregateAchievementCounts(data);
+    expect(result).toHaveLength(1);
+    expect(result[0].achievement_count).toBe(1);
+  });
+
+  it("should skip records with null missions relation", () => {
+    const data: RawAchievementRecord[] = [
+      {
+        mission_id: "m1",
+        missions: null,
+      },
+    ];
+
+    const result = aggregateAchievementCounts(data);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(aggregateAchievementCounts([])).toEqual([]);
+  });
+
+  it("should only return achievements with count > 0", () => {
+    const data: RawAchievementRecord[] = [
+      {
+        mission_id: "m1",
+        missions: {
+          id: "m1",
+          slug: "mission-1",
+          title: "Mission 1",
+          max_achievement_count: null,
+        },
+      },
+    ];
+
+    const result = aggregateAchievementCounts(data);
+    expect(result).toHaveLength(1);
+    expect(result[0].achievement_count).toBeGreaterThan(0);
+  });
+});
+
+describe("buildAchievementMap", () => {
+  it("should build a map of mission_id to count", () => {
+    const achievements = [
+      { mission_id: "m1" },
+      { mission_id: "m1" },
+      { mission_id: "m2" },
+      { mission_id: "m1" },
+    ];
+
+    const result = buildAchievementMap(achievements);
+
+    expect(result.get("m1")).toBe(3);
+    expect(result.get("m2")).toBe(1);
+    expect(result.size).toBe(2);
+  });
+
+  it("should skip null mission_ids", () => {
+    const achievements = [
+      { mission_id: "m1" },
+      { mission_id: null },
+      { mission_id: "m1" },
+    ];
+
+    const result = buildAchievementMap(achievements);
+    expect(result.get("m1")).toBe(2);
+    expect(result.size).toBe(1);
+  });
+
+  it("should return empty map for empty input", () => {
+    const result = buildAchievementMap([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("should handle single achievement", () => {
+    const result = buildAchievementMap([{ mission_id: "m1" }]);
+    expect(result.get("m1")).toBe(1);
+    expect(result.size).toBe(1);
+  });
+});

--- a/src/features/user-achievements/utils/achievement-aggregation.ts
+++ b/src/features/user-achievements/utils/achievement-aggregation.ts
@@ -1,0 +1,60 @@
+import type { MissionAchievementSummary } from "../types/achievement-types";
+
+/**
+ * 達成データの生レコード型（Supabaseリレーション結果）
+ */
+export interface RawAchievementRecord {
+  mission_id: string | null;
+  missions: {
+    id: string;
+    slug: string;
+    title: string;
+    max_achievement_count: number | null;
+  } | null;
+}
+
+/**
+ * 達成データをミッション別に集計し、MissionAchievementSummary配列を返す
+ */
+export function aggregateAchievementCounts(
+  data: RawAchievementRecord[],
+): MissionAchievementSummary[] {
+  const achievementCounts = data.reduce(
+    (acc, achievement) => {
+      const missionId = achievement.mission_id;
+      if (!missionId || !achievement.missions) return acc;
+
+      if (!acc[missionId]) {
+        acc[missionId] = {
+          mission_id: missionId,
+          mission_slug: achievement.missions.slug,
+          mission_title: achievement.missions.title,
+          achievement_count: 0,
+        };
+      }
+      acc[missionId].achievement_count += 1;
+      return acc;
+    },
+    {} as Record<string, MissionAchievementSummary>,
+  );
+
+  return Object.values(achievementCounts).filter(
+    (achievement) => achievement.achievement_count > 0,
+  );
+}
+
+/**
+ * 達成データからMap<mission_id, count>を構築する
+ */
+export function buildAchievementMap(
+  achievements: { mission_id: string | null }[],
+): Map<string, number> {
+  const achievementMap = new Map<string, number>();
+  for (const achievement of achievements) {
+    if (achievement.mission_id) {
+      const current = achievementMap.get(achievement.mission_id) ?? 0;
+      achievementMap.set(achievement.mission_id, current + 1);
+    }
+  }
+  return achievementMap;
+}


### PR DESCRIPTION
# 変更の概要
- `action-stats-service.ts` から2つの変換関数を `stats-transform.ts` に切り出し
  - `transformActionStatsResult` - RPC結果をActionStatsSummary型に変換
  - `mapMissionRankingResults` - ミッション別ランキング結果の型変換
- `achievements.ts` から2つの集計関数を `achievement-aggregation.ts` に切り出し
  - `aggregateAchievementCounts` - ミッション別の達成回数をreduce()で集計
  - `buildAchievementMap` - Map<mission_id, count>の構築
- 切り出した関数に対するユニットテストを追加（100%カバレッジ）

# 変更の背景
- サービス層の純粋ロジックをテスト可能な関数として分離し、保守性とテスタビリティを向上
- 機能的な変更はなく、リファクタリングのみ

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました