### PR TITLE
refactor: 数値フォーマット関数を共通utilsに統合してDRY化

### DIFF
--- a/src/features/action-stats/components/action-stats-chart.tsx
+++ b/src/features/action-stats/components/action-stats-chart.tsx
@@ -8,6 +8,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { formatNumberJaShort } from "@/lib/utils/format-number-ja";
 import type { DailyActionItem } from "../types";
 
 interface ActionStatsChartProps {
@@ -20,13 +21,6 @@ const chartConfig = {
     color: "hsl(var(--chart-3))",
   },
 } satisfies ChartConfig;
-
-function formatNumberShort(num: number): string {
-  if (num >= 10_000) {
-    return `${Math.round(num / 10_000)}万`;
-  }
-  return num.toLocaleString();
-}
 
 export function ActionStatsChart({ data }: ActionStatsChartProps) {
   if (data.length < 2) {
@@ -66,7 +60,7 @@ export function ActionStatsChart({ data }: ActionStatsChartProps) {
             axisLine={false}
             tickMargin={8}
             fontSize={10}
-            tickFormatter={formatNumberShort}
+            tickFormatter={formatNumberJaShort}
           />
           <ChartTooltip content={<ChartTooltipContent />} />
           <Line

--- a/src/features/action-stats/components/action-stats-summary.tsx
+++ b/src/features/action-stats/components/action-stats-summary.tsx
@@ -1,13 +1,10 @@
 import { TrendingUp, Users, Zap } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { formatNumberLocale } from "@/lib/utils/format-number-ja";
 import type { ActionStatsSummary as ActionStatsSummaryType } from "../types";
 
 interface ActionStatsSummaryProps {
   summary: ActionStatsSummaryType;
-}
-
-function formatNumber(num: number): string {
-  return num.toLocaleString();
 }
 
 export function ActionStatsSummary({ summary }: ActionStatsSummaryProps) {
@@ -34,13 +31,13 @@ export function ActionStatsSummary({ summary }: ActionStatsSummaryProps) {
             <span className="text-gray-600">{stat.icon}</span>
             <div>
               <div className="text-2xl font-bold text-gray-900">
-                {formatNumber(stat.value)}
+                {formatNumberLocale(stat.value)}
               </div>
               <div className="text-sm text-gray-500">{stat.label}</div>
               {stat.increase !== undefined && stat.increase > 0 && (
                 <div className="flex items-center gap-1 text-xs text-green-600 mt-1">
                   <TrendingUp className="w-3 h-3" />
-                  <span>+{formatNumber(stat.increase)} (24h)</span>
+                  <span>+{formatNumberLocale(stat.increase)} (24h)</span>
                 </div>
               )}
             </div>

--- a/src/features/action-stats/components/active-users-chart.tsx
+++ b/src/features/action-stats/components/active-users-chart.tsx
@@ -8,6 +8,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { formatNumberJaShort } from "@/lib/utils/format-number-ja";
 import type { DailyActiveUsersItem } from "../types";
 
 interface ActiveUsersChartProps {
@@ -20,13 +21,6 @@ const chartConfig = {
     color: "hsl(var(--chart-3))",
   },
 } satisfies ChartConfig;
-
-function formatNumberShort(num: number): string {
-  if (num >= 10_000) {
-    return `${Math.round(num / 10_000)}万`;
-  }
-  return num.toLocaleString();
-}
 
 export function ActiveUsersChart({ data }: ActiveUsersChartProps) {
   if (data.length < 2) {
@@ -66,7 +60,7 @@ export function ActiveUsersChart({ data }: ActiveUsersChartProps) {
             axisLine={false}
             tickMargin={8}
             fontSize={10}
-            tickFormatter={formatNumberShort}
+            tickFormatter={formatNumberJaShort}
           />
           <ChartTooltip content={<ChartTooltipContent />} />
           <Line

--- a/src/features/action-stats/components/mission-ranking-list.tsx
+++ b/src/features/action-stats/components/mission-ranking-list.tsx
@@ -2,14 +2,11 @@ import { EyeOff } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { Card } from "@/components/ui/card";
+import { formatNumberLocale } from "@/lib/utils/format-number-ja";
 import type { MissionActionRanking } from "../types";
 
 interface MissionRankingListProps {
   rankings: MissionActionRanking[];
-}
-
-function formatNumber(num: number): string {
-  return num.toLocaleString();
 }
 
 function MissionRankingItem({
@@ -49,7 +46,7 @@ function MissionRankingItem({
         </div>
       </div>
       <div className="text-sm font-bold text-gray-700">
-        {formatNumber(mission.actionCount)}
+        {formatNumberLocale(mission.actionCount)}
         <span className="text-xs font-normal text-gray-500 ml-1">件</span>
       </div>
     </>

--- a/src/lib/utils/format-number-ja.test.ts
+++ b/src/lib/utils/format-number-ja.test.ts
@@ -1,4 +1,8 @@
-import { formatNumberJa, formatNumberJaShort } from "./format-number-ja";
+import {
+  formatNumberJa,
+  formatNumberJaShort,
+  formatNumberLocale,
+} from "./format-number-ja";
 
 describe("formatNumberJa", () => {
   describe("null値", () => {
@@ -143,5 +147,27 @@ describe("formatNumberJaShort", () => {
     test("-100000000は-1億と表示する", () => {
       expect(formatNumberJaShort(-100000000)).toBe("-1億");
     });
+  });
+});
+
+describe("formatNumberLocale", () => {
+  test("0をそのまま返す", () => {
+    expect(formatNumberLocale(0)).toBe("0");
+  });
+
+  test("1000をカンマ区切りで返す", () => {
+    expect(formatNumberLocale(1000)).toBe("1,000");
+  });
+
+  test("1234567をカンマ区切りで返す", () => {
+    expect(formatNumberLocale(1234567)).toBe("1,234,567");
+  });
+
+  test("負の数値もカンマ区切りで返す", () => {
+    expect(formatNumberLocale(-5000)).toBe("-5,000");
+  });
+
+  test("小さい数値はそのまま返す", () => {
+    expect(formatNumberLocale(42)).toBe("42");
   });
 });

--- a/src/lib/utils/format-number-ja.ts
+++ b/src/lib/utils/format-number-ja.ts
@@ -44,3 +44,8 @@ export function formatNumberJaShort(num: number): string {
 
   return num.toLocaleString();
 }
+
+/** 数値をカンマ区切りでフォーマットする (toLocaleString ラッパー) */
+export function formatNumberLocale(num: number): string {
+  return num.toLocaleString();
+}


### PR DESCRIPTION
# 変更の概要
- 4つのTSXコンポーネントに重複定義されていた数値フォーマット関数を `src/lib/utils/format-number-ja.ts` に集約
- 各コンポーネントからインライン定義を削除し、共通関数のimportに変更
- 新規関数のユニットテストを追加（既存テストも維持）

# 変更の背景
- DRY原則に基づくコードの重複削減
- 同一ロジックが複数コンポーネントに散在し、保守性が低下していた

## 統合した関数
| 関数名 | 元の関数名 | 重複箇所数 |
|--------|-----------|-----------|
| `formatNumberJaShort` (既存) | `formatNumberShort` | 2箇所 |
| `formatNumberLocale` (新規) | `formatNumber` | 2箇所 |

## 変更対象ファイル
- `src/lib/utils/format-number-ja.ts` - `formatNumberLocale` 追加
- `src/lib/utils/format-number-ja.test.ts` - テスト追加
- `src/features/action-stats/components/action-stats-chart.tsx`
- `src/features/action-stats/components/active-users-chart.tsx`
- `src/features/action-stats/components/action-stats-summary.tsx`
- `src/features/action-stats/components/mission-ranking-list.tsx`

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました