### PR TITLE
refactor: extract batch/join helper functions into batch-helpers

### DIFF
--- a/src/app/api/batch/backfill-missing-xp/route.ts
+++ b/src/app/api/batch/backfill-missing-xp/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { grantXpBatch } from "@/features/user-level/services/level";
 import { calculateMissionXp } from "@/features/user-level/utils/level-calculator";
 import { createAdminClient } from "@/lib/supabase/adminClient";
+import { normalizeJoinResult } from "@/lib/utils/batch-helpers";
 import { executeChunkedQuery } from "@/lib/utils/supabase-utils";
 
 // 型定義を明示（Supabaseの!innerJOINが配列を返す可能性を考慮）
@@ -174,9 +175,7 @@ export async function POST(request: NextRequest) {
 
     // 各達成のデータを検証してバッチに追加
     for (const achievement of missingXpAchievements) {
-      const mission = Array.isArray(achievement.missions)
-        ? achievement.missions[0]
-        : achievement.missions;
+      const mission = normalizeJoinResult(achievement.missions);
 
       if (!mission) {
         console.warn(

--- a/src/features/youtube/actions/youtube-sync-actions.ts
+++ b/src/features/youtube/actions/youtube-sync-actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { joinNonEmptyStrings } from "@/lib/utils/batch-helpers";
 import { syncYouTubeCommentsAction } from "./youtube-comment-actions";
 import {
   type SyncLikesResult,
@@ -51,6 +52,6 @@ export async function syncAllYouTubeDataAction(): Promise<SyncAllResult> {
     totalXpGranted,
     error: success
       ? undefined
-      : [likesResult.error, commentsResult.error].filter(Boolean).join("; "),
+      : joinNonEmptyStrings("; ", likesResult.error, commentsResult.error),
   };
 }

--- a/src/lib/utils/batch-helpers.test.ts
+++ b/src/lib/utils/batch-helpers.test.ts
@@ -1,0 +1,62 @@
+import { joinNonEmptyStrings, normalizeJoinResult } from "./batch-helpers";
+
+describe("normalizeJoinResult", () => {
+  it("単一オブジェクトの場合はそのまま返す", () => {
+    const obj = { id: "1", title: "test" };
+    expect(normalizeJoinResult(obj)).toBe(obj);
+  });
+
+  it("配列の場合は先頭要素を返す", () => {
+    const arr = [
+      { id: "1", title: "first" },
+      { id: "2", title: "second" },
+    ];
+    expect(normalizeJoinResult(arr)).toEqual({ id: "1", title: "first" });
+  });
+
+  it("空配列の場合は null を返す", () => {
+    expect(normalizeJoinResult([])).toBeNull();
+  });
+
+  it("null の場合は null を返す", () => {
+    expect(normalizeJoinResult(null)).toBeNull();
+  });
+
+  it("undefined の場合は null を返す", () => {
+    expect(normalizeJoinResult(undefined)).toBeNull();
+  });
+});
+
+describe("joinNonEmptyStrings", () => {
+  it("複数の有効な文字列をセパレータで結合する", () => {
+    expect(joinNonEmptyStrings("; ", "error1", "error2")).toBe(
+      "error1; error2",
+    );
+  });
+
+  it("null/undefined を除外して結合する", () => {
+    expect(joinNonEmptyStrings("; ", "error1", null, undefined, "error2")).toBe(
+      "error1; error2",
+    );
+  });
+
+  it("空文字列を除外して結合する", () => {
+    expect(joinNonEmptyStrings("; ", "", "error1", "", "error2")).toBe(
+      "error1; error2",
+    );
+  });
+
+  it("すべてが null/undefined/空文字列の場合は undefined を返す", () => {
+    expect(joinNonEmptyStrings("; ", null, undefined, "")).toBeUndefined();
+  });
+
+  it("単一の有効な値の場合はその値をそのまま返す", () => {
+    expect(joinNonEmptyStrings("; ", null, "only-error", undefined)).toBe(
+      "only-error",
+    );
+  });
+
+  it("値が一つもない場合は undefined を返す", () => {
+    expect(joinNonEmptyStrings("; ")).toBeUndefined();
+  });
+});

--- a/src/lib/utils/batch-helpers.ts
+++ b/src/lib/utils/batch-helpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Supabase の !inner JOIN 結果を正規化する。
+ * JOIN 結果が配列の場合は先頭要素、単一オブジェクトの場合はそのまま返す。
+ * null/undefined の場合は null を返す。
+ */
+export function normalizeJoinResult<T>(
+  data: T | T[] | null | undefined,
+): T | null {
+  if (data == null) {
+    return null;
+  }
+  if (Array.isArray(data)) {
+    return data[0] ?? null;
+  }
+  return data;
+}
+
+/**
+ * null/undefined/空文字列を除外して、指定セパレータで結合する。
+ * 結合後の文字列が空の場合は undefined を返す。
+ */
+export function joinNonEmptyStrings(
+  separator: string,
+  ...values: (string | undefined | null)[]
+): string | undefined {
+  const filtered = values.filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+  return filtered.length > 0 ? filtered.join(separator) : undefined;
+}


### PR DESCRIPTION
# 変更の概要
- Supabase `!inner` JOIN結果の正規化ロジック（`normalizeJoinResult`）を `batch-helpers.ts` に切り出し
- エラーメッセージ結合ロジック（`joinNonEmptyStrings`）を `batch-helpers.ts` に切り出し
- `backfill-missing-xp/route.ts` と `youtube-sync-actions.ts` のインラインロジックをヘルパー関数呼び出しに置き換え
- 11件のユニットテストを追加（カバレッジ100%）

# 変更の背景
- バッチ処理やServer Actionで繰り返し使われるパターン（JOIN結果の正規化、エラーメッセージ結合）を再利用可能な純粋関数に分離し、テスタビリティと保守性を向上させる

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました