### PR TITLE
refactor: YouTubeいいね・動画統計の変換ロジックをutils層に切り出し

### DIFF
--- a/src/features/youtube/actions/youtube-like-actions.ts
+++ b/src/features/youtube/actions/youtube-like-actions.ts
@@ -11,6 +11,7 @@ import {
   isTokenExpired,
   type LikedVideo,
 } from "../services/youtube-like-service";
+import { transformValidLikesToRecordedLikes } from "../utils/like-video-transformers";
 import { refreshYouTubeTokenAction } from "./youtube-auth-actions";
 
 /**
@@ -311,20 +312,9 @@ export async function getRecordedLikesAction(): Promise<{
       };
     }
 
-    const recordedLikes: RecordedLike[] = (likes || [])
-      .filter((like) => like.youtube_videos)
-      .map((like) => ({
-        videoId: like.video_id,
-        title: like.youtube_videos?.title || "Unknown",
-        channelTitle: like.youtube_videos?.channel_title || undefined,
-        thumbnailUrl: like.youtube_videos?.thumbnail_url || undefined,
-        videoUrl:
-          like.youtube_videos?.video_url ||
-          `https://www.youtube.com/watch?v=${like.video_id}`,
-        publishedAt: like.youtube_videos?.published_at || undefined,
-        recordedAt:
-          like.detected_at || like.created_at || new Date().toISOString(),
-      }));
+    const recordedLikes = transformValidLikesToRecordedLikes(
+      (likes || []) as Parameters<typeof transformValidLikesToRecordedLikes>[0],
+    );
 
     return {
       success: true,

--- a/src/features/youtube/actions/youtube-video-actions.ts
+++ b/src/features/youtube/actions/youtube-video-actions.ts
@@ -7,6 +7,7 @@ import {
   type YouTubeSyncResult,
 } from "../services/youtube-video-service";
 import type { YouTubeLinkStatus, YouTubeVideoWithStats } from "../types";
+import { enrichVideosWithLatestStats } from "../utils/like-video-transformers";
 import { refreshYouTubeTokenAction } from "./youtube-auth-actions";
 
 /**
@@ -136,42 +137,8 @@ export async function getMyUploadedVideosAction(
     }
 
     // 各動画の最新統計を整形
-    const videosWithStats: YouTubeVideoWithStats[] = (videos || []).map(
-      (video) => {
-        const stats = video.youtube_video_stats as Array<{
-          view_count: number | null;
-          like_count: number | null;
-          comment_count: number | null;
-          recorded_at: string;
-        }>;
-
-        // 最新の統計を取得
-        const latestStats = stats?.sort(
-          (a, b) =>
-            new Date(b.recorded_at).getTime() -
-            new Date(a.recorded_at).getTime(),
-        )[0];
-
-        return {
-          video_id: video.video_id,
-          video_url: video.video_url,
-          title: video.title,
-          description: video.description,
-          thumbnail_url: video.thumbnail_url,
-          channel_id: video.channel_id,
-          channel_title: video.channel_title,
-          published_at: video.published_at,
-          duration: video.duration,
-          tags: video.tags,
-          is_active: video.is_active,
-          created_at: video.created_at,
-          updated_at: video.updated_at,
-          comments_synced_at: video.comments_synced_at,
-          latest_view_count: latestStats?.view_count ?? null,
-          latest_like_count: latestStats?.like_count ?? null,
-          latest_comment_count: latestStats?.comment_count ?? null,
-        };
-      },
+    const videosWithStats = enrichVideosWithLatestStats(
+      (videos || []) as Parameters<typeof enrichVideosWithLatestStats>[0],
     );
 
     return {

--- a/src/features/youtube/utils/like-video-transformers.test.ts
+++ b/src/features/youtube/utils/like-video-transformers.test.ts
@@ -1,0 +1,265 @@
+import {
+  enrichVideosWithLatestStats,
+  transformValidLikesToRecordedLikes,
+} from "./like-video-transformers";
+
+describe("transformValidLikesToRecordedLikes", () => {
+  const baseLike = {
+    video_id: "video-1",
+    detected_at: "2025-01-15T10:00:00Z" as string | null,
+    created_at: "2025-01-15T09:00:00Z" as string | null,
+    youtube_videos: {
+      title: "Test Video",
+      channel_title: "Test Channel",
+      video_url: "https://www.youtube.com/watch?v=video-1" as string | null,
+      thumbnail_url: "https://img.youtube.com/thumb.jpg" as string | null,
+      published_at: "2024-12-01T00:00:00Z" as string | null,
+    },
+  };
+
+  it("should transform a like with full video data", () => {
+    const result = transformValidLikesToRecordedLikes([baseLike]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      videoId: "video-1",
+      title: "Test Video",
+      channelTitle: "Test Channel",
+      thumbnailUrl: "https://img.youtube.com/thumb.jpg",
+      videoUrl: "https://www.youtube.com/watch?v=video-1",
+      publishedAt: "2024-12-01T00:00:00Z",
+      recordedAt: "2025-01-15T10:00:00Z",
+    });
+  });
+
+  it("should filter out likes where youtube_videos is null", () => {
+    const likes = [
+      baseLike,
+      { ...baseLike, video_id: "video-2", youtube_videos: null },
+    ];
+
+    const result = transformValidLikesToRecordedLikes(likes);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].videoId).toBe("video-1");
+  });
+
+  it("should use 'Unknown' title when title is missing", () => {
+    const like = {
+      ...baseLike,
+      youtube_videos: { ...baseLike.youtube_videos!, title: "" },
+    };
+
+    // Empty string is falsy, so it should fallback to "Unknown"
+    const result = transformValidLikesToRecordedLikes([like]);
+    expect(result[0].title).toBe("Unknown");
+  });
+
+  it("should generate fallback URL when video_url is null", () => {
+    const like = {
+      ...baseLike,
+      youtube_videos: { ...baseLike.youtube_videos!, video_url: null },
+    };
+
+    const result = transformValidLikesToRecordedLikes([like]);
+
+    expect(result[0].videoUrl).toBe("https://www.youtube.com/watch?v=video-1");
+  });
+
+  it("should use undefined for optional null fields", () => {
+    const like = {
+      ...baseLike,
+      youtube_videos: {
+        ...baseLike.youtube_videos!,
+        channel_title: "",
+        thumbnail_url: null,
+        published_at: null,
+      },
+    };
+
+    const result = transformValidLikesToRecordedLikes([like]);
+
+    expect(result[0].channelTitle).toBeUndefined();
+    expect(result[0].thumbnailUrl).toBeUndefined();
+    expect(result[0].publishedAt).toBeUndefined();
+  });
+
+  it("should fallback to created_at when detected_at is null", () => {
+    const like = { ...baseLike, detected_at: null };
+
+    const result = transformValidLikesToRecordedLikes([like]);
+
+    expect(result[0].recordedAt).toBe("2025-01-15T09:00:00Z");
+  });
+
+  it("should fallback to current date when both detected_at and created_at are null", () => {
+    const now = new Date("2025-06-01T00:00:00Z");
+    jest.useFakeTimers({ now });
+
+    const like = { ...baseLike, detected_at: null, created_at: null };
+
+    const result = transformValidLikesToRecordedLikes([like]);
+
+    expect(result[0].recordedAt).toBe("2025-06-01T00:00:00.000Z");
+
+    jest.useRealTimers();
+  });
+});
+
+describe("enrichVideosWithLatestStats", () => {
+  const baseVideo = {
+    video_id: "video-1",
+    video_url: "https://www.youtube.com/watch?v=video-1",
+    title: "Test Video",
+    description: "A test video" as string | null,
+    thumbnail_url: "https://img.youtube.com/thumb.jpg" as string | null,
+    channel_id: "channel-1",
+    channel_title: "Test Channel",
+    published_at: "2024-12-01T00:00:00Z",
+    duration: "PT10M30S" as string | null,
+    tags: ["test", "video"] as string[] | null,
+    is_active: true,
+    created_at: "2024-12-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    comments_synced_at: null as string | null,
+    youtube_video_stats: [
+      {
+        view_count: 1000 as number | null,
+        like_count: 50 as number | null,
+        comment_count: 10 as number | null,
+        recorded_at: "2025-01-01T00:00:00Z",
+      },
+    ],
+  };
+
+  it("should enrich video with latest stats", () => {
+    const result = enrichVideosWithLatestStats([baseVideo]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].latest_view_count).toBe(1000);
+    expect(result[0].latest_like_count).toBe(50);
+    expect(result[0].latest_comment_count).toBe(10);
+  });
+
+  it("should select the most recent stats entry", () => {
+    const video = {
+      ...baseVideo,
+      youtube_video_stats: [
+        {
+          view_count: 500,
+          like_count: 20,
+          comment_count: 5,
+          recorded_at: "2025-01-01T00:00:00Z",
+        },
+        {
+          view_count: 1500,
+          like_count: 80,
+          comment_count: 25,
+          recorded_at: "2025-01-10T00:00:00Z",
+        },
+        {
+          view_count: 800,
+          like_count: 30,
+          comment_count: 8,
+          recorded_at: "2025-01-05T00:00:00Z",
+        },
+      ],
+    };
+
+    const result = enrichVideosWithLatestStats([video]);
+
+    expect(result[0].latest_view_count).toBe(1500);
+    expect(result[0].latest_like_count).toBe(80);
+    expect(result[0].latest_comment_count).toBe(25);
+  });
+
+  it("should return null stats when stats array is empty", () => {
+    const video = { ...baseVideo, youtube_video_stats: [] };
+
+    const result = enrichVideosWithLatestStats([video]);
+
+    expect(result[0].latest_view_count).toBeNull();
+    expect(result[0].latest_like_count).toBeNull();
+    expect(result[0].latest_comment_count).toBeNull();
+  });
+
+  it("should preserve all video fields in the output", () => {
+    const result = enrichVideosWithLatestStats([baseVideo]);
+
+    expect(result[0].video_id).toBe("video-1");
+    expect(result[0].video_url).toBe("https://www.youtube.com/watch?v=video-1");
+    expect(result[0].title).toBe("Test Video");
+    expect(result[0].description).toBe("A test video");
+    expect(result[0].channel_id).toBe("channel-1");
+    expect(result[0].channel_title).toBe("Test Channel");
+    expect(result[0].duration).toBe("PT10M30S");
+    expect(result[0].tags).toEqual(["test", "video"]);
+    expect(result[0].is_active).toBe(true);
+  });
+
+  it("should handle null stat values in the latest entry", () => {
+    const video = {
+      ...baseVideo,
+      youtube_video_stats: [
+        {
+          view_count: null,
+          like_count: null,
+          comment_count: null,
+          recorded_at: "2025-01-01T00:00:00Z",
+        },
+      ],
+    };
+
+    const result = enrichVideosWithLatestStats([video]);
+
+    expect(result[0].latest_view_count).toBeNull();
+    expect(result[0].latest_like_count).toBeNull();
+    expect(result[0].latest_comment_count).toBeNull();
+  });
+
+  it("should handle null optional video fields", () => {
+    const video = {
+      ...baseVideo,
+      description: null,
+      thumbnail_url: null,
+      duration: null,
+      tags: null,
+      comments_synced_at: null,
+    };
+
+    const result = enrichVideosWithLatestStats([video]);
+
+    expect(result[0].description).toBeNull();
+    expect(result[0].thumbnail_url).toBeNull();
+    expect(result[0].duration).toBeNull();
+    expect(result[0].tags).toBeNull();
+    expect(result[0].comments_synced_at).toBeNull();
+  });
+
+  it("should handle multiple videos", () => {
+    const videos = [
+      baseVideo,
+      {
+        ...baseVideo,
+        video_id: "video-2",
+        title: "Second Video",
+        youtube_video_stats: [
+          {
+            view_count: 2000,
+            like_count: 100,
+            comment_count: 20,
+            recorded_at: "2025-01-02T00:00:00Z",
+          },
+        ],
+      },
+    ];
+
+    const result = enrichVideosWithLatestStats(videos);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].video_id).toBe("video-1");
+    expect(result[0].latest_view_count).toBe(1000);
+    expect(result[1].video_id).toBe("video-2");
+    expect(result[1].latest_view_count).toBe(2000);
+  });
+});

--- a/src/features/youtube/utils/like-video-transformers.ts
+++ b/src/features/youtube/utils/like-video-transformers.ts
@@ -1,0 +1,95 @@
+import type { RecordedLike } from "../actions/youtube-like-actions";
+import type { YouTubeVideoWithStats } from "../types";
+
+/**
+ * DBから取得したいいね記録を、youtube_videos情報が存在するものだけフィルタして
+ * RecordedLike形式に変換する
+ */
+export function transformValidLikesToRecordedLikes(
+  likes: Array<{
+    video_id: string;
+    detected_at: string | null;
+    created_at: string | null;
+    youtube_videos: {
+      title: string;
+      channel_title: string;
+      video_url: string | null;
+      thumbnail_url: string | null;
+      published_at: string | null;
+    } | null;
+  }>,
+): RecordedLike[] {
+  return likes
+    .filter((like) => like.youtube_videos)
+    .map((like) => ({
+      videoId: like.video_id,
+      title: like.youtube_videos?.title || "Unknown",
+      channelTitle: like.youtube_videos?.channel_title || undefined,
+      thumbnailUrl: like.youtube_videos?.thumbnail_url || undefined,
+      videoUrl:
+        like.youtube_videos?.video_url ||
+        `https://www.youtube.com/watch?v=${like.video_id}`,
+      publishedAt: like.youtube_videos?.published_at || undefined,
+      recordedAt:
+        like.detected_at || like.created_at || new Date().toISOString(),
+    }));
+}
+
+/**
+ * youtube_videosに関連するyoutube_video_statsから最新の統計情報を付加して
+ * YouTubeVideoWithStats形式に変換する
+ */
+export function enrichVideosWithLatestStats(
+  videos: Array<{
+    video_id: string;
+    video_url: string;
+    title: string;
+    description: string | null;
+    thumbnail_url: string | null;
+    channel_id: string;
+    channel_title: string;
+    published_at: string;
+    duration: string | null;
+    tags: string[] | null;
+    is_active: boolean;
+    created_at: string;
+    updated_at: string;
+    comments_synced_at: string | null;
+    youtube_video_stats: Array<{
+      view_count: number | null;
+      like_count: number | null;
+      comment_count: number | null;
+      recorded_at: string;
+    }>;
+  }>,
+): YouTubeVideoWithStats[] {
+  return videos.map((video) => {
+    const stats = video.youtube_video_stats;
+
+    // 最新の統計を取得
+    const latestStats = stats?.sort(
+      (a, b) =>
+        new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime(),
+    )[0];
+
+    return {
+      video_id: video.video_id,
+      video_url: video.video_url,
+      title: video.title,
+      description: video.description,
+      thumbnail_url: video.thumbnail_url,
+      channel_id: video.channel_id,
+      channel_title: video.channel_title,
+      published_at: video.published_at,
+      duration: video.duration,
+      tags: video.tags,
+      is_active: video.is_active,
+      created_at: video.created_at,
+      updated_at: video.updated_at,
+      comments_synced_at: video.comments_synced_at,
+      latest_view_count: latestStats?.view_count ?? null,
+      latest_like_count: latestStats?.like_count ?? null,
+      latest_comment_count: latestStats?.comment_count ?? null,
+    };
+  });
+}


### PR DESCRIPTION
# 変更の概要
- `youtube-like-actions.ts`のいいね変換ロジックと`youtube-video-actions.ts`の動画統計enrich ロジックを`like-video-transformers.ts`に切り出し
  - `transformValidLikesToRecordedLikes`: DB行をRecordedLike形式に変換（youtube_videosがnullのものをフィルタ）
  - `enrichVideosWithLatestStats`: 動画にyoutube_video_statsから最新統計情報を付加
- テスト14件を追加（100%カバレッジ）

# 変更の背景
- Server Action内のインライン`.filter().map()`/`.map()`ロジックをテスト可能な純粋関数として切り出し、テスタビリティと保守性を向上

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました