### PR TITLE
refactor: sync-likes-coreのマッパー関数をsync-helpersに切り出し

### DIFF
--- a/src/features/youtube/services/sync-likes-core.ts
+++ b/src/features/youtube/services/sync-likes-core.ts
@@ -5,7 +5,11 @@
 
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { hasTeamMiraiTag } from "../constants/team-mirai";
-import { buildLikeVideoRecord, filterNewIds } from "../utils/sync-helpers";
+import {
+  buildLikeVideoRecord,
+  filterNewIds,
+  mapLikedVideoItem,
+} from "../utils/sync-helpers";
 import {
   fetchUserLikedVideos as fetchUserLikedVideosRaw,
   fetchVideoDetails,
@@ -34,16 +38,7 @@ export async function fetchUserLikedVideos(
 ): Promise<LikedVideo[]> {
   const rawItems = await fetchUserLikedVideosRaw(accessToken, maxResults);
 
-  return rawItems.map((item) => ({
-    videoId: item.id,
-    title: item.snippet.title,
-    channelId: item.snippet.channelId,
-    channelTitle: item.snippet.channelTitle,
-    thumbnailUrl:
-      item.snippet.thumbnails.medium?.url ||
-      item.snippet.thumbnails.default?.url,
-    publishedAt: item.snippet.publishedAt,
-  }));
+  return rawItems.map(mapLikedVideoItem);
 }
 
 /**

--- a/src/features/youtube/utils/sync-helpers.ts
+++ b/src/features/youtube/utils/sync-helpers.ts
@@ -1,4 +1,4 @@
-import type { CommentThread } from "../services/youtube-client";
+import type { CommentThread, LikedVideoItem } from "../services/youtube-client";
 
 /**
  * キャッシュされたコメント情報
@@ -11,6 +11,29 @@ export interface CachedComment {
   textDisplay: string | null;
   textOriginal: string | null;
   publishedAt: string;
+}
+
+/**
+ * YouTube APIのいいね動画アイテムをアプリ内の LikedVideo 形式にマッピングする
+ */
+export function mapLikedVideoItem(item: LikedVideoItem): {
+  videoId: string;
+  title: string;
+  channelId: string;
+  channelTitle: string;
+  thumbnailUrl?: string;
+  publishedAt: string;
+} {
+  return {
+    videoId: item.id,
+    title: item.snippet.title,
+    channelId: item.snippet.channelId,
+    channelTitle: item.snippet.channelTitle,
+    thumbnailUrl:
+      item.snippet.thumbnails.medium?.url ||
+      item.snippet.thumbnails.default?.url,
+    publishedAt: item.snippet.publishedAt,
+  };
 }
 
 /**


### PR DESCRIPTION
# 変更の概要
- `sync-likes-core.ts` 内のインライン `LikedVideoItem -> LikedVideo` マッピングロジックを `sync-helpers.ts` の純粋関数 `mapLikedVideoItem` として切り出し
- `sync-likes-core.ts` を新関数を使用するように更新
- `mapLikedVideoItem` のユニットテストを追加（サムネイル優先順位、undefined ケース等）

# 変更の背景
- YouTube同期サービスの変換ロジックを純粋関数として切り出すリファクタリングの一環
- `buildLikeVideoRecord`, `buildCommentCacheRecord`, `filterNewIds`, `groupCommentsByUser` は既に切り出し済み（#2049）
- `parseIdToken` のテストも既に存在（#2049）
- 残っていた `mapLikedVideoItem` を同様のパターンで切り出し

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました