### PR TITLE
refactor: getPrefectureInternalLabelをutilsに切り出しテスト追加

### DIFF
--- a/src/features/prefecture-team/components/prefecture-team-user-card-content.tsx
+++ b/src/features/prefecture-team/components/prefecture-team-user-card-content.tsx
@@ -4,13 +4,7 @@ import type {
   UserPrefectureContribution,
 } from "../types/prefecture-team-types";
 import { formatContributionPercent } from "../utils/format-contribution-percent";
-
-function getPrefectureInternalLabel(prefecture: string): string {
-  if (prefecture === "東京都") return "都内";
-  if (prefecture === "北海道") return "道内";
-  if (prefecture.endsWith("府")) return "府内";
-  return "県内";
-}
+import { getPrefectureInternalLabel } from "../utils/prefecture-label";
 
 interface PrefectureTeamUserCardContentProps {
   prefectureRanking: PrefectureTeamRanking;

--- a/src/features/prefecture-team/utils/prefecture-label.test.ts
+++ b/src/features/prefecture-team/utils/prefecture-label.test.ts
@@ -1,0 +1,25 @@
+import { getPrefectureInternalLabel } from "./prefecture-label";
+
+describe("getPrefectureInternalLabel", () => {
+  test("returns 都内 for 東京都", () => {
+    expect(getPrefectureInternalLabel("東京都")).toBe("都内");
+  });
+
+  test("returns 道内 for 北海道", () => {
+    expect(getPrefectureInternalLabel("北海道")).toBe("道内");
+  });
+
+  test("returns 府内 for 大阪府", () => {
+    expect(getPrefectureInternalLabel("大阪府")).toBe("府内");
+  });
+
+  test("returns 府内 for 京都府", () => {
+    expect(getPrefectureInternalLabel("京都府")).toBe("府内");
+  });
+
+  test("returns 県内 for standard prefectures", () => {
+    expect(getPrefectureInternalLabel("神奈川県")).toBe("県内");
+    expect(getPrefectureInternalLabel("愛知県")).toBe("県内");
+    expect(getPrefectureInternalLabel("福岡県")).toBe("県内");
+  });
+});

--- a/src/features/prefecture-team/utils/prefecture-label.ts
+++ b/src/features/prefecture-team/utils/prefecture-label.ts
@@ -1,0 +1,6 @@
+export function getPrefectureInternalLabel(prefecture: string): string {
+  if (prefecture === "東京都") return "都内";
+  if (prefecture === "北海道") return "道内";
+  if (prefecture.endsWith("府")) return "府内";
+  return "県内";
+}


### PR DESCRIPTION
# 変更の概要
- `prefecture-team-user-card-content.tsx` 内の `getPrefectureInternalLabel` 関数を `src/features/prefecture-team/utils/prefecture-label.ts` に切り出し
- 都道府県名から都内/道内/府内/県内への変換ロジックのユニットテストを追加（5ケース）
- コンポーネントは新しいutilsからimportするように更新

# 変更の背景
- テストカバレッジ向上の一環として、コンポーネント内の純粋関数をutils/に切り出しテスト可能にする
- 既存の ranking-utils テストと plans テストは既にdevelopにマージ済みのため、今回は prefecture-label の切り出しとテストのみ

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました