### PR TITLE
fix: みらい動画スタジオミッションの説明文を修正

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -825,7 +825,7 @@ missions:
   - slug: share-vstudio-video
     title: みらい動画スタジオで動画を作って投稿してみよう
     icon_url: /img/mission-icons/actionboard_icon_work_20250713_ol_youtube-clip.svg
-    content: 'みんなの力で、チームみらいを届けよう！<br><br>選挙はいよいよ明日。最後の一押しに、あなたの力を貸してください！<br>チームみらいの動画から「これ！」という場面を簡単に見つけて、SNSでシェアできるツールを作りました。<br><br>使い方はとってもカンタン（3ステップ）：<br><br>・<a href="https://vstudio.team-mir.ai/" target="_blank" rel="noopener noreferrer">みらい動画スタジオ</a>にアクセス → 「皆が切り抜いた動画はこちら」をタップ<br>・気に入ったクリップを選んで操作すると、AIが自動で字幕をつけてくれます（待つだけでOK！）<br>・完成した動画をダウンロードして、TikTok・X・Instagram・YouTubeなどに投稿！<br><br>難しい編集は一切不要。スマホだけでできます。<br>あなたが届けた一本の動画が、まだチームみらいを知らない誰かの心を動かすかもしれません。みんなで広げていきましょう！'
+    content: 'みらい動画スタジオで、チームみらいの動画から「これ！」という場面を簡単に見つけて、SNSでシェアしましょう。<br><br>使い方はとってもカンタン（3ステップ）：<br>・<a href="https://vstudio.team-mir.ai/" target="_blank" rel="noopener noreferrer">みらい動画スタジオ</a>にアクセス → 「皆が切り抜いた動画はこちら」をタップ<br>・気に入ったクリップを選んで操作すると、AIが自動で字幕をつけてくれます（待つだけでOK！）<br>・完成した動画をダウンロードして、TikTok・X・Instagram・YouTubeなどに投稿！<br>難しい編集は一切不要。スマホだけでできます。<br>あなたが届けた一本の動画が、まだチームみらいを知らない誰かの心を動かすかもしれません。みんなで広げていきましょう！'
     difficulty: 4
     required_artifact_type: LINK
     max_achievement_count: null


### PR DESCRIPTION
## Summary
- みらい動画スタジオミッションの説明文から選挙前の時限的な文言を削除
- 汎用的な説明文に変更

## Test plan
- [ ] `pnpm run mission:sync:dry` でドライラン確認
- [ ] ミッション詳細ページで説明文が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ビデオ共有ミッションの説明が改善されました。チーム動画からシーンを見つけてSNSで共有する手順を、より簡潔で分かりやすいフローに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->