### PR TITLE
docs: Supabaseクライアント使い分けルールをCLAUDE.mdに追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,58 +107,11 @@ const { data } = await supabase.from("table").select(); // NG: 直接アクセ�
 
 ### Supabaseクライアントの使い分けルール
 
-このプロジェクトには2種類のSupabaseクライアントがあり、用途に応じて正しく使い分ける必要があります。
+詳細は [docs/20260206_2220_Supabaseクライアント使い分けガイド.md](docs/20260206_2220_Supabaseクライアント使い分けガイド.md) を参照。
 
-| クライアント | 用途 | cookie/セッション | RLSバイパス |
-|---|---|---|---|
-| `createClient()` | 認証操作（セッション管理） | あり | なし |
-| `createAdminClient()` | データベース操作（CRUD） | なし | あり |
-
-#### `createClient()` を使うべき場面（`@/lib/supabase/client`）
-- `supabase.auth.getUser()` - 現在のログインユーザー取得
-- `supabase.auth.exchangeCodeForSession()` - OAuthコールバック処理
-- `supabase.auth.updateUser()` - ユーザー情報更新
-- その他すべての `supabase.auth.*` 操作
-
-**理由**: `createClient` は `@supabase/ssr` の `createServerClient` を使い、Next.jsのcookieと連携してセッション情報を読み書きします。
-
-#### `createAdminClient()` を使うべき場面（`@/lib/supabase/adminClient`）
-- `supabase.from("table").select()` - テーブルデータの読み取り
-- `supabase.from("table").insert()` / `.update()` / `.delete()` - テーブルデータの書き込み
-- その他すべての `supabase.from(...)` 操作
-
-**理由**: RLSポリシーが削除されているため、`service_role` キーを持つ `createAdminClient` でないとデータにアクセスできません。
-
-#### 両方が必要な場合のパターン
-認証とデータベース操作の両方が必要な場合は、2つのクライアントを併用します：
-
-```typescript
-// 正しいパターン: 認証 + DB操作の併用
-import { createClient } from "@/lib/supabase/client";
-import { createAdminClient } from "@/lib/supabase/adminClient";
-
-export async function someAction() {
-  // 認証: cookie-aware clientでユーザー取得
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error("Not authenticated");
-
-  // DB操作: admin clientでデータアクセス
-  const supabaseAdmin = await createAdminClient();
-  const { data } = await supabaseAdmin.from("table").select().eq("user_id", user.id);
-}
-```
-
-#### 禁止パターン
-```typescript
-// NG: admin clientで認証操作 → cookieが読めずセッション取得失敗
-const supabase = await createAdminClient();
-const { data: { user } } = await supabase.auth.getUser(); // 動かない
-
-// NG: 通常clientでDB操作 → RLSで拒否される
-const supabase = createClient();
-const { data } = await supabase.from("table").select(); // RLSで空結果
-```
+- **`createClient()` / `getAuth()` / `getStorage()`**: 認証操作（`supabase.auth.*`）やStorage操作に使用。cookie連携あり。
+- **`createAdminClient()`**: DB操作（`supabase.from(...)`）に使用。service_roleでRLSバイパス。
+- **`createAdminClient()` で `supabase.auth.*` を呼んではいけない**（cookieが読めずセッション取得失敗）
 
 ### 主要技術スタック
 - **フレームワーク**: Next.js 15 with App Router

--- a/docs/20260206_2220_Supabaseクライアント使い分けガイド.md
+++ b/docs/20260206_2220_Supabaseクライアント使い分けガイド.md
@@ -1,0 +1,89 @@
+# Supabaseクライアント使い分けガイド
+
+## 概要
+
+このプロジェクトには2種類のSupabaseクライアントがあり、用途に応じて正しく使い分ける必要があります。
+
+| クライアント | 用途 | cookie/セッション | RLSバイパス |
+|---|---|---|---|
+| `createClient()` | 認証操作（セッション管理） | あり | なし |
+| `createAdminClient()` | データベース操作（CRUD） | なし | あり |
+
+また、用途別のヘルパー関数も提供されています：
+
+| ヘルパー | 説明 |
+|---|---|
+| `getAuth()` | `createClient().auth` のショートカット。認証操作用 |
+| `getStorage()` | `createClient().storage` のショートカット。ファイル操作用 |
+
+## `createClient()` を使うべき場面
+
+**ファイル**: `@/lib/supabase/client`
+
+- `supabase.auth.getUser()` - 現在のログインユーザー取得
+- `supabase.auth.exchangeCodeForSession()` - OAuthコールバック処理
+- `supabase.auth.updateUser()` - ユーザー情報更新
+- `supabase.storage.from("bucket")` - ファイルアップロード、Public URL取得
+- その他すべての `supabase.auth.*` / `supabase.storage.*` 操作
+
+**理由**: `createClient` は `@supabase/ssr` の `createServerClient` を使い、Next.jsのcookieと連携してセッション情報を読み書きします。
+
+### ヘルパー関数の利用
+
+```typescript
+import { getAuth, getStorage } from "@/lib/supabase/client";
+
+// 認証操作
+const { data: { user } } = await getAuth().getUser();
+
+// Storage操作
+const { data } = getStorage().from("avatars").getPublicUrl(avatarPath);
+```
+
+## `createAdminClient()` を使うべき場面
+
+**ファイル**: `@/lib/supabase/adminClient`
+
+- `supabase.from("table").select()` - テーブルデータの読み取り
+- `supabase.from("table").insert()` / `.update()` / `.delete()` - テーブルデータの書き込み
+- その他すべての `supabase.from(...)` 操作
+
+**理由**: RLSポリシーが削除されているため、`service_role` キーを持つ `createAdminClient` でないとデータにアクセスできません。
+
+## 両方が必要な場合のパターン
+
+認証とデータベース操作の両方が必要な場合は、2つのクライアントを併用します：
+
+```typescript
+import { getAuth } from "@/lib/supabase/client";
+import { createAdminClient } from "@/lib/supabase/adminClient";
+
+export async function someAction() {
+  // 認証: cookie-aware clientでユーザー取得
+  const { data: { user } } = await getAuth().getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  // DB操作: admin clientでデータアクセス
+  const supabaseAdmin = await createAdminClient();
+  const { data } = await supabaseAdmin.from("table").select().eq("user_id", user.id);
+}
+```
+
+## 禁止パターン
+
+```typescript
+// NG: admin clientで認証操作 → cookieが読めずセッション取得失敗
+const supabase = await createAdminClient();
+const { data: { user } } = await supabase.auth.getUser(); // 動かない
+
+// NG: 通常clientでDB操作 → RLSで拒否される
+const supabase = createClient();
+const { data } = await supabase.from("table").select(); // RLSで空結果
+```
+
+## 判断フローチャート
+
+1. `supabase.auth.*` を使う？ → `createClient()` または `getAuth()`
+2. `supabase.storage.*` を使う？ → `createClient()` または `getStorage()`
+3. `supabase.from(...)` を使う？ → `createAdminClient()`
+4. 上記を複数組み合わせる？ → それぞれのクライアントを併用


### PR DESCRIPTION
## Summary
- `createClient`（cookie-aware/auth操作用）と`createAdminClient`（service_role/DB操作用）の使い分けルールをCLAUDE.mdに追加
- 正しいパターン（auth+DB併用時のコード例）と禁止パターンを文書化
- RLSポリシー削除後の運用で、auth操作にcreateAdminClientを使うバグを防止

## Background
PR #2017-#2020 でSupabaseアクセスをservice_role経由に移行した際、`supabase.auth.getUser()`等のauth操作まで`createAdminClient`に変更してしまうバグが発生。`createAdminClient`はcookie連携がないため、セッション取得やOAuthコールバックが動作しない。

## Test plan
- [ ] CLAUDE.mdの内容が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)