### PR TITLE
test: posting filter helpers 切り出し + テスト追加

### DIFF
--- a/src/features/map-posting/hooks/use-posting-filter.ts
+++ b/src/features/map-posting/hooks/use-posting-filter.ts
@@ -2,6 +2,10 @@
 
 import { useCallback, useState } from "react";
 import type { MapShape } from "../types/posting-types";
+import {
+  isOwnerOfShape as isOwner,
+  shouldShowShape as shouldShow,
+} from "../utils/posting-filter-helpers";
 
 /**
  * フィルター状態を管理するhook
@@ -13,8 +17,7 @@ export function usePostingFilter(userId: string) {
   // シェイプが現在のユーザーのものかどうか判定
   const isOwnerOfShape = useCallback(
     (shape: MapShape | undefined): boolean => {
-      if (!shape) return false;
-      return shape.user_id === userId;
+      return isOwner(shape, userId);
     },
     [userId],
   );
@@ -22,10 +25,9 @@ export function usePostingFilter(userId: string) {
   // フィルター条件に基づいてシェイプを表示すべきか判定
   const shouldShowShape = useCallback(
     (shape: MapShape | undefined): boolean => {
-      if (!showOnlyMine) return true;
-      return isOwnerOfShape(shape);
+      return shouldShow(shape, userId, showOnlyMine);
     },
-    [showOnlyMine, isOwnerOfShape],
+    [showOnlyMine, userId],
   );
 
   // フィルターをトグル

--- a/src/features/map-posting/utils/posting-filter-helpers.test.ts
+++ b/src/features/map-posting/utils/posting-filter-helpers.test.ts
@@ -1,0 +1,59 @@
+import type { MapShape } from "../types/posting-types";
+import { isOwnerOfShape, shouldShowShape } from "./posting-filter-helpers";
+
+const createShape = (userId?: string): MapShape => ({
+  type: "polygon",
+  coordinates: { type: "Polygon", coordinates: [] },
+  user_id: userId,
+});
+
+describe("isOwnerOfShape", () => {
+  it("returns false for undefined shape", () => {
+    expect(isOwnerOfShape(undefined, "user-1")).toBe(false);
+  });
+
+  it("returns true when shape user_id matches userId", () => {
+    const shape = createShape("user-1");
+    expect(isOwnerOfShape(shape, "user-1")).toBe(true);
+  });
+
+  it("returns false when shape user_id does not match userId", () => {
+    const shape = createShape("user-2");
+    expect(isOwnerOfShape(shape, "user-1")).toBe(false);
+  });
+
+  it("returns false when shape has no user_id", () => {
+    const shape = createShape(undefined);
+    expect(isOwnerOfShape(shape, "user-1")).toBe(false);
+  });
+});
+
+describe("shouldShowShape", () => {
+  it("returns true for any shape when showOnlyMine is false", () => {
+    const shape = createShape("user-2");
+    expect(shouldShowShape(shape, "user-1", false)).toBe(true);
+  });
+
+  it("returns true for undefined shape when showOnlyMine is false", () => {
+    expect(shouldShowShape(undefined, "user-1", false)).toBe(true);
+  });
+
+  it("returns true for owned shape when showOnlyMine is true", () => {
+    const shape = createShape("user-1");
+    expect(shouldShowShape(shape, "user-1", true)).toBe(true);
+  });
+
+  it("returns false for non-owned shape when showOnlyMine is true", () => {
+    const shape = createShape("user-2");
+    expect(shouldShowShape(shape, "user-1", true)).toBe(false);
+  });
+
+  it("returns false for undefined shape when showOnlyMine is true", () => {
+    expect(shouldShowShape(undefined, "user-1", true)).toBe(false);
+  });
+
+  it("returns false for shape without user_id when showOnlyMine is true", () => {
+    const shape = createShape(undefined);
+    expect(shouldShowShape(shape, "user-1", true)).toBe(false);
+  });
+});

--- a/src/features/map-posting/utils/posting-filter-helpers.ts
+++ b/src/features/map-posting/utils/posting-filter-helpers.ts
@@ -1,0 +1,26 @@
+import type { MapShape } from "../types/posting-types";
+
+/**
+ * Checks whether a shape belongs to the specified user.
+ */
+export function isOwnerOfShape(
+  shape: MapShape | undefined,
+  userId: string,
+): boolean {
+  if (!shape) return false;
+  return shape.user_id === userId;
+}
+
+/**
+ * Determines whether a shape should be displayed based on the filter setting.
+ * When showOnlyMine is false, all shapes are shown.
+ * When showOnlyMine is true, only shapes owned by the user are shown.
+ */
+export function shouldShowShape(
+  shape: MapShape | undefined,
+  userId: string,
+  showOnlyMine: boolean,
+): boolean {
+  if (!showOnlyMine) return true;
+  return isOwnerOfShape(shape, userId);
+}


### PR DESCRIPTION
# 変更の概要
- `use-posting-filter` フック内の `isOwnerOfShape` / `shouldShowShape` ロジックを `utils/posting-filter-helpers.ts` に純粋関数として切り出し
- 切り出した関数に対するユニットテスト (10 ケース) を追加
- フックは切り出したヘルパーを利用するよう変更

# 変更の背景
- フック内にあったフィルタロジックはReact依存がなく、純粋関数として切り出すことでテスタビリティが向上する
- `isOwnerOfShape`: undefined、一致・不一致・user_id未設定のケースをカバー
- `shouldShowShape`: showOnlyMine の true/false 両方 x 各シェイプパターンをカバー

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [x] CLAの内容を読み、同意しました