### PR TITLE
refactor: 日付フォーマット関数を共通utilsに統合してDRY化

### DIFF
--- a/src/features/action-stats/components/action-period-filter.tsx
+++ b/src/features/action-stats/components/action-period-filter.tsx
@@ -10,15 +10,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DatePicker } from "@/features/youtube-stats/components/date-picker";
+import { formatLocalDate } from "@/lib/utils/date-formatters";
 import { PERIOD_OPTIONS, type PeriodType } from "../types";
-
-/** ローカルタイムゾーンで日付を YYYY-MM-DD 形式にフォーマット */
-function formatLocalDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
 
 interface ActionPeriodFilterProps {
   defaultPeriod?: PeriodType;

--- a/src/features/metrics/components/achievement-metric.tsx
+++ b/src/features/metrics/components/achievement-metric.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { AchievementData } from "@/features/metrics/types/metrics-types";
+import { formatDateLabel } from "@/lib/utils/date-formatters";
 import { formatNumber } from "@/lib/utils/metrics-formatter";
 
 interface AchievementMetricProps {
@@ -7,16 +8,6 @@ interface AchievementMetricProps {
   fallbackTotal?: number;
   fallbackToday?: number;
   startDate?: Date;
-}
-
-/**
- * 日付を YYYY.MM.DD 形式でフォーマット
- */
-function formatDateLabel(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}.${month}.${day}`;
 }
 
 /**

--- a/src/features/metrics/components/video-metric.tsx
+++ b/src/features/metrics/components/video-metric.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { formatDateLabel } from "@/lib/utils/date-formatters";
 import { formatNumber } from "@/lib/utils/metrics-formatter";
 
 interface VideoMetricProps {
@@ -7,16 +8,6 @@ interface VideoMetricProps {
   dailyViewsIncrease?: number;
   dailyVideosIncrease?: number;
   startDate?: Date;
-}
-
-/**
- * 日付を YYYY.MM.DD 形式でフォーマット
- */
-function formatDateLabel(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}.${month}.${day}`;
 }
 
 /**

--- a/src/features/metrics/components/youtube-metric.tsx
+++ b/src/features/metrics/components/youtube-metric.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { formatDateLabel } from "@/lib/utils/date-formatters";
 import { formatNumber } from "@/lib/utils/metrics-formatter";
 
 interface YouTubeMetricProps {
@@ -7,16 +8,6 @@ interface YouTubeMetricProps {
   dailyViewsIncrease?: number;
   dailyVideosIncrease?: number;
   startDate?: Date;
-}
-
-/**
- * 日付を YYYY.MM.DD 形式でフォーマット
- */
-function formatDateLabel(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}.${month}.${day}`;
 }
 
 /**

--- a/src/features/tiktok-stats/components/tiktok-period-filter.tsx
+++ b/src/features/tiktok-stats/components/tiktok-period-filter.tsx
@@ -9,15 +9,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { formatLocalDate } from "@/lib/utils/date-formatters";
 import { PERIOD_OPTIONS, type PeriodType } from "../types";
 import { DatePicker } from "./date-picker";
-
-function formatLocalDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
 
 interface TikTokPeriodFilterProps {
   defaultPeriod?: PeriodType;

--- a/src/features/tiktok-stats/components/tiktok-video-card.tsx
+++ b/src/features/tiktok-stats/components/tiktok-video-card.tsx
@@ -1,27 +1,15 @@
 import { Eye, Heart, MessageCircle, Share2 } from "lucide-react";
 import Link from "next/link";
 import { TikTokIcon } from "@/features/tiktok/components";
+import {
+  formatDateShort,
+  formatSecondsDuration,
+} from "@/lib/utils/date-formatters";
 import type { TikTokVideoWithStats } from "../types";
 import { formatNumberJa } from "../utils/format";
 
 interface TikTokVideoCardProps {
   video: TikTokVideoWithStats;
-}
-
-function formatDuration(seconds: number | null): string {
-  if (!seconds) return "";
-  const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
-}
-
-function formatDate(dateStr: string | null): string {
-  if (!dateStr) return "";
-  return new Date(dateStr).toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
 }
 
 export function TikTokVideoCard({ video }: TikTokVideoCardProps) {
@@ -49,7 +37,7 @@ export function TikTokVideoCard({ video }: TikTokVideoCardProps) {
         {/* 再生時間 */}
         {video.duration && (
           <div className="absolute bottom-0.5 right-0.5 bg-black/80 text-white text-[10px] px-1 rounded">
-            {formatDuration(video.duration)}
+            {formatSecondsDuration(video.duration)}
           </div>
         )}
       </div>
@@ -64,7 +52,7 @@ export function TikTokVideoCard({ video }: TikTokVideoCardProps) {
         {/* クリエイター名・日付 */}
         <p className="text-xs text-gray-500 truncate">
           {video.creator_username ? `@${video.creator_username}` : "TikTok"} •{" "}
-          {formatDate(video.published_at)}
+          {formatDateShort(video.published_at)}
         </p>
 
         {/* 統計 */}

--- a/src/features/youtube-stats/components/youtube-period-filter.tsx
+++ b/src/features/youtube-stats/components/youtube-period-filter.tsx
@@ -9,16 +9,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { formatLocalDate } from "@/lib/utils/date-formatters";
 import { PERIOD_OPTIONS, type PeriodType } from "../types";
 import { DatePicker } from "./date-picker";
-
-/** ローカルタイムゾーンで日付を YYYY-MM-DD 形式にフォーマット */
-function formatLocalDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
 
 interface YouTubePeriodFilterProps {
   defaultPeriod?: PeriodType;

--- a/src/features/youtube-stats/components/youtube-video-card.tsx
+++ b/src/features/youtube-stats/components/youtube-video-card.tsx
@@ -1,37 +1,15 @@
 import { Eye, MessageCircle, ThumbsUp } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import {
+  formatDateShort,
+  formatIsoDuration,
+} from "@/lib/utils/date-formatters";
 import type { YouTubeVideoWithStats } from "../types";
 import { formatNumberJa } from "../utils/format";
 
 interface YouTubeVideoCardProps {
   video: YouTubeVideoWithStats;
-}
-
-function formatDuration(duration: string | null): string {
-  if (!duration) return "";
-
-  // ISO 8601 duration format (PT1H2M3S)
-  const match = duration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
-  if (!match) return duration;
-
-  const hours = match[1] ? Number.parseInt(match[1], 10) : 0;
-  const minutes = match[2] ? Number.parseInt(match[2], 10) : 0;
-  const seconds = match[3] ? Number.parseInt(match[3], 10) : 0;
-
-  if (hours > 0) {
-    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-  }
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-}
-
-function formatDate(dateStr: string | null): string {
-  if (!dateStr) return "";
-  return new Date(dateStr).toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
 }
 
 export function YouTubeVideoCard({ video }: YouTubeVideoCardProps) {
@@ -60,7 +38,7 @@ export function YouTubeVideoCard({ video }: YouTubeVideoCardProps) {
         {/* 再生時間 */}
         {video.duration && (
           <div className="absolute bottom-0.5 right-0.5 bg-black/80 text-white text-[10px] px-1 rounded">
-            {formatDuration(video.duration)}
+            {formatIsoDuration(video.duration)}
           </div>
         )}
       </div>
@@ -74,7 +52,7 @@ export function YouTubeVideoCard({ video }: YouTubeVideoCardProps) {
 
         {/* チャンネル名・日付 */}
         <p className="text-xs text-gray-500 truncate">
-          {video.channel_title} • {formatDate(video.published_at)}
+          {video.channel_title} • {formatDateShort(video.published_at)}
         </p>
 
         {/* 統計 */}

--- a/src/lib/utils/date-formatters.test.ts
+++ b/src/lib/utils/date-formatters.test.ts
@@ -1,4 +1,12 @@
-import { dateFormatter, dateTimeFormatter } from "./date-formatters";
+import {
+  dateFormatter,
+  dateTimeFormatter,
+  formatDateLabel,
+  formatDateShort,
+  formatIsoDuration,
+  formatLocalDate,
+  formatSecondsDuration,
+} from "./date-formatters";
 
 describe("dateTimeFormatter", () => {
   test("UTC日時をJST日時文字列に変換する", () => {
@@ -75,5 +83,112 @@ describe("dateFormatter", () => {
   test("月と日が2桁ゼロパディングされる", () => {
     const date = new Date("2025-03-05T00:00:00Z");
     expect(dateFormatter(date)).toBe("2025/03/05");
+  });
+});
+
+describe("formatLocalDate", () => {
+  test("日付をYYYY-MM-DD形式にフォーマットする", () => {
+    const date = new Date(2025, 0, 15); // 2025-01-15
+    expect(formatLocalDate(date)).toBe("2025-01-15");
+  });
+
+  test("月と日が1桁の場合ゼロパディングされる", () => {
+    const date = new Date(2025, 2, 5); // 2025-03-05
+    expect(formatLocalDate(date)).toBe("2025-03-05");
+  });
+
+  test("12月31日を正しくフォーマットする", () => {
+    const date = new Date(2025, 11, 31); // 2025-12-31
+    expect(formatLocalDate(date)).toBe("2025-12-31");
+  });
+});
+
+describe("formatDateShort", () => {
+  test("日付文字列をja-JPロケールでフォーマットする", () => {
+    const result = formatDateShort("2025-01-15");
+    expect(result).toMatch(/2025/);
+    expect(result).toMatch(/1/);
+    expect(result).toMatch(/15/);
+  });
+
+  test("nullの場合は空文字を返す", () => {
+    expect(formatDateShort(null)).toBe("");
+  });
+
+  test("空文字の場合は空文字を返す", () => {
+    expect(formatDateShort("")).toBe("");
+  });
+});
+
+describe("formatDateLabel", () => {
+  test("日付をYYYY.MM.DD形式にフォーマットする", () => {
+    const date = new Date(2025, 0, 15); // 2025-01-15
+    expect(formatDateLabel(date)).toBe("2025.01.15");
+  });
+
+  test("月と日が1桁の場合ゼロパディングされる", () => {
+    const date = new Date(2025, 2, 5); // 2025-03-05
+    expect(formatDateLabel(date)).toBe("2025.03.05");
+  });
+
+  test("12月31日を正しくフォーマットする", () => {
+    const date = new Date(2025, 11, 31); // 2025-12-31
+    expect(formatDateLabel(date)).toBe("2025.12.31");
+  });
+});
+
+describe("formatIsoDuration", () => {
+  test("時間・分・秒をH:MM:SS形式にフォーマットする", () => {
+    expect(formatIsoDuration("PT1H2M3S")).toBe("1:02:03");
+  });
+
+  test("分・秒のみの場合M:SS形式にフォーマットする", () => {
+    expect(formatIsoDuration("PT5M30S")).toBe("5:30");
+  });
+
+  test("秒のみの場合0:SS形式にフォーマットする", () => {
+    expect(formatIsoDuration("PT45S")).toBe("0:45");
+  });
+
+  test("分のみの場合M:00形式にフォーマットする", () => {
+    expect(formatIsoDuration("PT10M")).toBe("10:00");
+  });
+
+  test("時間のみの場合H:00:00形式にフォーマットする", () => {
+    expect(formatIsoDuration("PT2H")).toBe("2:00:00");
+  });
+
+  test("nullの場合は空文字を返す", () => {
+    expect(formatIsoDuration(null)).toBe("");
+  });
+
+  test("不正な形式の場合はそのまま返す", () => {
+    expect(formatIsoDuration("invalid")).toBe("invalid");
+  });
+});
+
+describe("formatSecondsDuration", () => {
+  test("秒数をM:SS形式にフォーマットする", () => {
+    expect(formatSecondsDuration(90)).toBe("1:30");
+  });
+
+  test("60秒未満の場合0:SS形式にフォーマットする", () => {
+    expect(formatSecondsDuration(45)).toBe("0:45");
+  });
+
+  test("ちょうど1分の場合1:00にフォーマットする", () => {
+    expect(formatSecondsDuration(60)).toBe("1:00");
+  });
+
+  test("0秒の場合は空文字を返す", () => {
+    expect(formatSecondsDuration(0)).toBe("");
+  });
+
+  test("nullの場合は空文字を返す", () => {
+    expect(formatSecondsDuration(null)).toBe("");
+  });
+
+  test("大きな秒数を正しくフォーマットする", () => {
+    expect(formatSecondsDuration(605)).toBe("10:05");
   });
 });

--- a/src/lib/utils/date-formatters.ts
+++ b/src/lib/utils/date-formatters.ts
@@ -25,3 +25,54 @@ export function dateFormatter(date: Date) {
     day: "2-digit",
   });
 }
+
+/** ローカルタイムゾーンで日付を YYYY-MM-DD 形式にフォーマット */
+export function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** 日付文字列を ja-JP ロケールの短い月名形式でフォーマット (例: 2025年1月15日) */
+export function formatDateShort(dateStr: string | null): string {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** 日付を YYYY.MM.DD 形式でフォーマット */
+export function formatDateLabel(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}.${month}.${day}`;
+}
+
+/** ISO 8601 duration (PT1H2M3S) を HH:MM:SS または MM:SS 形式にフォーマット */
+export function formatIsoDuration(duration: string | null): string {
+  if (!duration) return "";
+
+  const match = duration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  if (!match) return duration;
+
+  const hours = match[1] ? Number.parseInt(match[1], 10) : 0;
+  const minutes = match[2] ? Number.parseInt(match[2], 10) : 0;
+  const seconds = match[3] ? Number.parseInt(match[3], 10) : 0;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+  }
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+/** 秒数を MM:SS 形式にフォーマット */
+export function formatSecondsDuration(seconds: number | null): string {
+  if (!seconds) return "";
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}


### PR DESCRIPTION
# 変更の概要
- 10個のTSXコンポーネントに重複定義されていた日付フォーマット関数を `src/lib/utils/date-formatters.ts` に集約
- 各コンポーネントからインライン定義を削除し、共通関数のimportに変更
- 新規関数のユニットテストを追加（既存テストも維持）

# 変更の背景
- DRY原則に基づくコードの重複削減
- 同一ロジックが複数コンポーネントに散在し、保守性が低下していた

## 統合した関数
| 関数名 | フォーマット | 重複箇所数 |
|--------|------------|-----------|
| `formatLocalDate` | YYYY-MM-DD | 3箇所 |
| `formatDateShort` | ja-JPロケール短縮月名 | 2箇所 |
| `formatDateLabel` | YYYY.MM.DD | 3箇所 |
| `formatIsoDuration` | ISO 8601 → HH:MM:SS | 1箇所 (YouTube) |
| `formatSecondsDuration` | 秒数 → MM:SS | 1箇所 (TikTok) |

## 変更対象ファイル
- `src/lib/utils/date-formatters.ts` - 共通関数の追加
- `src/lib/utils/date-formatters.test.ts` - テストの追加
- `src/features/youtube-stats/components/youtube-period-filter.tsx`
- `src/features/tiktok-stats/components/tiktok-period-filter.tsx`
- `src/features/action-stats/components/action-period-filter.tsx`
- `src/features/youtube-stats/components/youtube-video-card.tsx`
- `src/features/tiktok-stats/components/tiktok-video-card.tsx`
- `src/features/metrics/components/youtube-metric.tsx`
- `src/features/metrics/components/achievement-metric.tsx`
- `src/features/metrics/components/video-metric.tsx`

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました