### PR TITLE
refactor: 住所組み立てロジックとmapUserToHistoryの純粋関数切り出し

### DIFF
--- a/src/features/map-poster/actions/poster-boards.ts
+++ b/src/features/map-poster/actions/poster-boards.ts
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/client";
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import type { Database } from "@/lib/types/supabase";
+import { mapUserToHistory } from "../utils/history-helpers";
 import {
   countBoardsByStatus,
   createEmptyStatusCounts,
@@ -307,8 +308,5 @@ export async function getBoardStatusHistoryAction(boardId: string) {
   const userMap = new Map(userData?.map((u) => [u.id, u]) || []);
 
   // 履歴データにユーザー情報を追加
-  return historyData.map((h) => ({
-    ...h,
-    user: userMap.get(h.user_id) || null,
-  }));
+  return mapUserToHistory(historyData, userMap);
 }

--- a/src/features/map-poster/utils/history-helpers.test.ts
+++ b/src/features/map-poster/utils/history-helpers.test.ts
@@ -1,0 +1,93 @@
+import { mapUserToHistory } from "./history-helpers";
+
+describe("mapUserToHistory", () => {
+  const userA = {
+    id: "user-a",
+    name: "ユーザーA",
+    address_prefecture: "東京都",
+  };
+  const userB = {
+    id: "user-b",
+    name: "ユーザーB",
+    address_prefecture: "大阪府",
+  };
+
+  it("履歴レコードにユーザー情報を付加する", () => {
+    const history = [
+      { user_id: "user-a", board_id: "board-1", status: "done" },
+      { user_id: "user-b", board_id: "board-2", status: "reserved" },
+    ];
+    const userMap = new Map([
+      ["user-a", userA],
+      ["user-b", userB],
+    ]);
+
+    const result = mapUserToHistory(history, userMap);
+    expect(result).toEqual([
+      { user_id: "user-a", board_id: "board-1", status: "done", user: userA },
+      {
+        user_id: "user-b",
+        board_id: "board-2",
+        status: "reserved",
+        user: userB,
+      },
+    ]);
+  });
+
+  it("userMapに存在しないユーザーの場合はuser: nullになる", () => {
+    const history = [
+      { user_id: "user-unknown", board_id: "board-1", status: "done" },
+    ];
+    const userMap = new Map([["user-a", userA]]);
+
+    const result = mapUserToHistory(history, userMap);
+    expect(result).toEqual([
+      {
+        user_id: "user-unknown",
+        board_id: "board-1",
+        status: "done",
+        user: null,
+      },
+    ]);
+  });
+
+  it("空の履歴配列の場合は空配列を返す", () => {
+    const userMap = new Map([["user-a", userA]]);
+    const result = mapUserToHistory([], userMap);
+    expect(result).toEqual([]);
+  });
+
+  it("空のuserMapの場合はすべてuser: nullになる", () => {
+    const history = [
+      { user_id: "user-a", board_id: "board-1", status: "done" },
+    ];
+    const userMap = new Map<
+      string,
+      { id: string; name: string | null; address_prefecture: string | null }
+    >();
+
+    const result = mapUserToHistory(history, userMap);
+    expect(result).toEqual([
+      { user_id: "user-a", board_id: "board-1", status: "done", user: null },
+    ]);
+  });
+
+  it("元のレコードのプロパティを保持する", () => {
+    const history = [
+      {
+        user_id: "user-a",
+        board_id: "board-1",
+        status: "done",
+        created_at: "2026-01-01",
+        extra_field: 42,
+      },
+    ];
+    const userMap = new Map([["user-a", userA]]);
+
+    const result = mapUserToHistory(history, userMap);
+    expect(result[0].board_id).toBe("board-1");
+    expect(result[0].created_at).toBe("2026-01-01");
+    expect(result[0].extra_field).toBe(42);
+    expect(result[0].user).toEqual(userA);
+  });
+});

--- a/src/features/map-poster/utils/history-helpers.ts
+++ b/src/features/map-poster/utils/history-helpers.ts
@@ -1,0 +1,28 @@
+/**
+ * ポスター掲示板のステータス履歴にユーザー情報を紐付ける純粋関数
+ */
+
+interface UserProfile {
+  id: string;
+  name: string | null;
+  address_prefecture: string | null;
+}
+
+interface StatusHistoryRecord {
+  user_id: string;
+  [key: string]: unknown;
+}
+
+/**
+ * ステータス履歴レコードの配列にユーザープロフィール情報を付加する。
+ * userMapにユーザーが存在しない場合はuser: nullとなる。
+ */
+export function mapUserToHistory<T extends StatusHistoryRecord>(
+  historyData: T[],
+  userMap: Map<string, UserProfile>,
+): (T & { user: UserProfile | null })[] {
+  return historyData.map((h) => ({
+    ...h,
+    user: userMap.get(h.user_id) || null,
+  }));
+}

--- a/src/features/map-posting/services/reverse-geocoding.ts
+++ b/src/features/map-posting/services/reverse-geocoding.ts
@@ -7,6 +7,8 @@
  * - User-Agent を設定すること
  */
 
+import { buildAddressFromGeocode } from "@/features/map-posting/utils/address-utils";
+
 export interface ReverseGeocodingResult {
   prefecture: string | null;
   city: string | null;
@@ -29,57 +31,6 @@ interface NominatimAddress {
   house_number?: string; // 番地
   postcode?: string; // 郵便番号
 }
-
-// ISO 3166-2:JP コードから都道府県名へのマッピング
-const ISO3166_TO_PREFECTURE: Record<string, string> = {
-  "JP-01": "北海道",
-  "JP-02": "青森県",
-  "JP-03": "岩手県",
-  "JP-04": "宮城県",
-  "JP-05": "秋田県",
-  "JP-06": "山形県",
-  "JP-07": "福島県",
-  "JP-08": "茨城県",
-  "JP-09": "栃木県",
-  "JP-10": "群馬県",
-  "JP-11": "埼玉県",
-  "JP-12": "千葉県",
-  "JP-13": "東京都",
-  "JP-14": "神奈川県",
-  "JP-15": "新潟県",
-  "JP-16": "富山県",
-  "JP-17": "石川県",
-  "JP-18": "福井県",
-  "JP-19": "山梨県",
-  "JP-20": "長野県",
-  "JP-21": "岐阜県",
-  "JP-22": "静岡県",
-  "JP-23": "愛知県",
-  "JP-24": "三重県",
-  "JP-25": "滋賀県",
-  "JP-26": "京都府",
-  "JP-27": "大阪府",
-  "JP-28": "兵庫県",
-  "JP-29": "奈良県",
-  "JP-30": "和歌山県",
-  "JP-31": "鳥取県",
-  "JP-32": "島根県",
-  "JP-33": "岡山県",
-  "JP-34": "広島県",
-  "JP-35": "山口県",
-  "JP-36": "徳島県",
-  "JP-37": "香川県",
-  "JP-38": "愛媛県",
-  "JP-39": "高知県",
-  "JP-40": "福岡県",
-  "JP-41": "佐賀県",
-  "JP-42": "長崎県",
-  "JP-43": "熊本県",
-  "JP-44": "大分県",
-  "JP-45": "宮崎県",
-  "JP-46": "鹿児島県",
-  "JP-47": "沖縄県",
-};
 
 interface NominatimResponse {
   address?: NominatimAddress;
@@ -125,36 +76,7 @@ export async function reverseGeocode(
       return { prefecture: null, city: null, address: null, postcode: null };
     }
 
-    // 都道府県を取得（ISO3166-2コードから変換、またはprovince/stateから直接取得）
-    let prefecture: string | null = null;
-    if (addr["ISO3166-2-lvl4"]) {
-      prefecture = ISO3166_TO_PREFECTURE[addr["ISO3166-2-lvl4"]] || null;
-    }
-    if (!prefecture) {
-      prefecture = addr.province || addr.state || null;
-    }
-
-    // 市区町村を取得（市 + 区 or 町/村）
-    const cityParts: string[] = [];
-    if (addr.city) cityParts.push(addr.city);
-    if (addr.city_district) cityParts.push(addr.city_district);
-    if (addr.town) cityParts.push(addr.town);
-    if (addr.village) cityParts.push(addr.village);
-    const city = cityParts.length > 0 ? cityParts.join("") : null;
-
-    // 詳細住所を取得
-    const addressParts: string[] = [];
-    if (addr.suburb) addressParts.push(addr.suburb);
-    if (addr.neighbourhood) addressParts.push(addr.neighbourhood);
-    if (addr.quarter) addressParts.push(addr.quarter);
-    if (addr.road) addressParts.push(addr.road);
-    if (addr.house_number) addressParts.push(addr.house_number);
-    const address = addressParts.length > 0 ? addressParts.join("") : null;
-
-    // 郵便番号を取得
-    const postcode = addr.postcode || null;
-
-    return { prefecture, city, address, postcode };
+    return buildAddressFromGeocode(addr);
   } catch (error) {
     console.error("Reverse geocoding failed:", error);
     return { prefecture: null, city: null, address: null, postcode: null };

--- a/src/features/map-posting/utils/address-utils.test.ts
+++ b/src/features/map-posting/utils/address-utils.test.ts
@@ -1,0 +1,126 @@
+import {
+  buildAddressFromGeocode,
+  convertISO3166ToPrefecture,
+} from "./address-utils";
+
+describe("convertISO3166ToPrefecture", () => {
+  it("JP-13を東京都に変換する", () => {
+    expect(convertISO3166ToPrefecture("JP-13")).toBe("東京都");
+  });
+
+  it("JP-01を北海道に変換する", () => {
+    expect(convertISO3166ToPrefecture("JP-01")).toBe("北海道");
+  });
+
+  it("JP-27を大阪府に変換する", () => {
+    expect(convertISO3166ToPrefecture("JP-27")).toBe("大阪府");
+  });
+
+  it("JP-47を沖縄県に変換する", () => {
+    expect(convertISO3166ToPrefecture("JP-47")).toBe("沖縄県");
+  });
+
+  it("存在しないコードにはnullを返す", () => {
+    expect(convertISO3166ToPrefecture("JP-99")).toBeNull();
+  });
+
+  it("空文字にはnullを返す", () => {
+    expect(convertISO3166ToPrefecture("")).toBeNull();
+  });
+});
+
+describe("buildAddressFromGeocode", () => {
+  it("完全な住所データから全フィールドを組み立てる", () => {
+    const result = buildAddressFromGeocode({
+      "ISO3166-2-lvl4": "JP-13",
+      city: "新宿区",
+      suburb: "西新宿",
+      neighbourhood: "二丁目",
+      road: "国道20号",
+      house_number: "8-1",
+      postcode: "163-8001",
+    });
+    expect(result).toEqual({
+      prefecture: "東京都",
+      city: "新宿区",
+      address: "西新宿二丁目国道20号8-1",
+      postcode: "163-8001",
+    });
+  });
+
+  it("ISO3166コードがない場合はprovinceから都道府県を取得する", () => {
+    const result = buildAddressFromGeocode({
+      province: "東京都",
+      city: "渋谷区",
+    });
+    expect(result.prefecture).toBe("東京都");
+    expect(result.city).toBe("渋谷区");
+  });
+
+  it("ISO3166コードがない場合はstateから都道府県を取得する", () => {
+    const result = buildAddressFromGeocode({
+      state: "大阪府",
+    });
+    expect(result.prefecture).toBe("大阪府");
+  });
+
+  it("ISO3166コードが不明な場合はprovinceにフォールバックする", () => {
+    const result = buildAddressFromGeocode({
+      "ISO3166-2-lvl4": "JP-99",
+      province: "テスト県",
+    });
+    expect(result.prefecture).toBe("テスト県");
+  });
+
+  it("市区町村がcity + city_districtの場合", () => {
+    const result = buildAddressFromGeocode({
+      city: "横浜市",
+      city_district: "中区",
+    });
+    expect(result.city).toBe("横浜市中区");
+  });
+
+  it("町村のみの場合", () => {
+    const result = buildAddressFromGeocode({
+      town: "箱根町",
+    });
+    expect(result.city).toBe("箱根町");
+  });
+
+  it("villageのみの場合", () => {
+    const result = buildAddressFromGeocode({
+      village: "十津川村",
+    });
+    expect(result.city).toBe("十津川村");
+  });
+
+  it("詳細住所がquarterとroadの場合", () => {
+    const result = buildAddressFromGeocode({
+      quarter: "1番地",
+      road: "中央通り",
+    });
+    expect(result.address).toBe("1番地中央通り");
+  });
+
+  it("全フィールドが空の場合はすべてnullを返す", () => {
+    const result = buildAddressFromGeocode({});
+    expect(result).toEqual({
+      prefecture: null,
+      city: null,
+      address: null,
+      postcode: null,
+    });
+  });
+
+  it("postcodeのみの場合", () => {
+    const result = buildAddressFromGeocode({
+      postcode: "100-0001",
+    });
+    expect(result).toEqual({
+      prefecture: null,
+      city: null,
+      address: null,
+      postcode: "100-0001",
+    });
+  });
+});

--- a/src/features/map-posting/utils/address-utils.ts
+++ b/src/features/map-posting/utils/address-utils.ts
@@ -1,0 +1,119 @@
+/**
+ * Nominatimレスポンスの住所部品から住所情報を組み立てる純粋関数群
+ */
+
+interface NominatimAddress {
+  province?: string;
+  state?: string;
+  "ISO3166-2-lvl4"?: string;
+  city?: string;
+  town?: string;
+  village?: string;
+  city_district?: string;
+  suburb?: string;
+  neighbourhood?: string;
+  quarter?: string;
+  road?: string;
+  house_number?: string;
+  postcode?: string;
+}
+
+// ISO 3166-2:JP コードから都道府県名へのマッピング
+const ISO3166_TO_PREFECTURE: Record<string, string> = {
+  "JP-01": "北海道",
+  "JP-02": "青森県",
+  "JP-03": "岩手県",
+  "JP-04": "宮城県",
+  "JP-05": "秋田県",
+  "JP-06": "山形県",
+  "JP-07": "福島県",
+  "JP-08": "茨城県",
+  "JP-09": "栃木県",
+  "JP-10": "群馬県",
+  "JP-11": "埼玉県",
+  "JP-12": "千葉県",
+  "JP-13": "東京都",
+  "JP-14": "神奈川県",
+  "JP-15": "新潟県",
+  "JP-16": "富山県",
+  "JP-17": "石川県",
+  "JP-18": "福井県",
+  "JP-19": "山梨県",
+  "JP-20": "長野県",
+  "JP-21": "岐阜県",
+  "JP-22": "静岡県",
+  "JP-23": "愛知県",
+  "JP-24": "三重県",
+  "JP-25": "滋賀県",
+  "JP-26": "京都府",
+  "JP-27": "大阪府",
+  "JP-28": "兵庫県",
+  "JP-29": "奈良県",
+  "JP-30": "和歌山県",
+  "JP-31": "鳥取県",
+  "JP-32": "島根県",
+  "JP-33": "岡山県",
+  "JP-34": "広島県",
+  "JP-35": "山口県",
+  "JP-36": "徳島県",
+  "JP-37": "香川県",
+  "JP-38": "愛媛県",
+  "JP-39": "高知県",
+  "JP-40": "福岡県",
+  "JP-41": "佐賀県",
+  "JP-42": "長崎県",
+  "JP-43": "熊本県",
+  "JP-44": "大分県",
+  "JP-45": "宮崎県",
+  "JP-46": "鹿児島県",
+  "JP-47": "沖縄県",
+};
+
+/**
+ * ISO3166-2:JP コードから都道府県名に変換する。
+ * 該当しない場合はnullを返す。
+ */
+export function convertISO3166ToPrefecture(code: string): string | null {
+  return ISO3166_TO_PREFECTURE[code] || null;
+}
+
+/**
+ * Nominatimの住所データから構造化された住所情報を組み立てる。
+ */
+export function buildAddressFromGeocode(addr: NominatimAddress): {
+  prefecture: string | null;
+  city: string | null;
+  address: string | null;
+  postcode: string | null;
+} {
+  // 都道府県を取得（ISO3166-2コードから変換、またはprovince/stateから直接取得）
+  let prefecture: string | null = null;
+  if (addr["ISO3166-2-lvl4"]) {
+    prefecture = ISO3166_TO_PREFECTURE[addr["ISO3166-2-lvl4"]] || null;
+  }
+  if (!prefecture) {
+    prefecture = addr.province || addr.state || null;
+  }
+
+  // 市区町村を取得（市 + 区 or 町/村）
+  const cityParts: string[] = [];
+  if (addr.city) cityParts.push(addr.city);
+  if (addr.city_district) cityParts.push(addr.city_district);
+  if (addr.town) cityParts.push(addr.town);
+  if (addr.village) cityParts.push(addr.village);
+  const city = cityParts.length > 0 ? cityParts.join("") : null;
+
+  // 詳細住所を取得
+  const addressParts: string[] = [];
+  if (addr.suburb) addressParts.push(addr.suburb);
+  if (addr.neighbourhood) addressParts.push(addr.neighbourhood);
+  if (addr.quarter) addressParts.push(addr.quarter);
+  if (addr.road) addressParts.push(addr.road);
+  if (addr.house_number) addressParts.push(addr.house_number);
+  const address = addressParts.length > 0 ? addressParts.join("") : null;
+
+  // 郵便番号を取得
+  const postcode = addr.postcode || null;
+
+  return { prefecture, city, address, postcode };
+}


### PR DESCRIPTION
# 変更の概要
- `buildAddressFromGeocode`: `reverse-geocoding.ts`のNominatim住所データ組み立てロジックを`map-posting/utils/address-utils.ts`に純粋関数として切り出し
- `convertISO3166ToPrefecture`: ISO3166-2:JPコードから都道府県名への変換関数を切り出し
- `mapUserToHistory`: `poster-boards.ts`のステータス履歴へのユーザー情報付加ロジックを`map-poster/utils/history-helpers.ts`に切り出し
- 各関数のユニットテストを追加（21テスト、全関数100%カバレッジ）

# 変更の背景
- サービス層やServer Actions内にインラインで書かれた純粋ロジックをユーティリティ関数として切り出し、テスタビリティと再利用性を向上させる
- 元のファイルからはimportする形に変更し、動作に変更なし

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました