### PR TITLE
test: mission_data export transform functions

### DIFF
--- a/mission_data/src/transforms.test.ts
+++ b/mission_data/src/transforms.test.ts
@@ -1,0 +1,320 @@
+import {
+  groupLinksByCategory,
+  transformCategoriesToYaml,
+  transformMissionMainLinksToYaml,
+  transformMissionQuizLinksToYaml,
+  transformMissionsToYaml,
+  transformQuizCategoriesToYaml,
+  transformQuizQuestionsToYaml,
+} from "./transforms";
+
+describe("transformCategoriesToYaml", () => {
+  it("should transform DB rows to Category YAML format", () => {
+    const dbRows = [
+      {
+        slug: "basic",
+        category_title: "基本ミッション",
+        sort_no: 1,
+        category_kbn: "normal",
+      },
+      {
+        slug: "advanced",
+        category_title: null,
+        sort_no: 2,
+        category_kbn: "special",
+      },
+    ];
+
+    const result = transformCategoriesToYaml(dbRows);
+
+    expect(result).toEqual([
+      {
+        slug: "basic",
+        title: "基本ミッション",
+        sort_no: 1,
+        category_kbn: "normal",
+      },
+      { slug: "advanced", title: null, sort_no: 2, category_kbn: "special" },
+    ]);
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(transformCategoriesToYaml([])).toEqual([]);
+  });
+});
+
+describe("transformMissionsToYaml", () => {
+  it("should transform DB rows to Mission YAML format", () => {
+    const dbRows = [
+      {
+        slug: "mission-1",
+        title: "ミッション1",
+        icon_url: "https://example.com/icon.png",
+        content: "テスト内容",
+        difficulty: 3,
+        required_artifact_type: "LINK",
+        max_achievement_count: 1,
+        is_featured: true,
+        is_hidden: false,
+        artifact_label: "URL",
+        ogp_image_url: "https://example.com/ogp.png",
+        event_date: "2025-01-01",
+      },
+    ];
+
+    const result = transformMissionsToYaml(dbRows);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      slug: "mission-1",
+      title: "ミッション1",
+      icon_url: "https://example.com/icon.png",
+      content: "テスト内容",
+      difficulty: 3,
+      required_artifact_type: "LINK",
+      max_achievement_count: 1,
+      is_featured: true,
+      is_hidden: false,
+      artifact_label: "URL",
+      ogp_image_url: "https://example.com/ogp.png",
+      event_date: "2025-01-01",
+    });
+  });
+
+  it("should handle null optional fields", () => {
+    const dbRows = [
+      {
+        slug: "mission-2",
+        title: "ミッション2",
+        icon_url: null,
+        content: null,
+        difficulty: 1,
+        required_artifact_type: "NONE",
+        max_achievement_count: null,
+        is_featured: false,
+        is_hidden: false,
+        artifact_label: null,
+        ogp_image_url: null,
+        event_date: null,
+      },
+    ];
+
+    const result = transformMissionsToYaml(dbRows);
+
+    expect(result[0].icon_url).toBeNull();
+    expect(result[0].content).toBeNull();
+    expect(result[0].max_achievement_count).toBeNull();
+  });
+});
+
+describe("groupLinksByCategory", () => {
+  it("should group links by category slug", () => {
+    const dbRows = [
+      {
+        mission_id: "m1",
+        category_id: "c1",
+        sort_no: 1,
+        missions: { slug: "mission-a" },
+        mission_category: { slug: "basic" },
+      },
+      {
+        mission_id: "m2",
+        category_id: "c1",
+        sort_no: 2,
+        missions: { slug: "mission-b" },
+        mission_category: { slug: "basic" },
+      },
+      {
+        mission_id: "m3",
+        category_id: "c2",
+        sort_no: 1,
+        missions: { slug: "mission-c" },
+        mission_category: { slug: "advanced" },
+      },
+    ];
+
+    const result = groupLinksByCategory(dbRows);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      category_slug: "basic",
+      missions: [
+        { mission_slug: "mission-a", sort_no: 1 },
+        { mission_slug: "mission-b", sort_no: 2 },
+      ],
+    });
+    expect(result[1]).toEqual({
+      category_slug: "advanced",
+      missions: [{ mission_slug: "mission-c", sort_no: 1 }],
+    });
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(groupLinksByCategory([])).toEqual([]);
+  });
+});
+
+describe("transformQuizCategoriesToYaml", () => {
+  it("should transform DB rows to QuizCategory YAML format", () => {
+    const dbRows = [
+      {
+        slug: "politics",
+        name: "政治",
+        description: "政治に関するクイズ",
+        display_order: 1,
+        is_active: true,
+      },
+      {
+        slug: "economy",
+        name: "経済",
+        description: null,
+        display_order: 2,
+        is_active: false,
+      },
+    ];
+
+    const result = transformQuizCategoriesToYaml(dbRows);
+
+    expect(result).toEqual([
+      {
+        slug: "politics",
+        name: "政治",
+        description: "政治に関するクイズ",
+        display_order: 1,
+        is_active: true,
+      },
+      {
+        slug: "economy",
+        name: "経済",
+        description: null,
+        display_order: 2,
+        is_active: false,
+      },
+    ]);
+  });
+});
+
+describe("transformQuizQuestionsToYaml", () => {
+  it("should transform DB rows with joined relations to QuizQuestion YAML format", () => {
+    const dbRows = [
+      {
+        id: "q1",
+        quiz_categories: { slug: "politics" },
+        missions: { slug: "mission-1" },
+        question: "質問1",
+        option1: "選択肢1",
+        option2: "選択肢2",
+        option3: "選択肢3",
+        option4: "選択肢4",
+        correct_answer: 2,
+        explanation: "解説文",
+        question_order: 1,
+        is_active: true,
+      },
+    ];
+
+    const result = transformQuizQuestionsToYaml(dbRows);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "q1",
+      category_slug: "politics",
+      mission_slug: "mission-1",
+      question: "質問1",
+      option1: "選択肢1",
+      option2: "選択肢2",
+      option3: "選択肢3",
+      option4: "選択肢4",
+      correct_answer: 2,
+      explanation: "解説文",
+      question_order: 1,
+      is_active: true,
+    });
+  });
+
+  it("should handle null mission reference", () => {
+    const dbRows = [
+      {
+        id: "q2",
+        quiz_categories: { slug: "economy" },
+        missions: null,
+        question: "質問2",
+        option1: "A",
+        option2: "B",
+        option3: "C",
+        option4: "D",
+        correct_answer: 1,
+        explanation: null,
+        question_order: null,
+        is_active: true,
+      },
+    ];
+
+    const result = transformQuizQuestionsToYaml(dbRows);
+
+    expect(result[0].mission_slug).toBeNull();
+    expect(result[0].explanation).toBeNull();
+  });
+});
+
+describe("transformMissionQuizLinksToYaml", () => {
+  it("should transform DB rows to MissionQuizLink YAML format", () => {
+    const dbRows = [
+      {
+        missions: { slug: "mission-quiz" },
+        link: "https://example.com/quiz",
+        remark: "テスト用",
+        display_order: 1,
+      },
+      {
+        missions: { slug: "mission-quiz-2" },
+        link: "https://example.com/quiz2",
+        remark: null,
+        display_order: 2,
+      },
+    ];
+
+    const result = transformMissionQuizLinksToYaml(dbRows);
+
+    expect(result).toEqual([
+      {
+        mission_slug: "mission-quiz",
+        link: "https://example.com/quiz",
+        remark: "テスト用",
+        display_order: 1,
+      },
+      {
+        mission_slug: "mission-quiz-2",
+        link: "https://example.com/quiz2",
+        remark: null,
+        display_order: 2,
+      },
+    ]);
+  });
+});
+
+describe("transformMissionMainLinksToYaml", () => {
+  it("should transform DB rows to MissionMainLink YAML format", () => {
+    const dbRows = [
+      {
+        missions: { slug: "mission-main" },
+        label: "公式サイト",
+        link: "https://example.com",
+      },
+    ];
+
+    const result = transformMissionMainLinksToYaml(dbRows);
+
+    expect(result).toEqual([
+      {
+        mission_slug: "mission-main",
+        label: "公式サイト",
+        link: "https://example.com",
+      },
+    ]);
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(transformMissionMainLinksToYaml([])).toEqual([]);
+  });
+});

--- a/mission_data/src/transforms.ts
+++ b/mission_data/src/transforms.ts
@@ -1,0 +1,188 @@
+import type {
+  Category,
+  CategoryLink,
+  Mission,
+  MissionMainLink,
+  MissionQuizLink,
+  QuizCategory,
+  QuizQuestion,
+} from "./types";
+
+/**
+ * DB row from mission_category table -> Category YAML format
+ */
+export function transformCategoriesToYaml(
+  data: Array<{
+    slug: string;
+    category_title: string | null;
+    sort_no: number;
+    category_kbn: string;
+  }>,
+): Category[] {
+  return data.map((item) => ({
+    slug: item.slug,
+    title: item.category_title,
+    sort_no: item.sort_no,
+    category_kbn: item.category_kbn,
+  }));
+}
+
+/**
+ * DB row from missions table -> Mission YAML format
+ */
+export function transformMissionsToYaml(
+  data: Array<{
+    slug: string;
+    title: string;
+    icon_url: string | null;
+    content: string | null;
+    difficulty: number;
+    required_artifact_type: string;
+    max_achievement_count: number | null;
+    is_featured: boolean;
+    is_hidden: boolean;
+    artifact_label?: string | null;
+    ogp_image_url?: string | null;
+    event_date?: string | null;
+  }>,
+): Mission[] {
+  return data.map((item) => ({
+    slug: item.slug,
+    title: item.title,
+    icon_url: item.icon_url,
+    content: item.content,
+    difficulty: item.difficulty,
+    required_artifact_type: item.required_artifact_type,
+    max_achievement_count: item.max_achievement_count,
+    is_featured: item.is_featured,
+    is_hidden: item.is_hidden,
+    artifact_label: item.artifact_label,
+    ogp_image_url: item.ogp_image_url,
+    event_date: item.event_date,
+  }));
+}
+
+/**
+ * DB row from mission_category_link (with joins) -> grouped CategoryLink[] YAML format
+ */
+export function groupLinksByCategory(
+  data: Array<{
+    mission_id: string;
+    category_id: string;
+    sort_no: number;
+    missions: { slug: string };
+    mission_category: { slug: string };
+  }>,
+): CategoryLink[] {
+  const linksByCategory = data.reduce(
+    (acc, item) => {
+      const categorySlug = item.mission_category.slug;
+      if (!acc[categorySlug]) {
+        acc[categorySlug] = [];
+      }
+      acc[categorySlug].push({
+        mission_slug: item.missions.slug,
+        sort_no: item.sort_no,
+      });
+      return acc;
+    },
+    {} as Record<string, Array<{ mission_slug: string; sort_no: number }>>,
+  );
+
+  return Object.entries(linksByCategory).map(([category_slug, missions]) => ({
+    category_slug,
+    missions,
+  }));
+}
+
+/**
+ * DB row from quiz_categories table -> QuizCategory YAML format
+ */
+export function transformQuizCategoriesToYaml(
+  data: Array<{
+    slug: string;
+    name: string;
+    description: string | null;
+    display_order: number;
+    is_active: boolean;
+  }>,
+): QuizCategory[] {
+  return data.map((item) => ({
+    slug: item.slug,
+    name: item.name,
+    description: item.description,
+    display_order: item.display_order,
+    is_active: item.is_active,
+  }));
+}
+
+/**
+ * DB row from quiz_questions (with joins) -> QuizQuestion YAML format
+ */
+export function transformQuizQuestionsToYaml(
+  data: Array<{
+    id: string;
+    quiz_categories: { slug: string };
+    missions: { slug: string } | null;
+    question: string;
+    option1: string;
+    option2: string;
+    option3: string;
+    option4: string;
+    correct_answer: number;
+    explanation: string | null;
+    question_order: number | null;
+    is_active: boolean;
+  }>,
+): QuizQuestion[] {
+  return data.map((item) => ({
+    id: item.id,
+    category_slug: item.quiz_categories.slug,
+    mission_slug: item.missions?.slug || null,
+    question: item.question,
+    option1: item.option1,
+    option2: item.option2,
+    option3: item.option3,
+    option4: item.option4,
+    correct_answer: item.correct_answer,
+    explanation: item.explanation,
+    question_order: item.question_order,
+    is_active: item.is_active,
+  }));
+}
+
+/**
+ * DB row from mission_quiz_links (with join) -> MissionQuizLink YAML format
+ */
+export function transformMissionQuizLinksToYaml(
+  data: Array<{
+    missions: { slug: string };
+    link: string;
+    remark: string | null;
+    display_order: number;
+  }>,
+): MissionQuizLink[] {
+  return data.map((item) => ({
+    mission_slug: item.missions.slug,
+    link: item.link,
+    remark: item.remark,
+    display_order: item.display_order,
+  }));
+}
+
+/**
+ * DB row from mission_main_links (with join) -> MissionMainLink YAML format
+ */
+export function transformMissionMainLinksToYaml(
+  data: Array<{
+    missions: { slug: string };
+    label: string;
+    link: string;
+  }>,
+): MissionMainLink[] {
+  return data.map((item) => ({
+    mission_slug: item.missions.slug,
+    label: item.label,
+    link: item.link,
+  }));
+}


### PR DESCRIPTION
# 変更の概要
- mission_data/src/export.ts から純粋なDB→YAML変換ロジックを mission_data/src/transforms.ts に切り出し
- 7つの変換関数に対して12のユニットテストを追加

切り出した関数:
- `transformCategoriesToYaml` - カテゴリDB行→YAML形式
- `transformMissionsToYaml` - ミッションDB行→YAML形式
- `groupLinksByCategory` - カテゴリリンクをカテゴリ別にグループ化
- `transformQuizCategoriesToYaml` - クイズカテゴリDB行→YAML形式
- `transformQuizQuestionsToYaml` - クイズ問題DB行→YAML形式
- `transformMissionQuizLinksToYaml` - クイズリンクDB行→YAML形式
- `transformMissionMainLinksToYaml` - メインリンクDB行→YAML形式

# 変更の背景
- export.tsのDB取得と変換ロジックが混在しており、変換ロジックのテストが困難だった
- 純粋関数として切り出すことで、DBモック不要でテスト可能に

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました