### PR TITLE
refactor: YouTube同期サービスから純粋ロジックをutils/に切り出し

### DIFF
--- a/src/features/youtube/utils/sync-helpers.test.ts
+++ b/src/features/youtube/utils/sync-helpers.test.ts
@@ -1,0 +1,266 @@
+import type { CommentThread } from "../services/youtube-client";
+import {
+  buildCommentCacheRecord,
+  buildLikeVideoRecord,
+  filterNewIds,
+  groupCommentsByUser,
+} from "./sync-helpers";
+
+describe("buildLikeVideoRecord", () => {
+  it("APIの動画詳細からDB保存用レコードを構築する", () => {
+    const detail = {
+      id: "video-123",
+      snippet: {
+        title: "Test Video",
+        description: "A test video description",
+        thumbnails: {
+          medium: { url: "https://example.com/medium.jpg" },
+          default: { url: "https://example.com/default.jpg" },
+        },
+        channelId: "channel-1",
+        channelTitle: "Test Channel",
+        publishedAt: "2025-01-15T10:00:00Z",
+        tags: ["tag1", "tag2"],
+      },
+    };
+
+    const record = buildLikeVideoRecord(detail);
+
+    expect(record).toEqual({
+      video_id: "video-123",
+      video_url: "https://www.youtube.com/watch?v=video-123",
+      title: "Test Video",
+      description: "A test video description",
+      thumbnail_url: "https://example.com/medium.jpg",
+      channel_id: "channel-1",
+      channel_title: "Test Channel",
+      published_at: "2025-01-15T10:00:00Z",
+      tags: ["tag1", "tag2"],
+      is_active: true,
+    });
+  });
+
+  it("descriptionがない場合はnullにする", () => {
+    const detail = {
+      id: "video-456",
+      snippet: {
+        title: "No Description Video",
+        thumbnails: {
+          default: { url: "https://example.com/default.jpg" },
+        },
+        channelId: "channel-1",
+        channelTitle: "Test Channel",
+        publishedAt: "2025-01-15T10:00:00Z",
+      },
+    };
+
+    const record = buildLikeVideoRecord(detail);
+
+    expect(record.description).toBeNull();
+    expect(record.tags).toEqual([]);
+  });
+
+  it("mediumサムネイルがない場合はdefaultを使用する", () => {
+    const detail = {
+      id: "video-789",
+      snippet: {
+        title: "Test",
+        thumbnails: {
+          default: { url: "https://example.com/default.jpg" },
+        },
+        channelId: "channel-1",
+        channelTitle: "Test Channel",
+        publishedAt: "2025-01-15T10:00:00Z",
+      },
+    };
+
+    const record = buildLikeVideoRecord(detail);
+
+    expect(record.thumbnail_url).toBe("https://example.com/default.jpg");
+  });
+
+  it("サムネイルがない場合はnullにする", () => {
+    const detail = {
+      id: "video-000",
+      snippet: {
+        title: "No Thumbnail",
+        thumbnails: {},
+        channelId: "channel-1",
+        channelTitle: "Test Channel",
+        publishedAt: "2025-01-15T10:00:00Z",
+      },
+    };
+
+    const record = buildLikeVideoRecord(detail);
+
+    expect(record.thumbnail_url).toBeNull();
+  });
+});
+
+describe("filterNewIds", () => {
+  it("既存IDセットに含まれないIDのみを返す", () => {
+    const allIds = ["a", "b", "c", "d"];
+    const existingIds = new Set(["b", "d"]);
+
+    const result = filterNewIds(allIds, existingIds);
+
+    expect(result).toEqual(["a", "c"]);
+  });
+
+  it("全て既存の場合は空配列を返す", () => {
+    const allIds = ["a", "b"];
+    const existingIds = new Set(["a", "b"]);
+
+    const result = filterNewIds(allIds, existingIds);
+
+    expect(result).toEqual([]);
+  });
+
+  it("既存IDが空の場合は全IDを返す", () => {
+    const allIds = ["a", "b", "c"];
+    const existingIds = new Set<string>();
+
+    const result = filterNewIds(allIds, existingIds);
+
+    expect(result).toEqual(["a", "b", "c"]);
+  });
+
+  it("空の入力配列に対して空配列を返す", () => {
+    const result = filterNewIds([], new Set(["a"]));
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("buildCommentCacheRecord", () => {
+  it("CommentThreadからDB保存用のレコードを構築する", () => {
+    const comment: CommentThread = {
+      id: "thread-1",
+      snippet: {
+        videoId: "video-123",
+        topLevelComment: {
+          id: "comment-1",
+          snippet: {
+            videoId: "video-123",
+            textDisplay: "Great video!",
+            textOriginal: "Great video!",
+            authorDisplayName: "User One",
+            authorChannelId: { value: "channel-user-1" },
+            publishedAt: "2025-01-15T12:00:00Z",
+          },
+        },
+      },
+    };
+
+    const record = buildCommentCacheRecord(comment);
+
+    expect(record).toEqual({
+      video_id: "video-123",
+      comment_id: "comment-1",
+      author_channel_id: "channel-user-1",
+      author_display_name: "User One",
+      text_display: "Great video!",
+      text_original: "Great video!",
+      published_at: "2025-01-15T12:00:00Z",
+    });
+  });
+});
+
+describe("groupCommentsByUser", () => {
+  const channelIdToUserId = new Map([
+    ["channel-a", "user-1"],
+    ["channel-b", "user-2"],
+  ]);
+
+  it("コメントをユーザーIDごとにグループ化する", () => {
+    const comments = [
+      {
+        comment_id: "c1",
+        video_id: "v1",
+        author_channel_id: "channel-a",
+        author_display_name: "User A",
+        text_display: "Comment 1",
+        text_original: "Comment 1",
+        published_at: "2025-01-15T10:00:00Z",
+      },
+      {
+        comment_id: "c2",
+        video_id: "v1",
+        author_channel_id: "channel-b",
+        author_display_name: "User B",
+        text_display: "Comment 2",
+        text_original: "Comment 2",
+        published_at: "2025-01-15T11:00:00Z",
+      },
+      {
+        comment_id: "c3",
+        video_id: "v2",
+        author_channel_id: "channel-a",
+        author_display_name: "User A",
+        text_display: "Comment 3",
+        text_original: "Comment 3",
+        published_at: "2025-01-15T12:00:00Z",
+      },
+    ];
+
+    const result = groupCommentsByUser(comments, channelIdToUserId);
+
+    expect(result.size).toBe(2);
+    expect(result.get("user-1")).toHaveLength(2);
+    expect(result.get("user-2")).toHaveLength(1);
+    expect(result.get("user-1")![0].commentId).toBe("c1");
+    expect(result.get("user-1")![1].commentId).toBe("c3");
+    expect(result.get("user-2")![0].commentId).toBe("c2");
+  });
+
+  it("マップにないチャンネルIDのコメントは無視する", () => {
+    const comments = [
+      {
+        comment_id: "c1",
+        video_id: "v1",
+        author_channel_id: "channel-unknown",
+        author_display_name: "Unknown",
+        text_display: "Hello",
+        text_original: "Hello",
+        published_at: "2025-01-15T10:00:00Z",
+      },
+    ];
+
+    const result = groupCommentsByUser(comments, channelIdToUserId);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("空のコメント配列に対して空のMapを返す", () => {
+    const result = groupCommentsByUser([], channelIdToUserId);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("CachedComment形式に正しく変換する", () => {
+    const comments = [
+      {
+        comment_id: "c1",
+        video_id: "v1",
+        author_channel_id: "channel-a",
+        author_display_name: null,
+        text_display: null,
+        text_original: null,
+        published_at: "2025-01-15T10:00:00Z",
+      },
+    ];
+
+    const result = groupCommentsByUser(comments, channelIdToUserId);
+    const cached = result.get("user-1")![0];
+
+    expect(cached).toEqual({
+      commentId: "c1",
+      videoId: "v1",
+      authorChannelId: "channel-a",
+      authorDisplayName: null,
+      textDisplay: null,
+      textOriginal: null,
+      publishedAt: "2025-01-15T10:00:00Z",
+    });
+  });
+});

--- a/src/features/youtube/utils/sync-helpers.ts
+++ b/src/features/youtube/utils/sync-helpers.ts
@@ -1,0 +1,115 @@
+import type { CommentThread } from "../services/youtube-client";
+
+/**
+ * キャッシュされたコメント情報
+ */
+export interface CachedComment {
+  commentId: string;
+  videoId: string;
+  authorChannelId: string;
+  authorDisplayName: string | null;
+  textDisplay: string | null;
+  textOriginal: string | null;
+  publishedAt: string;
+}
+
+/**
+ * YouTube APIの動画詳細からDB保存用のいいね動画レコードを構築する
+ */
+export function buildLikeVideoRecord(detail: {
+  id: string;
+  snippet: {
+    title: string;
+    description?: string;
+    thumbnails: {
+      medium?: { url: string };
+      default?: { url: string };
+    };
+    channelId: string;
+    channelTitle: string;
+    publishedAt: string;
+    tags?: string[];
+  };
+}) {
+  return {
+    video_id: detail.id,
+    video_url: `https://www.youtube.com/watch?v=${detail.id}`,
+    title: detail.snippet.title,
+    description: detail.snippet.description || null,
+    thumbnail_url:
+      detail.snippet.thumbnails.medium?.url ||
+      detail.snippet.thumbnails.default?.url ||
+      null,
+    channel_id: detail.snippet.channelId,
+    channel_title: detail.snippet.channelTitle,
+    published_at: detail.snippet.publishedAt,
+    tags: detail.snippet.tags || [],
+    is_active: true,
+  };
+}
+
+/**
+ * 全IDリストから既存IDセットに含まれないIDをフィルタする
+ */
+export function filterNewIds(
+  allIds: string[],
+  existingIds: Set<string>,
+): string[] {
+  return allIds.filter((id) => !existingIds.has(id));
+}
+
+/**
+ * CommentThread をDBキャッシュ保存用のレコードに変換する
+ */
+export function buildCommentCacheRecord(comment: CommentThread) {
+  return {
+    video_id: comment.snippet.videoId,
+    comment_id: comment.snippet.topLevelComment.id,
+    author_channel_id:
+      comment.snippet.topLevelComment.snippet.authorChannelId.value,
+    author_display_name:
+      comment.snippet.topLevelComment.snippet.authorDisplayName,
+    text_display: comment.snippet.topLevelComment.snippet.textDisplay,
+    text_original: comment.snippet.topLevelComment.snippet.textOriginal,
+    published_at: comment.snippet.topLevelComment.snippet.publishedAt,
+  };
+}
+
+/**
+ * コメント配列をchannelIdToUserIdマップを使ってユーザーIDごとにグループ化する
+ */
+export function groupCommentsByUser(
+  comments: Array<{
+    comment_id: string;
+    video_id: string;
+    author_channel_id: string;
+    author_display_name: string | null;
+    text_display: string | null;
+    text_original: string | null;
+    published_at: string;
+  }>,
+  channelIdToUserId: Map<string, string>,
+): Map<string, CachedComment[]> {
+  const result = new Map<string, CachedComment[]>();
+
+  for (const comment of comments) {
+    const userId = channelIdToUserId.get(comment.author_channel_id);
+    if (!userId) continue;
+
+    const cachedComment: CachedComment = {
+      commentId: comment.comment_id,
+      videoId: comment.video_id,
+      authorChannelId: comment.author_channel_id,
+      authorDisplayName: comment.author_display_name,
+      textDisplay: comment.text_display,
+      textOriginal: comment.text_original,
+      publishedAt: comment.published_at,
+    };
+
+    const userComments = result.get(userId) || [];
+    userComments.push(cachedComment);
+    result.set(userId, userComments);
+  }
+
+  return result;
+}


### PR DESCRIPTION
# 変更の概要
- YouTube同期サービス（`sync-likes-core.ts`, `sync-comments-core.ts`）からテスト可能な純粋ロジックを `utils/sync-helpers.ts` に切り出し
- 切り出した関数のユニットテストを追加（13テスト）

# 変更の背景
- サービスファイルに埋め込まれていた純粋なデータ変換・フィルタリングロジックをutils/に切り出してテスタビリティを向上させるリファクタリング

## 切り出した関数
### `sync-helpers.ts`
- `buildLikeVideoRecord(detail)` - YouTube APIの動画詳細からDB保存用のいいね動画レコードを構築
- `filterNewIds(allIds, existingIds)` - 既存IDセットに含まれないIDをフィルタ
- `buildCommentCacheRecord(comment)` - CommentThreadからDBキャッシュ保存用レコードに変換
- `groupCommentsByUser(comments, channelToUserMap)` - コメントをユーザーIDごとにグループ化
- `CachedComment` 型定義を移動（`sync-comments-core.ts`から再エクスポート）

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [x] CLAの内容を読み、同意しました