### PR TITLE
fix: みらい動画スタジオミッションのYAML整形とラベル修正

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -832,6 +832,7 @@ missions:
       ・<a href="https://vstudio.team-mir.ai/" target="_blank" rel="noopener noreferrer">みらい動画スタジオ</a>にアクセス → 「皆が切り抜いた動画はこちら」をタップ
       ・気に入ったクリップを選んで操作すると、AIが自動で字幕をつけてくれます（待つだけでOK！）
       ・完成した動画をダウンロードして、TikTok・X・Instagram・YouTubeなどに投稿！
+
       難しい編集は一切不要。スマホだけでできます。
       あなたが届けた一本の動画が、まだチームみらいを知らない誰かの心を動かすかもしれません。みんなで広げていきましょう！
     difficulty: 4


### PR DESCRIPTION
## Summary
- contentを`|-`のYAML複数行形式に変更（`<br>`タグ → 改行）
- artifact_labelを「投稿した動画のURL」→「動画や投稿のURL」に変更

## Test plan
- [ ] `pnpm run mission:sync:dry` でドライラン確認
- [ ] ミッション詳細ページで説明文が正しく改行表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)