### PR TITLE
refactor: ミッション選択のカテゴリグルーピングロジックをutilsに切り出し

### DIFF
--- a/src/features/ranking/utils/mission-grouping.test.ts
+++ b/src/features/ranking/utils/mission-grouping.test.ts
@@ -1,0 +1,129 @@
+import {
+  groupMissionsByCategory,
+  type MissionWithCategory,
+} from "./mission-grouping";
+
+function makeMission(
+  id: string,
+  title: string,
+  category?: { id: string; category_title: string | null; sort_no: number },
+): MissionWithCategory {
+  return {
+    id,
+    title,
+    mission_category_link: category ? [{ mission_category: category }] : [],
+  } as unknown as MissionWithCategory;
+}
+
+describe("groupMissionsByCategory", () => {
+  it("returns empty groups for empty input", () => {
+    const result = groupMissionsByCategory([]);
+    expect(result.sortedCategories).toHaveLength(0);
+    expect(result.uncategorized).toHaveLength(0);
+  });
+
+  it("groups missions under a single category", () => {
+    const missions = [
+      makeMission("m1", "Mission 1", {
+        id: "cat1",
+        category_title: "Category A",
+        sort_no: 1,
+      }),
+      makeMission("m2", "Mission 2", {
+        id: "cat1",
+        category_title: "Category A",
+        sort_no: 1,
+      }),
+    ];
+
+    const result = groupMissionsByCategory(missions);
+    expect(result.sortedCategories).toHaveLength(1);
+    expect(result.sortedCategories[0][0]).toBe("cat1");
+    expect(result.sortedCategories[0][1].category).toBe("Category A");
+    expect(result.sortedCategories[0][1].missions).toHaveLength(2);
+    expect(result.uncategorized).toHaveLength(0);
+  });
+
+  it("sorts multiple categories by sort_no", () => {
+    const missions = [
+      makeMission("m1", "Mission 1", {
+        id: "cat2",
+        category_title: "Category B",
+        sort_no: 20,
+      }),
+      makeMission("m2", "Mission 2", {
+        id: "cat1",
+        category_title: "Category A",
+        sort_no: 10,
+      }),
+      makeMission("m3", "Mission 3", {
+        id: "cat3",
+        category_title: "Category C",
+        sort_no: 30,
+      }),
+    ];
+
+    const result = groupMissionsByCategory(missions);
+    expect(result.sortedCategories).toHaveLength(3);
+    expect(result.sortedCategories[0][1].category).toBe("Category A");
+    expect(result.sortedCategories[1][1].category).toBe("Category B");
+    expect(result.sortedCategories[2][1].category).toBe("Category C");
+  });
+
+  it("puts missions without category link into uncategorized", () => {
+    const missions = [makeMission("m1", "No Category Mission")];
+
+    const result = groupMissionsByCategory(missions);
+    expect(result.sortedCategories).toHaveLength(0);
+    expect(result.uncategorized).toHaveLength(1);
+    expect(result.uncategorized[0].id).toBe("m1");
+  });
+
+  it("puts missions with null category_title into uncategorized", () => {
+    const missions = [
+      makeMission("m1", "Null Title", {
+        id: "cat1",
+        category_title: null,
+        sort_no: 1,
+      }),
+    ];
+
+    const result = groupMissionsByCategory(missions);
+    expect(result.sortedCategories).toHaveLength(0);
+    expect(result.uncategorized).toHaveLength(1);
+  });
+
+  it("handles mix of categorized and uncategorized missions", () => {
+    const missions = [
+      makeMission("m1", "Categorized", {
+        id: "cat1",
+        category_title: "Category A",
+        sort_no: 1,
+      }),
+      makeMission("m2", "Uncategorized"),
+      makeMission("m3", "Also Categorized", {
+        id: "cat1",
+        category_title: "Category A",
+        sort_no: 1,
+      }),
+    ];
+
+    const result = groupMissionsByCategory(missions);
+    expect(result.sortedCategories).toHaveLength(1);
+    expect(result.sortedCategories[0][1].missions).toHaveLength(2);
+    expect(result.uncategorized).toHaveLength(1);
+    expect(result.uncategorized[0].id).toBe("m2");
+  });
+
+  it("handles mission_category_link with null mission_category", () => {
+    const mission = {
+      id: "m1",
+      title: "Test",
+      mission_category_link: [{ mission_category: null }],
+    } as unknown as MissionWithCategory;
+
+    const result = groupMissionsByCategory([mission]);
+    expect(result.sortedCategories).toHaveLength(0);
+    expect(result.uncategorized).toHaveLength(1);
+  });
+});

--- a/src/features/ranking/utils/mission-grouping.ts
+++ b/src/features/ranking/utils/mission-grouping.ts
@@ -1,0 +1,59 @@
+import type { Tables } from "@/lib/types/supabase";
+
+export type MissionWithCategory = Tables<"missions"> & {
+  mission_category_link: Array<{
+    mission_category: {
+      id: string;
+      category_title: string | null;
+      sort_no: number;
+    } | null;
+  }>;
+};
+
+interface CategoryGroup {
+  category: string;
+  missions: MissionWithCategory[];
+  sortNo: number;
+}
+
+export interface GroupedMissions {
+  sortedCategories: [string, CategoryGroup][];
+  uncategorized: MissionWithCategory[];
+}
+
+/**
+ * Group missions by their first linked category, sorted by sort_no.
+ * Missions without a valid category are collected into `uncategorized`.
+ */
+export function groupMissionsByCategory(
+  missions: MissionWithCategory[],
+): GroupedMissions {
+  const groups: Record<string, CategoryGroup> = {};
+  const uncategorized: MissionWithCategory[] = [];
+
+  for (const mission of missions) {
+    const categoryLink = mission.mission_category_link?.[0];
+    const category = categoryLink?.mission_category;
+
+    if (category?.category_title) {
+      const key = category.id;
+      if (!groups[key]) {
+        groups[key] = {
+          category: category.category_title,
+          missions: [],
+          sortNo: category.sort_no,
+        };
+      }
+      groups[key].missions.push(mission);
+    } else {
+      uncategorized.push(mission);
+    }
+  }
+
+  // カテゴリを sort_no でソート
+  const sortedCategories = Object.entries(groups).sort(
+    ([, a], [, b]) => a.sortNo - b.sortNo,
+  );
+
+  return { sortedCategories, uncategorized };
+}


### PR DESCRIPTION
# 変更の概要
- `mission-select.tsx` の `useMemo` 内にあったカテゴリ別グルーピングロジックを `utils/mission-grouping.ts` に切り出し
- `groupMissionsByCategory` 関数と `MissionWithCategory` 型を独立モジュールとしてエクスポート
- 7件のユニットテストを追加（カバレッジ100%）

# 変更の背景
- コンポーネント内の純粋なデータ変換ロジックをutilsに分離し、テスタビリティと再利用性を向上
- テストケース: 空配列、単一カテゴリ、複数カテゴリのソート順、未カテゴリ、nullカテゴリタイトル、混合パターン

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました