### PR TITLE
refactor: TikTokサービスから純粋ロジックをutils/に切り出し

### DIFF
--- a/src/features/tiktok/services/tiktok-auth.ts
+++ b/src/features/tiktok/services/tiktok-auth.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { base64UrlEncode } from "../utils/auth-helpers";
+
 /**
  * TikTokアカウント連携開始関数
  * TikTok Display API を使用してTikTok認証ページにリダイレクト
@@ -58,14 +60,6 @@ async function generateCodeChallenge(codeVerifier: string): Promise<string> {
   const data = encoder.encode(codeVerifier);
   const digest = await crypto.subtle.digest("SHA-256", data);
   return base64UrlEncode(new Uint8Array(digest));
-}
-
-/**
- * Base64 URL エンコード
- */
-function base64UrlEncode(buffer: Uint8Array): string {
-  const base64 = btoa(String.fromCharCode.apply(null, Array.from(buffer)));
-  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 /**

--- a/src/features/tiktok/utils/auth-helpers.test.ts
+++ b/src/features/tiktok/utils/auth-helpers.test.ts
@@ -1,0 +1,54 @@
+import { base64UrlEncode } from "./auth-helpers";
+
+describe("base64UrlEncode", () => {
+  it("Uint8ArrayをBase64 URLセーフ文字列にエンコードする", () => {
+    const input = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+    const result = base64UrlEncode(input);
+
+    expect(result).toBe("SGVsbG8");
+    // URL-safe: +, /, = は含まれない
+    expect(result).not.toContain("+");
+    expect(result).not.toContain("/");
+    expect(result).not.toContain("=");
+  });
+
+  it("空のUint8Arrayを処理できる", () => {
+    const input = new Uint8Array([]);
+    const result = base64UrlEncode(input);
+    expect(result).toBe("");
+  });
+
+  it("+を-に、/を_に置換する", () => {
+    // Base64で+や/が出るバイト列を使用
+    // 0xFB, 0xEF, 0xBE -> base64: "+++" -> URL-safe: "---"
+    const input = new Uint8Array([0xfb, 0xef, 0xbe]);
+    const result = base64UrlEncode(input);
+
+    expect(result).not.toContain("+");
+    expect(result).not.toContain("/");
+  });
+
+  it("末尾のパディング(=)を除去する", () => {
+    // 1バイトの場合、通常のBase64では==パディングが付く
+    const input = new Uint8Array([65]); // "A" -> base64: "QQ=="
+    const result = base64UrlEncode(input);
+
+    expect(result).not.toContain("=");
+    expect(result).toBe("QQ");
+  });
+
+  it("32バイトのランダムデータを正しくエンコードできる（PKCE verifier相当）", () => {
+    const input = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+      input[i] = i;
+    }
+
+    const result = base64UrlEncode(input);
+
+    // 結果がURL-safe Base64の文字のみを含むこと
+    expect(result).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 32バイト -> 約43文字のBase64（パディングなし）
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThanOrEqual(44);
+  });
+});

--- a/src/features/tiktok/utils/auth-helpers.ts
+++ b/src/features/tiktok/utils/auth-helpers.ts
@@ -1,0 +1,7 @@
+/**
+ * Base64 URL エンコード
+ */
+export function base64UrlEncode(buffer: Uint8Array): string {
+  const base64 = btoa(String.fromCharCode.apply(null, Array.from(buffer)));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/src/features/tiktok/utils/video-helpers.test.ts
+++ b/src/features/tiktok/utils/video-helpers.test.ts
@@ -1,0 +1,222 @@
+import type { TikTokVideo, TikTokVideoStats } from "../types";
+import {
+  attachLatestStats,
+  formatDateToYMD,
+  sortTikTokVideos,
+  type VideoWithStats,
+} from "./video-helpers";
+
+function createVideoWithStats(
+  overrides: Partial<VideoWithStats> = {},
+): VideoWithStats {
+  return {
+    id: "vid-1",
+    video_id: "tiktok-123",
+    user_id: "user-1",
+    creator_id: "creator-1",
+    creator_username: "testuser",
+    title: "Test Video",
+    description: "A test video",
+    thumbnail_url: "https://example.com/thumb.jpg",
+    video_url: "https://example.com/video.mp4",
+    published_at: "2025-01-15T10:00:00Z",
+    duration: 60,
+    tags: ["test"],
+    is_active: true,
+    created_at: "2025-01-15T10:00:00Z",
+    updated_at: "2025-01-15T10:00:00Z",
+    tiktok_video_stats: [],
+    ...overrides,
+  };
+}
+
+describe("attachLatestStats", () => {
+  it("統計データがない場合、latest_statsがundefinedになる", () => {
+    const video = createVideoWithStats({ tiktok_video_stats: [] });
+    const result = attachLatestStats(video);
+
+    expect(result.latest_stats).toBeUndefined();
+    expect(result.id).toBe("vid-1");
+    expect(result.video_id).toBe("tiktok-123");
+  });
+
+  it("統計データがある場合、最新のものをlatest_statsに付与する", () => {
+    const video = createVideoWithStats({
+      tiktok_video_stats: [
+        {
+          view_count: 100,
+          like_count: 10,
+          comment_count: 5,
+          share_count: 2,
+          recorded_at: "2025-01-14",
+        },
+        {
+          view_count: 200,
+          like_count: 20,
+          comment_count: 8,
+          share_count: 3,
+          recorded_at: "2025-01-15",
+        },
+      ],
+    });
+
+    const result = attachLatestStats(video);
+
+    expect(result.latest_stats).toBeDefined();
+    expect(result.latest_stats?.view_count).toBe(200);
+    expect(result.latest_stats?.like_count).toBe(20);
+    expect(result.latest_stats?.comment_count).toBe(8);
+    expect(result.latest_stats?.share_count).toBe(3);
+    expect(result.latest_stats?.tiktok_video_id).toBe("vid-1");
+  });
+
+  it("latest_statsのidとcreated_atは空文字が設定される", () => {
+    const video = createVideoWithStats({
+      tiktok_video_stats: [
+        {
+          view_count: 100,
+          like_count: 10,
+          comment_count: 5,
+          share_count: 2,
+          recorded_at: "2025-01-15",
+        },
+      ],
+    });
+
+    const result = attachLatestStats(video);
+
+    expect(result.latest_stats?.id).toBe("");
+    expect(result.latest_stats?.created_at).toBe("");
+  });
+});
+
+describe("sortTikTokVideos", () => {
+  function createVideoResult(
+    overrides: Partial<TikTokVideo & { latest_stats?: TikTokVideoStats }> = {},
+  ): TikTokVideo & { latest_stats?: TikTokVideoStats } {
+    return {
+      id: "vid-1",
+      video_id: "tiktok-123",
+      user_id: "user-1",
+      creator_id: "creator-1",
+      creator_username: "testuser",
+      title: "Test",
+      description: null,
+      thumbnail_url: null,
+      video_url: "https://example.com/video.mp4",
+      published_at: "2025-01-15T10:00:00Z",
+      duration: 60,
+      tags: null,
+      is_active: true,
+      created_at: "2025-01-15T10:00:00Z",
+      updated_at: "2025-01-15T10:00:00Z",
+      ...overrides,
+    };
+  }
+
+  const videos = [
+    createVideoResult({
+      id: "a",
+      published_at: "2025-01-10T10:00:00Z",
+      latest_stats: {
+        id: "",
+        tiktok_video_id: "a",
+        recorded_at: "2025-01-15",
+        view_count: 300,
+        like_count: 5,
+        comment_count: 0,
+        share_count: 0,
+        created_at: "",
+      },
+    }),
+    createVideoResult({
+      id: "b",
+      published_at: "2025-01-15T10:00:00Z",
+      latest_stats: {
+        id: "",
+        tiktok_video_id: "b",
+        recorded_at: "2025-01-15",
+        view_count: 100,
+        like_count: 50,
+        comment_count: 0,
+        share_count: 0,
+        created_at: "",
+      },
+    }),
+    createVideoResult({
+      id: "c",
+      published_at: "2025-01-12T10:00:00Z",
+      latest_stats: {
+        id: "",
+        tiktok_video_id: "c",
+        recorded_at: "2025-01-15",
+        view_count: 200,
+        like_count: 20,
+        comment_count: 0,
+        share_count: 0,
+        created_at: "",
+      },
+    }),
+  ];
+
+  it("view_countでソートできる", () => {
+    const sorted = sortTikTokVideos(videos, "view_count");
+    expect(sorted.map((v) => v.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("like_countでソートできる", () => {
+    const sorted = sortTikTokVideos(videos, "like_count");
+    expect(sorted.map((v) => v.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("published_atでソートできる（デフォルト: 新しい順）", () => {
+    const sorted = sortTikTokVideos(videos, "published_at");
+    expect(sorted.map((v) => v.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("元の配列を変更しない", () => {
+    const original = [...videos];
+    sortTikTokVideos(videos, "view_count");
+    expect(videos.map((v) => v.id)).toEqual(original.map((v) => v.id));
+  });
+
+  it("latest_statsがnullの場合は0として扱う", () => {
+    const videosWithNull = [
+      createVideoResult({ id: "x", latest_stats: undefined }),
+      createVideoResult({
+        id: "y",
+        latest_stats: {
+          id: "",
+          tiktok_video_id: "y",
+          recorded_at: "2025-01-15",
+          view_count: 100,
+          like_count: 10,
+          comment_count: 0,
+          share_count: 0,
+          created_at: "",
+        },
+      }),
+    ];
+
+    const sorted = sortTikTokVideos(videosWithNull, "view_count");
+    expect(sorted[0].id).toBe("y");
+    expect(sorted[1].id).toBe("x");
+  });
+});
+
+describe("formatDateToYMD", () => {
+  it("DateオブジェクトをYYYY-MM-DD形式にフォーマットする", () => {
+    const date = new Date("2025-03-15T10:30:00Z");
+    expect(formatDateToYMD(date)).toBe("2025-03-15");
+  });
+
+  it("月初をフォーマットできる", () => {
+    const date = new Date("2025-01-01T00:00:00Z");
+    expect(formatDateToYMD(date)).toBe("2025-01-01");
+  });
+
+  it("年末をフォーマットできる", () => {
+    const date = new Date("2025-12-31T23:59:59Z");
+    expect(formatDateToYMD(date)).toBe("2025-12-31");
+  });
+});

--- a/src/features/tiktok/utils/video-helpers.ts
+++ b/src/features/tiktok/utils/video-helpers.ts
@@ -1,0 +1,90 @@
+import { getLatestStats } from "@/features/tiktok-stats/utils/stats-utils";
+import type { TikTokVideo, TikTokVideoStats } from "../types";
+
+/**
+ * VideoWithStats: DBから取得したTikTok動画（統計データ付き）の型
+ */
+export interface VideoWithStats {
+  id: string;
+  video_id: string;
+  user_id: string | null;
+  creator_id: string;
+  creator_username: string | null;
+  title: string | null;
+  description: string | null;
+  thumbnail_url: string | null;
+  video_url: string;
+  published_at: string | null;
+  duration: number | null;
+  tags: string[] | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  tiktok_video_stats: Array<{
+    view_count: number | null;
+    like_count: number | null;
+    comment_count: number | null;
+    share_count: number | null;
+    recorded_at: string;
+  }>;
+}
+
+/**
+ * 動画に最新統計データを付与する
+ */
+export function attachLatestStats(
+  video: VideoWithStats,
+): TikTokVideo & { latest_stats?: TikTokVideoStats } {
+  const stats = video.tiktok_video_stats || [];
+  const latestStats = getLatestStats(stats);
+
+  return {
+    ...video,
+    tiktok_video_stats: undefined,
+    latest_stats: latestStats
+      ? {
+          id: "",
+          tiktok_video_id: video.id,
+          recorded_at: latestStats.recorded_at,
+          view_count: latestStats.view_count,
+          like_count: latestStats.like_count,
+          comment_count: latestStats.comment_count,
+          share_count: latestStats.share_count,
+          created_at: "",
+        }
+      : undefined,
+  } as TikTokVideo & { latest_stats?: TikTokVideoStats };
+}
+
+/**
+ * TikTok動画をソートする
+ */
+export function sortTikTokVideos(
+  videos: (TikTokVideo & { latest_stats?: TikTokVideoStats })[],
+  sortBy: "published_at" | "view_count" | "like_count",
+): (TikTokVideo & { latest_stats?: TikTokVideoStats })[] {
+  return [...videos].sort((a, b) => {
+    switch (sortBy) {
+      case "view_count":
+        return (
+          (b.latest_stats?.view_count ?? 0) - (a.latest_stats?.view_count ?? 0)
+        );
+      case "like_count":
+        return (
+          (b.latest_stats?.like_count ?? 0) - (a.latest_stats?.like_count ?? 0)
+        );
+      default:
+        return (
+          new Date(b.published_at ?? 0).getTime() -
+          new Date(a.published_at ?? 0).getTime()
+        );
+    }
+  });
+}
+
+/**
+ * 日付をYYYY-MM-DD形式にフォーマットする
+ */
+export function formatDateToYMD(date: Date): string {
+  return date.toISOString().split("T")[0];
+}


### PR DESCRIPTION
# 変更の概要
- TikTok動画サービス（`tiktok-video-service.ts`）からテスト可能な純粋ロジックを `utils/` に切り出し
- TikTok認証（`tiktok-auth.ts`）から `base64UrlEncode` を `utils/auth-helpers.ts` に切り出し
- 切り出した関数のユニットテストを追加（16テスト）

# 変更の背景
- サービスファイルに埋め込まれていた純粋ロジック（統計付与、ソート、日付フォーマット、Base64エンコード）をutils/に切り出してテスタビリティを向上させるリファクタリング

## 切り出した関数
### `video-helpers.ts`
- `attachLatestStats(video)` - 動画に最新統計データを付与
- `sortTikTokVideos(videos, sortBy)` - view_count/like_count/published_atでソート
- `formatDateToYMD(date)` - Date → YYYY-MM-DD変換
- `VideoWithStats` 型定義の移動

### `auth-helpers.ts`
- `base64UrlEncode(buffer)` - Base64 URLセーフエンコード（PKCE用）

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [x] CLAの内容を読み、同意しました