### PR TITLE
refactor: extract avatar validation helpers from profile-actions

### DIFF
--- a/src/features/user-settings/actions/profile-actions.ts
+++ b/src/features/user-settings/actions/profile-actions.ts
@@ -5,8 +5,12 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import { recordSignupActivity } from "@/features/user-activity/services/activity";
+import {
+  extractAvatarPathFromUrl,
+  shouldDeleteOldAvatar,
+  validateAvatarFile,
+} from "@/features/user-settings/utils/avatar-helpers";
 import { PREFECTURES } from "@/lib/constants/prefectures";
-import { AVATAR_MAX_FILE_SIZE } from "@/lib/services/avatar";
 import { createOrUpdateHubSpotContact } from "@/lib/services/hubspot";
 import { sendWelcomeMail } from "@/lib/services/mail";
 import { createAdminClient } from "@/lib/supabase/adminClient";
@@ -131,40 +135,28 @@ export async function updateProfile(
   const avatar_file = formData.get("avatar") as File | null;
 
   // 画像ファイルのバリデーション
-  if (avatar_file && avatar_file.size > 0) {
-    // ファイルサイズのチェック
-    if (avatar_file.size > AVATAR_MAX_FILE_SIZE) {
-      return {
-        success: false,
-        error: "画像ファイルのサイズは5MB以下にしてください",
-      };
-    }
-
-    // ファイルタイプのチェック
-    const allowedTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
-    if (!allowedTypes.includes(avatar_file.type)) {
-      return {
-        success: false,
-        error: "対応している画像形式はJPEG、PNG、WebPです",
-      };
-    }
+  const avatarValidation = validateAvatarFile(avatar_file);
+  if (!avatarValidation.valid) {
+    return {
+      success: false,
+      error: avatarValidation.error,
+    };
   }
 
-  // 古い画像を削除するかチェック:
-  // 1. 画像が削除された場合（avatar_urlがnullになった）
-  // 2. 新しい画像がアップロードされる場合
-  const shouldDeleteOldAvatar =
-    previousAvatarUrl &&
-    (avatar_path === null || (avatar_file && avatar_file.size > 0));
+  // 古い画像を削除するかチェック
+  const needsDeleteOldAvatar = shouldDeleteOldAvatar(
+    previousAvatarUrl,
+    avatar_path,
+    !!(avatar_file && avatar_file.size > 0),
+  );
 
-  if (shouldDeleteOldAvatar) {
+  if (needsDeleteOldAvatar) {
     try {
-      // URLからファイルパスを抽出
-      // 例: https://xxxx.supabase.co/storage/v1/object/public/avatars/userid/12345.jpg
-      const pathMatch = previousAvatarUrl.match(/\/avatars\/(.+)$/);
+      const filePath = previousAvatarUrl
+        ? extractAvatarPathFromUrl(previousAvatarUrl)
+        : null;
 
-      if (pathMatch?.[1]) {
-        const filePath = pathMatch[1];
+      if (filePath) {
         // 古い画像をストレージから削除
         const { error: deleteError } = await supabaseServiceClient.storage
           .from("avatars")

--- a/src/features/user-settings/utils/avatar-helpers.test.ts
+++ b/src/features/user-settings/utils/avatar-helpers.test.ts
@@ -1,0 +1,140 @@
+import {
+  extractAvatarPathFromUrl,
+  shouldDeleteOldAvatar,
+  validateAvatarFile,
+} from "./avatar-helpers";
+
+describe("validateAvatarFile", () => {
+  it("null の場合は valid を返す", () => {
+    expect(validateAvatarFile(null)).toEqual({ valid: true });
+  });
+
+  it("size が 0 の場合は valid を返す", () => {
+    expect(validateAvatarFile({ size: 0, type: "image/png" })).toEqual({
+      valid: true,
+    });
+  });
+
+  it("5MB 以下の JPEG は valid", () => {
+    expect(
+      validateAvatarFile({ size: 1024 * 1024, type: "image/jpeg" }),
+    ).toEqual({ valid: true });
+  });
+
+  it("5MB 以下の JPG は valid", () => {
+    expect(
+      validateAvatarFile({ size: 1024 * 1024, type: "image/jpg" }),
+    ).toEqual({ valid: true });
+  });
+
+  it("5MB 以下の PNG は valid", () => {
+    expect(validateAvatarFile({ size: 1024, type: "image/png" })).toEqual({
+      valid: true,
+    });
+  });
+
+  it("5MB 以下の WebP は valid", () => {
+    expect(validateAvatarFile({ size: 1024, type: "image/webp" })).toEqual({
+      valid: true,
+    });
+  });
+
+  it("5MB 超のファイルはエラーを返す", () => {
+    const result = validateAvatarFile({
+      size: 5 * 1024 * 1024 + 1,
+      type: "image/png",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("画像ファイルのサイズは5MB以下にしてください");
+  });
+
+  it("不正な MIME タイプはエラーを返す (image/gif)", () => {
+    const result = validateAvatarFile({ size: 1024, type: "image/gif" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("対応している画像形式はJPEG、PNG、WebPです");
+  });
+
+  it("不正な MIME タイプはエラーを返す (application/pdf)", () => {
+    const result = validateAvatarFile({
+      size: 1024,
+      type: "application/pdf",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("対応している画像形式はJPEG、PNG、WebPです");
+  });
+});
+
+describe("shouldDeleteOldAvatar", () => {
+  it("previousUrl が null の場合は false", () => {
+    expect(shouldDeleteOldAvatar(null, null, false)).toBe(false);
+  });
+
+  it("previousUrl が null で新しいファイルがある場合も false", () => {
+    expect(shouldDeleteOldAvatar(null, "new/path.jpg", true)).toBe(false);
+  });
+
+  it("previousUrl があり newPath が null の場合は true (画像削除)", () => {
+    expect(
+      shouldDeleteOldAvatar("https://example.com/avatars/old.jpg", null, false),
+    ).toBe(true);
+  });
+
+  it("previousUrl があり hasNewFile が true の場合は true (画像差し替え)", () => {
+    expect(
+      shouldDeleteOldAvatar(
+        "https://example.com/avatars/old.jpg",
+        "new/path.jpg",
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("previousUrl があり newPath も hasNewFile も false でない場合は false", () => {
+    expect(
+      shouldDeleteOldAvatar(
+        "https://example.com/avatars/old.jpg",
+        "existing/path.jpg",
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it("previousUrl があり newPath が null かつ hasNewFile が true の場合は true", () => {
+    expect(
+      shouldDeleteOldAvatar("https://example.com/avatars/old.jpg", null, true),
+    ).toBe(true);
+  });
+});
+
+describe("extractAvatarPathFromUrl", () => {
+  it("正常な Supabase Storage URL からパスを抽出する", () => {
+    expect(
+      extractAvatarPathFromUrl(
+        "https://xxxx.supabase.co/storage/v1/object/public/avatars/userid/12345.jpg",
+      ),
+    ).toBe("userid/12345.jpg");
+  });
+
+  it("ネストしたパスからも正しく抽出する", () => {
+    expect(
+      extractAvatarPathFromUrl(
+        "https://example.com/storage/v1/object/public/avatars/abc/def/image.png",
+      ),
+    ).toBe("abc/def/image.png");
+  });
+
+  it("/avatars/ が含まれない URL は null を返す", () => {
+    expect(
+      extractAvatarPathFromUrl("https://example.com/storage/v1/object/public/"),
+    ).toBeNull();
+  });
+
+  it("空文字列に対しては null を返す", () => {
+    expect(extractAvatarPathFromUrl("")).toBeNull();
+  });
+
+  it("/avatars/ のみで後続パスがない URL は null を返す", () => {
+    // /avatars/ の後に何もない場合、正規表現の (.+)$ はマッチしない
+    expect(extractAvatarPathFromUrl("https://example.com/avatars/")).toBeNull();
+  });
+});

--- a/src/features/user-settings/utils/avatar-helpers.ts
+++ b/src/features/user-settings/utils/avatar-helpers.ts
@@ -1,0 +1,62 @@
+import { AVATAR_MAX_FILE_SIZE } from "@/lib/services/avatar";
+
+const ALLOWED_AVATAR_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+];
+
+/**
+ * アバターファイルのバリデーション
+ * File オブジェクトではなく { size, type } で抽象化し、テストしやすくしている
+ */
+export function validateAvatarFile(
+  file: { size: number; type: string } | null,
+): { valid: boolean; error?: string } {
+  if (!file || file.size === 0) {
+    return { valid: true };
+  }
+
+  if (file.size > AVATAR_MAX_FILE_SIZE) {
+    return {
+      valid: false,
+      error: "画像ファイルのサイズは5MB以下にしてください",
+    };
+  }
+
+  if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
+    return {
+      valid: false,
+      error: "対応している画像形式はJPEG、PNG、WebPです",
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * 旧アバターを削除すべきかどうかを判定する
+ * - 画像が削除された場合（avatar_path が null）
+ * - 新しい画像がアップロードされる場合
+ */
+export function shouldDeleteOldAvatar(
+  previousUrl: string | null,
+  newPath: string | null,
+  hasNewFile: boolean,
+): boolean {
+  if (!previousUrl) {
+    return false;
+  }
+  return newPath === null || hasNewFile;
+}
+
+/**
+ * アバターURLからストレージパスを抽出する
+ * 例: "https://xxxx.supabase.co/storage/v1/object/public/avatars/userid/12345.jpg"
+ *   → "userid/12345.jpg"
+ */
+export function extractAvatarPathFromUrl(url: string): string | null {
+  const match = url.match(/\/avatars\/(.+)$/);
+  return match?.[1] ?? null;
+}


### PR DESCRIPTION
# 変更の概要
- `profile-actions.ts` のインラインアバター処理ロジックを `avatar-helpers.ts` に純粋関数として切り出し
- 3つのヘルパー関数を抽出: `validateAvatarFile`, `shouldDeleteOldAvatar`, `extractAvatarPathFromUrl`
- 20件のユニットテストを追加（カバレッジ100%）

# 変更の背景
- Server Action内のインラインロジックをテスト可能な純粋関数に分離し、保守性・テスタビリティを向上させる
- `File` オブジェクトではなく `{ size, type }` インターフェースで抽象化し、テストしやすい設計にした

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました