### PR TITLE
refactor: ポスターマップのマーカーアイコン生成ロジックをutilsに切り出し

### DIFF
--- a/src/features/map-poster/components/poster-map-with-cluster.tsx
+++ b/src/features/map-poster/components/poster-map-with-cluster.tsx
@@ -17,6 +17,11 @@ import {
 } from "../constants/poster-prefectures";
 import { usePosterBoardFilterOptimized } from "../hooks/use-poster-board-filter-optimized";
 import { getCurrentUserId } from "../services/poster-boards";
+import {
+  createMarkerIconHtml,
+  createPieSegments,
+  statusColors,
+} from "../utils/marker-icons";
 import { PosterBoardFilter } from "./poster-board-filter";
 
 // Fix Leaflet default marker icon issue with Next.js
@@ -45,33 +50,10 @@ interface PosterMapWithClusterProps {
   defaultZoom?: number;
 }
 
-// Status colors for markers
-const statusColors: Record<BoardStatus, string> = {
-  not_yet: "#6B7280", // gray
-  not_yet_dangerous: "#6B7280", // gray
-  reserved: "#F59E0B", // yellow/orange
-  done: "#10B981", // green
-  error_wrong_place: "#EF4444", // red
-  error_damaged: "#EF4444", // red
-  error_wrong_poster: "#EF4444", // red
-  other: "#8B5CF6", // purple
-};
-
 // Create custom marker icon with status color
 function createMarkerIcon(status: BoardStatus) {
-  const color = statusColors[status];
-
   return L.divIcon({
-    html: `
-      <div style="
-        background-color: ${color};
-        width: 20px;
-        height: 20px;
-        border-radius: 50%;
-        border: 2px solid white;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-      "></div>
-    `,
+    html: createMarkerIconHtml(status),
     className: "custom-marker",
     iconSize: [20, 20],
     iconAnchor: [10, 10],
@@ -81,73 +63,6 @@ function createMarkerIcon(status: BoardStatus) {
 // Extend marker interface to include board data
 interface MarkerWithBoard extends L.Marker {
   boardData?: PosterBoard;
-}
-
-// Create pie chart segments for cluster using simpler approach
-function createPieSegments(
-  statusCounts: Record<BoardStatus, number>,
-  total: number,
-  size: number,
-) {
-  const statusOrder: BoardStatus[] = [
-    "done",
-    "reserved",
-    "not_yet",
-    "not_yet_dangerous",
-    "error_wrong_place",
-    "error_damaged",
-    "error_wrong_poster",
-    "other",
-  ];
-
-  const segments: string[] = [];
-  const radius = (size - 6) / 2; // Account for border
-  const center = size / 2;
-
-  // Start from top (-90 degrees)
-  let cumulativePercentage = 0;
-
-  for (const status of statusOrder) {
-    const count = statusCounts[status];
-    if (count === 0) continue;
-
-    const percentage = count / total;
-
-    if (percentage >= 1) {
-      // Full circle
-      segments.push(
-        `<circle cx="${center}" cy="${center}" r="${radius}" fill="${statusColors[status]}" />`,
-      );
-      break;
-    }
-
-    // Calculate stroke-dasharray for this segment
-    const circumference = 2 * Math.PI * radius;
-    const strokeLength = circumference * percentage;
-    const gapLength = circumference - strokeLength;
-
-    // Rotate the circle so this segment appears at the right position
-    const rotation = cumulativePercentage * 360 - 90; // -90 to start from top
-
-    segments.push(`
-      <circle
-        cx="${center}"
-        cy="${center}"
-        r="${radius}"
-        fill="none"
-        stroke="${statusColors[status]}"
-        stroke-width="${radius * 2}"
-        stroke-dasharray="${strokeLength} ${gapLength}"
-        stroke-dashoffset="0"
-        transform="rotate(${rotation} ${center} ${center})"
-        opacity="1"
-      />
-    `);
-
-    cumulativePercentage += percentage;
-  }
-
-  return segments.join("");
 }
 
 // Create custom cluster icon with pie chart

--- a/src/features/map-poster/utils/marker-icons.test.ts
+++ b/src/features/map-poster/utils/marker-icons.test.ts
@@ -1,0 +1,99 @@
+import type { Database } from "@/lib/types/supabase";
+import {
+  createMarkerIconHtml,
+  createPieSegments,
+  statusColors,
+} from "./marker-icons";
+
+type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
+
+function makeStatusCounts(
+  overrides: Partial<Record<BoardStatus, number>> = {},
+): Record<BoardStatus, number> {
+  return {
+    not_yet: 0,
+    not_yet_dangerous: 0,
+    reserved: 0,
+    done: 0,
+    error_wrong_place: 0,
+    error_damaged: 0,
+    error_wrong_poster: 0,
+    other: 0,
+    ...overrides,
+  };
+}
+
+describe("createMarkerIconHtml", () => {
+  it("returns HTML with the correct color for 'done' status", () => {
+    const html = createMarkerIconHtml("done");
+    expect(html).toContain(`background-color: ${statusColors.done}`);
+    expect(html).toContain("border-radius: 50%");
+  });
+
+  it("returns HTML with the correct color for 'reserved' status", () => {
+    const html = createMarkerIconHtml("reserved");
+    expect(html).toContain(`background-color: ${statusColors.reserved}`);
+  });
+
+  it("returns HTML with the correct color for 'not_yet' status", () => {
+    const html = createMarkerIconHtml("not_yet");
+    expect(html).toContain(`background-color: ${statusColors.not_yet}`);
+  });
+
+  it("returns HTML with the correct color for error statuses", () => {
+    const html = createMarkerIconHtml("error_wrong_place");
+    expect(html).toContain(
+      `background-color: ${statusColors.error_wrong_place}`,
+    );
+  });
+});
+
+describe("createPieSegments", () => {
+  it("returns a full circle when only one status has all counts", () => {
+    const counts = makeStatusCounts({ done: 10 });
+    const result = createPieSegments(counts, 10, 40);
+
+    expect(result).toContain("<circle");
+    expect(result).toContain(`fill="${statusColors.done}"`);
+    // Should be a filled circle, not a stroke-based segment
+    expect(result).not.toContain("stroke-dasharray");
+  });
+
+  it("returns segments for multiple statuses", () => {
+    const counts = makeStatusCounts({ done: 5, reserved: 3, not_yet: 2 });
+    const result = createPieSegments(counts, 10, 40);
+
+    expect(result).toContain(`stroke="${statusColors.done}"`);
+    expect(result).toContain(`stroke="${statusColors.reserved}"`);
+    expect(result).toContain(`stroke="${statusColors.not_yet}"`);
+    expect(result).toContain("stroke-dasharray");
+  });
+
+  it("returns empty string when all counts are zero", () => {
+    const counts = makeStatusCounts();
+    const result = createPieSegments(counts, 0, 40);
+
+    expect(result).toBe("");
+  });
+
+  it("calculates correct radius and center for given size", () => {
+    const size = 50;
+    const counts = makeStatusCounts({ done: 10 });
+    const result = createPieSegments(counts, 10, size);
+
+    const expectedRadius = (size - 6) / 2; // 22
+    const expectedCenter = size / 2; // 25
+    expect(result).toContain(`cx="${expectedCenter}"`);
+    expect(result).toContain(`cy="${expectedCenter}"`);
+    expect(result).toContain(`r="${expectedRadius}"`);
+  });
+
+  it("skips statuses with zero counts", () => {
+    const counts = makeStatusCounts({ done: 5, other: 5 });
+    const result = createPieSegments(counts, 10, 40);
+
+    // Should not contain colors for statuses with 0 count
+    expect(result).not.toContain(`stroke="${statusColors.reserved}"`);
+    expect(result).not.toContain(`stroke="${statusColors.not_yet}"`);
+  });
+});

--- a/src/features/map-poster/utils/marker-icons.ts
+++ b/src/features/map-poster/utils/marker-icons.ts
@@ -1,0 +1,103 @@
+import type { Database } from "@/lib/types/supabase";
+
+type BoardStatus = Database["public"]["Enums"]["poster_board_status"];
+
+/** Status colors for poster board markers */
+export const statusColors: Record<BoardStatus, string> = {
+  not_yet: "#6B7280", // gray
+  not_yet_dangerous: "#6B7280", // gray
+  reserved: "#F59E0B", // yellow/orange
+  done: "#10B981", // green
+  error_wrong_place: "#EF4444", // red
+  error_damaged: "#EF4444", // red
+  error_wrong_poster: "#EF4444", // red
+  other: "#8B5CF6", // purple
+};
+
+/**
+ * Create an HTML string for a circular marker icon with a status-based color.
+ */
+export function createMarkerIconHtml(status: BoardStatus): string {
+  const color = statusColors[status];
+
+  return `
+      <div style="
+        background-color: ${color};
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 2px solid white;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+      "></div>
+    `;
+}
+
+const statusOrder: BoardStatus[] = [
+  "done",
+  "reserved",
+  "not_yet",
+  "not_yet_dangerous",
+  "error_wrong_place",
+  "error_damaged",
+  "error_wrong_poster",
+  "other",
+];
+
+/**
+ * Create SVG pie chart segments string from status counts.
+ * Each segment represents the proportion of boards with that status.
+ */
+export function createPieSegments(
+  statusCounts: Record<BoardStatus, number>,
+  total: number,
+  size: number,
+): string {
+  const segments: string[] = [];
+  const radius = (size - 6) / 2; // Account for border
+  const center = size / 2;
+
+  // Start from top (-90 degrees)
+  let cumulativePercentage = 0;
+
+  for (const status of statusOrder) {
+    const count = statusCounts[status];
+    if (count === 0) continue;
+
+    const percentage = count / total;
+
+    if (percentage >= 1) {
+      // Full circle
+      segments.push(
+        `<circle cx="${center}" cy="${center}" r="${radius}" fill="${statusColors[status]}" />`,
+      );
+      break;
+    }
+
+    // Calculate stroke-dasharray for this segment
+    const circumference = 2 * Math.PI * radius;
+    const strokeLength = circumference * percentage;
+    const gapLength = circumference - strokeLength;
+
+    // Rotate the circle so this segment appears at the right position
+    const rotation = cumulativePercentage * 360 - 90; // -90 to start from top
+
+    segments.push(`
+      <circle
+        cx="${center}"
+        cy="${center}"
+        r="${radius}"
+        fill="none"
+        stroke="${statusColors[status]}"
+        stroke-width="${radius * 2}"
+        stroke-dasharray="${strokeLength} ${gapLength}"
+        stroke-dashoffset="0"
+        transform="rotate(${rotation} ${center} ${center})"
+        opacity="1"
+      />
+    `);
+
+    cumulativePercentage += percentage;
+  }
+
+  return segments.join("");
+}


### PR DESCRIPTION
# 変更の概要
- `poster-map-with-cluster.tsx` から SVG/HTML マーカーアイコン生成ロジックを `utils/marker-icons.ts` に切り出し
- `statusColors`, `createMarkerIconHtml`, `createPieSegments` を独立したユーティリティ関数として抽出
- 9件のユニットテストを追加（カバレッジ100%）

# 変更の背景
- コンポーネントファイルに含まれていた純粋な文字列生成ロジックをutilsに分離することで、テスタビリティと再利用性を向上
- Leaflet の `L.divIcon` 依存部分はコンポーネント内に残し、SVG/HTML文字列生成のみを切り出し

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました