### PR TITLE
refactor: getLevelBadgeStyle/Color を utils に統合、getDifficultyStyles を切り出し

### DIFF
--- a/src/features/missions/components/difficulty-badge.tsx
+++ b/src/features/missions/components/difficulty-badge.tsx
@@ -1,5 +1,9 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils/utils";
+import {
+  getDifficultyLabel,
+  getDifficultyStyles,
+} from "../utils/difficulty-styles";
 
 interface DifficultyBadgeProps {
   difficulty: number;
@@ -12,20 +16,7 @@ export function DifficultyBadge({
   showLabel = true,
   className,
 }: DifficultyBadgeProps) {
-  const getDifficultyStyles = (_difficulty: number) => {
-    return "text-gray-700 border-gray-400 hover:bg-gray-50";
-  };
-
-  const difficultyLabels = {
-    1: "⭐",
-    2: "⭐⭐",
-    3: "⭐⭐⭐",
-    4: "⭐⭐⭐⭐",
-    5: "⭐⭐⭐⭐⭐",
-  };
-
-  const label =
-    difficultyLabels[difficulty as keyof typeof difficultyLabels] || difficulty;
+  const label = getDifficultyLabel(difficulty);
 
   return (
     <Badge

--- a/src/features/missions/utils/__tests__/difficulty-styles.test.ts
+++ b/src/features/missions/utils/__tests__/difficulty-styles.test.ts
@@ -1,0 +1,67 @@
+import {
+  difficultyLabels,
+  getDifficultyLabel,
+  getDifficultyStyles,
+} from "../difficulty-styles";
+
+describe("getDifficultyStyles", () => {
+  it("returns consistent styles for any difficulty", () => {
+    const expected = "text-gray-700 border-gray-400 hover:bg-gray-50";
+    expect(getDifficultyStyles(1)).toBe(expected);
+    expect(getDifficultyStyles(2)).toBe(expected);
+    expect(getDifficultyStyles(3)).toBe(expected);
+    expect(getDifficultyStyles(4)).toBe(expected);
+    expect(getDifficultyStyles(5)).toBe(expected);
+  });
+
+  it("returns the same style for out-of-range values", () => {
+    const expected = "text-gray-700 border-gray-400 hover:bg-gray-50";
+    expect(getDifficultyStyles(0)).toBe(expected);
+    expect(getDifficultyStyles(100)).toBe(expected);
+    expect(getDifficultyStyles(-1)).toBe(expected);
+  });
+});
+
+describe("difficultyLabels", () => {
+  it("maps difficulty 1 to single star", () => {
+    expect(difficultyLabels[1]).toBe("⭐");
+  });
+
+  it("maps difficulty 2 to two stars", () => {
+    expect(difficultyLabels[2]).toBe("⭐⭐");
+  });
+
+  it("maps difficulty 3 to three stars", () => {
+    expect(difficultyLabels[3]).toBe("⭐⭐⭐");
+  });
+
+  it("maps difficulty 4 to four stars", () => {
+    expect(difficultyLabels[4]).toBe("⭐⭐⭐⭐");
+  });
+
+  it("maps difficulty 5 to five stars", () => {
+    expect(difficultyLabels[5]).toBe("⭐⭐⭐⭐⭐");
+  });
+
+  it("does not have labels for values outside 1-5", () => {
+    expect(difficultyLabels[0]).toBeUndefined();
+    expect(difficultyLabels[6]).toBeUndefined();
+  });
+});
+
+describe("getDifficultyLabel", () => {
+  it("returns star label for valid difficulties 1-5", () => {
+    expect(getDifficultyLabel(1)).toBe("⭐");
+    expect(getDifficultyLabel(2)).toBe("⭐⭐");
+    expect(getDifficultyLabel(3)).toBe("⭐⭐⭐");
+    expect(getDifficultyLabel(4)).toBe("⭐⭐⭐⭐");
+    expect(getDifficultyLabel(5)).toBe("⭐⭐⭐⭐⭐");
+  });
+
+  it("returns the number itself for unknown difficulties", () => {
+    expect(getDifficultyLabel(0)).toBe(0);
+    expect(getDifficultyLabel(6)).toBe(6);
+    expect(getDifficultyLabel(100)).toBe(100);
+    expect(getDifficultyLabel(-1)).toBe(-1);
+  });
+});

--- a/src/features/missions/utils/difficulty-styles.ts
+++ b/src/features/missions/utils/difficulty-styles.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns CSS classes for difficulty badge styling.
+ */
+export function getDifficultyStyles(_difficulty: number): string {
+  return "text-gray-700 border-gray-400 hover:bg-gray-50";
+}
+
+/**
+ * Difficulty labels mapping difficulty number to star representations.
+ */
+export const difficultyLabels: Record<number, string> = {
+  1: "⭐",
+  2: "⭐⭐",
+  3: "⭐⭐⭐",
+  4: "⭐⭐⭐⭐",
+  5: "⭐⭐⭐⭐⭐",
+};
+
+/**
+ * Returns the display label for a given difficulty level.
+ * Falls back to the number itself if no mapping exists.
+ */
+export function getDifficultyLabel(difficulty: number): string | number {
+  return difficultyLabels[difficulty] || difficulty;
+}

--- a/src/features/ranking/components/ranking-item.tsx
+++ b/src/features/ranking/components/ranking-item.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 // TOPページ用のランキングコンポーネント
 import { UserNameWithBadge } from "@/features/party-membership/components/user-name-with-badge";
 import type { UserMissionRanking, UserRanking } from "../types/ranking-types";
+import { getLevelBadgeColor } from "../utils/level-badge-styles";
 import { getRankIcon } from "./ranking-icon";
 
 interface RankingItemProps {
@@ -14,16 +15,6 @@ interface RankingItemProps {
     name: string;
   };
   badgeText?: string;
-}
-
-function getLevelBadgeColor(level: number | null) {
-  const displayLevel = level ?? 0;
-
-  if (displayLevel >= 40) return "bg-emerald-100 text-emerald-700";
-  if (displayLevel >= 30) return "bg-emerald-100 text-emerald-700";
-  if (displayLevel >= 20) return "bg-emerald-100 text-emerald-700";
-  if (displayLevel >= 10) return "bg-emerald-100 text-emerald-700";
-  return "text-emerald-700 bg-emerald-100";
 }
 
 export function RankingItem({

--- a/src/features/ranking/components/ranking-level-badge.tsx
+++ b/src/features/ranking/components/ranking-level-badge.tsx
@@ -1,17 +1,10 @@
 import { Badge } from "@/components/ui/badge";
+import { getLevelBadgeStyle } from "../utils/level-badge-styles";
 
 interface LevelBadgeProps {
   level: number;
   className?: string;
   showPrefix?: boolean;
-}
-
-function getLevelBadgeStyle(level: number) {
-  if (level >= 40) return "bg-emerald-600 text-white";
-  if (level >= 30) return "bg-emerald-500 text-white";
-  if (level >= 20) return "bg-emerald-200 text-emerald-800";
-  if (level >= 10) return "bg-emerald-100 text-emerald-700";
-  return "bg-emerald-50 text-emerald-600";
 }
 
 export function LevelBadge({

--- a/src/features/ranking/utils/__tests__/level-badge-styles.test.ts
+++ b/src/features/ranking/utils/__tests__/level-badge-styles.test.ts
@@ -1,0 +1,75 @@
+import { getLevelBadgeColor, getLevelBadgeStyle } from "../level-badge-styles";
+
+describe("getLevelBadgeStyle", () => {
+  it("returns emerald-600 for level >= 40", () => {
+    expect(getLevelBadgeStyle(40)).toBe("bg-emerald-600 text-white");
+    expect(getLevelBadgeStyle(50)).toBe("bg-emerald-600 text-white");
+  });
+
+  it("returns emerald-500 for level >= 30 and < 40", () => {
+    expect(getLevelBadgeStyle(30)).toBe("bg-emerald-500 text-white");
+    expect(getLevelBadgeStyle(31)).toBe("bg-emerald-500 text-white");
+  });
+
+  it("returns emerald-200 for level >= 20 and < 30", () => {
+    expect(getLevelBadgeStyle(20)).toBe("bg-emerald-200 text-emerald-800");
+    expect(getLevelBadgeStyle(21)).toBe("bg-emerald-200 text-emerald-800");
+  });
+
+  it("returns emerald-100 for level >= 10 and < 20", () => {
+    expect(getLevelBadgeStyle(10)).toBe("bg-emerald-100 text-emerald-700");
+    expect(getLevelBadgeStyle(11)).toBe("bg-emerald-100 text-emerald-700");
+  });
+
+  it("returns emerald-50 for level < 10", () => {
+    expect(getLevelBadgeStyle(0)).toBe("bg-emerald-50 text-emerald-600");
+    expect(getLevelBadgeStyle(1)).toBe("bg-emerald-50 text-emerald-600");
+    expect(getLevelBadgeStyle(9)).toBe("bg-emerald-50 text-emerald-600");
+  });
+
+  it("handles boundary values correctly", () => {
+    // Just below each threshold
+    expect(getLevelBadgeStyle(9)).toBe("bg-emerald-50 text-emerald-600");
+    expect(getLevelBadgeStyle(19)).toBe("bg-emerald-100 text-emerald-700");
+    expect(getLevelBadgeStyle(29)).toBe("bg-emerald-200 text-emerald-800");
+    expect(getLevelBadgeStyle(39)).toBe("bg-emerald-500 text-white");
+  });
+
+  it("handles negative levels", () => {
+    expect(getLevelBadgeStyle(-1)).toBe("bg-emerald-50 text-emerald-600");
+  });
+});
+
+describe("getLevelBadgeColor", () => {
+  it("returns emerald-100 text-emerald-700 for level >= 40", () => {
+    expect(getLevelBadgeColor(40)).toBe("bg-emerald-100 text-emerald-700");
+    expect(getLevelBadgeColor(50)).toBe("bg-emerald-100 text-emerald-700");
+  });
+
+  it("returns emerald-100 text-emerald-700 for level >= 30", () => {
+    expect(getLevelBadgeColor(30)).toBe("bg-emerald-100 text-emerald-700");
+  });
+
+  it("returns emerald-100 text-emerald-700 for level >= 20", () => {
+    expect(getLevelBadgeColor(20)).toBe("bg-emerald-100 text-emerald-700");
+  });
+
+  it("returns emerald-100 text-emerald-700 for level >= 10", () => {
+    expect(getLevelBadgeColor(10)).toBe("bg-emerald-100 text-emerald-700");
+    expect(getLevelBadgeColor(11)).toBe("bg-emerald-100 text-emerald-700");
+  });
+
+  it("returns text-emerald-700 bg-emerald-100 for level < 10", () => {
+    expect(getLevelBadgeColor(0)).toBe("text-emerald-700 bg-emerald-100");
+    expect(getLevelBadgeColor(1)).toBe("text-emerald-700 bg-emerald-100");
+    expect(getLevelBadgeColor(9)).toBe("text-emerald-700 bg-emerald-100");
+  });
+
+  it("handles null level by defaulting to 0", () => {
+    expect(getLevelBadgeColor(null)).toBe("text-emerald-700 bg-emerald-100");
+  });
+
+  it("handles negative levels", () => {
+    expect(getLevelBadgeColor(-5)).toBe("text-emerald-700 bg-emerald-100");
+  });
+});

--- a/src/features/ranking/utils/level-badge-styles.ts
+++ b/src/features/ranking/utils/level-badge-styles.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns CSS classes for level badge styling based on user level.
+ * Used in ranking components to visually differentiate levels.
+ */
+export function getLevelBadgeStyle(level: number): string {
+  if (level >= 40) return "bg-emerald-600 text-white";
+  if (level >= 30) return "bg-emerald-500 text-white";
+  if (level >= 20) return "bg-emerald-200 text-emerald-800";
+  if (level >= 10) return "bg-emerald-100 text-emerald-700";
+  return "bg-emerald-50 text-emerald-600";
+}
+
+/**
+ * Returns CSS classes for level badge color in ranking items.
+ * Accepts nullable level and defaults to 0.
+ */
+export function getLevelBadgeColor(level: number | null): string {
+  const displayLevel = level ?? 0;
+
+  if (displayLevel >= 40) return "bg-emerald-100 text-emerald-700";
+  if (displayLevel >= 30) return "bg-emerald-100 text-emerald-700";
+  if (displayLevel >= 20) return "bg-emerald-100 text-emerald-700";
+  if (displayLevel >= 10) return "bg-emerald-100 text-emerald-700";
+  return "text-emerald-700 bg-emerald-100";
+}


### PR DESCRIPTION
# 変更の概要
- ranking コンポーネント内に重複していた `getLevelBadgeStyle` と `getLevelBadgeColor` を `ranking/utils/level-badge-styles.ts` に統合
- missions コンポーネント内の `getDifficultyStyles` と `difficultyLabels` を `missions/utils/difficulty-styles.ts` に切り出し
- 統合・切り出した各関数のユニットテストを追加（計24テストケース）

# 変更の背景
- `ranking-level-badge.tsx` と `ranking-item.tsx` にそれぞれ別々に定義されていたレベルバッジスタイル関数を utils に統合し、重複を解消
- `difficulty-badge.tsx` 内にインラインで定義されていたスタイル/ラベルロジックを独立した utils に切り出し、テスタビリティを向上

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 難易度バッジとレベルバッジのスタイリング機能に対する包括的なテストを追加しました。これにより、複数のレベル閾値とエッジケースでの動作が検証されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->