### PR TITLE
refactor: extract chart date formatting and lookup map utils

### DIFF
--- a/src/features/action-stats/components/action-stats-chart.tsx
+++ b/src/features/action-stats/components/action-stats-chart.tsx
@@ -8,6 +8,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { formatChartDates } from "@/lib/utils/chart-transforms";
 import { formatNumberJaShort } from "@/lib/utils/format-number-ja";
 import type { DailyActionItem } from "../types";
 
@@ -34,14 +35,7 @@ export function ActionStatsChart({ data }: ActionStatsChartProps) {
     );
   }
 
-  // 日付をフォーマット
-  const formattedData = data.map((item) => ({
-    ...item,
-    date: new Date(item.date).toLocaleDateString("ja-JP", {
-      month: "short",
-      day: "numeric",
-    }),
-  }));
+  const formattedData = formatChartDates(data);
 
   return (
     <Card className="p-4 overflow-hidden">

--- a/src/features/prefecture-team/components/prefecture-team-map.tsx
+++ b/src/features/prefecture-team/components/prefecture-team-map.tsx
@@ -4,6 +4,7 @@ import type { Feature, FeatureCollection, Geometry } from "geojson";
 import L from "leaflet";
 import { useEffect, useRef, useState } from "react";
 import "leaflet/dist/leaflet.css";
+import { createLookupMap } from "@/lib/utils/chart-transforms";
 import "../styles/prefecture-map.css";
 import type { PrefectureTeamRanking } from "../types/prefecture-team-types";
 import { getColorForRank, NO_DATA_COLOR } from "../utils/color-scale";
@@ -33,7 +34,7 @@ export default function PrefectureTeamMap({
   const [error, setError] = useState<string | null>(null);
 
   // ランキングデータをマップで高速検索できるようにする
-  const rankingMap = new Map(rankings.map((r) => [r.prefecture, r]));
+  const rankingMap = createLookupMap(rankings, "prefecture");
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: 初期化は一度だけ実行
   useEffect(() => {

--- a/src/features/tiktok-stats/components/tiktok-overall-chart.tsx
+++ b/src/features/tiktok-stats/components/tiktok-overall-chart.tsx
@@ -8,6 +8,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { formatChartDates } from "@/lib/utils/chart-transforms";
 import type { OverallStatsHistoryItem } from "../types";
 import { formatNumberJaShort } from "../utils/format";
 
@@ -34,13 +35,7 @@ export function TikTokOverallChart({ data }: TikTokOverallChartProps) {
     );
   }
 
-  const formattedData = data.map((item) => ({
-    ...item,
-    date: new Date(item.date).toLocaleDateString("ja-JP", {
-      month: "short",
-      day: "numeric",
-    }),
-  }));
+  const formattedData = formatChartDates(data);
 
   return (
     <Card className="p-4">

--- a/src/features/tiktok-stats/components/tiktok-upload-chart.tsx
+++ b/src/features/tiktok-stats/components/tiktok-upload-chart.tsx
@@ -8,6 +8,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { formatChartDates } from "@/lib/utils/chart-transforms";
 import type { VideoCountByDateItem } from "../types";
 
 interface TikTokUploadChartProps {
@@ -33,13 +34,7 @@ export function TikTokUploadChart({ data }: TikTokUploadChartProps) {
     );
   }
 
-  const formattedData = data.map((item) => ({
-    ...item,
-    date: new Date(item.date).toLocaleDateString("ja-JP", {
-      month: "short",
-      day: "numeric",
-    }),
-  }));
+  const formattedData = formatChartDates(data);
 
   return (
     <Card className="p-4">

--- a/src/lib/utils/chart-transforms.test.ts
+++ b/src/lib/utils/chart-transforms.test.ts
@@ -1,0 +1,162 @@
+import { createLookupMap, formatChartDates } from "./chart-transforms";
+
+describe("formatChartDates", () => {
+  it("should format date strings to Japanese short format", () => {
+    const data = [
+      { date: "2025-01-05", count: 10 },
+      { date: "2025-12-25", count: 20 },
+    ];
+
+    const result = formatChartDates(data);
+
+    expect(result[0].date).toBe(
+      new Date("2025-01-05").toLocaleDateString("ja-JP", {
+        month: "short",
+        day: "numeric",
+      }),
+    );
+    expect(result[1].date).toBe(
+      new Date("2025-12-25").toLocaleDateString("ja-JP", {
+        month: "short",
+        day: "numeric",
+      }),
+    );
+  });
+
+  it("should preserve other properties in the data items", () => {
+    const data = [{ date: "2025-03-15", count: 42, extra: "value" }];
+
+    const result = formatChartDates(data);
+
+    expect(result[0].count).toBe(42);
+    expect(result[0].extra).toBe("value");
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(formatChartDates([])).toEqual([]);
+  });
+
+  it("should handle single item array", () => {
+    const data = [{ date: "2025-06-01", count: 5 }];
+
+    const result = formatChartDates(data);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(5);
+  });
+
+  it("should work with items that have multiple numeric fields", () => {
+    const data = [{ date: "2025-01-01", total_views: 1000, total_likes: 50 }];
+
+    const result = formatChartDates(data);
+
+    expect(result[0].total_views).toBe(1000);
+    expect(result[0].total_likes).toBe(50);
+    expect(typeof result[0].date).toBe("string");
+  });
+
+  it("should handle consecutive dates correctly", () => {
+    const data = [
+      { date: "2025-01-01", count: 1 },
+      { date: "2025-01-02", count: 2 },
+      { date: "2025-01-03", count: 3 },
+    ];
+
+    const result = formatChartDates(data);
+
+    expect(result).toHaveLength(3);
+    // Each date should be distinct
+    const dates = result.map((r) => r.date);
+    expect(new Set(dates).size).toBe(3);
+  });
+});
+
+describe("createLookupMap", () => {
+  it("should create a Map from an array using the specified key", () => {
+    const items = [
+      { prefecture: "東京都", rank: 1, totalXp: 1000 },
+      { prefecture: "大阪府", rank: 2, totalXp: 800 },
+    ];
+
+    const map = createLookupMap(items, "prefecture");
+
+    expect(map.get("東京都")).toEqual({
+      prefecture: "東京都",
+      rank: 1,
+      totalXp: 1000,
+    });
+    expect(map.get("大阪府")).toEqual({
+      prefecture: "大阪府",
+      rank: 2,
+      totalXp: 800,
+    });
+  });
+
+  it("should return undefined for missing keys", () => {
+    const items = [{ id: "a", name: "Alice" }];
+
+    const map = createLookupMap(items, "id");
+
+    expect(map.get("b")).toBeUndefined();
+  });
+
+  it("should handle empty array", () => {
+    const map = createLookupMap([], "id" as never);
+
+    expect(map.size).toBe(0);
+  });
+
+  it("should handle numeric keys", () => {
+    const items = [
+      { id: 1, value: "first" },
+      { id: 2, value: "second" },
+    ];
+
+    const map = createLookupMap(items, "id");
+
+    expect(map.get(1)?.value).toBe("first");
+    expect(map.get(2)?.value).toBe("second");
+  });
+
+  it("should use the last item when keys are duplicated", () => {
+    const items = [
+      { name: "Tokyo", rank: 1 },
+      { name: "Tokyo", rank: 5 },
+    ];
+
+    const map = createLookupMap(items, "name");
+
+    expect(map.get("Tokyo")?.rank).toBe(5);
+    expect(map.size).toBe(1);
+  });
+
+  it("should create correct size map", () => {
+    const items = [
+      {
+        prefecture: "北海道",
+        rank: 1,
+        xpPerCapita: 100,
+        totalXp: 500,
+        userCount: 10,
+      },
+      {
+        prefecture: "青森県",
+        rank: 2,
+        xpPerCapita: 90,
+        totalXp: 400,
+        userCount: 8,
+      },
+      {
+        prefecture: "岩手県",
+        rank: 3,
+        xpPerCapita: 80,
+        totalXp: 300,
+        userCount: 6,
+      },
+    ];
+
+    const map = createLookupMap(items, "prefecture");
+
+    expect(map.size).toBe(3);
+  });
+});

--- a/src/lib/utils/chart-transforms.ts
+++ b/src/lib/utils/chart-transforms.ts
@@ -1,0 +1,26 @@
+/**
+ * Format chart data items by converting date strings to Japanese short format (e.g. "1月5日").
+ * Used across action-stats, tiktok-stats chart components.
+ */
+export function formatChartDates<T extends { date: string }>(
+  data: T[],
+): (Omit<T, "date"> & { date: string })[] {
+  return data.map((item) => ({
+    ...item,
+    date: new Date(item.date).toLocaleDateString("ja-JP", {
+      month: "short",
+      day: "numeric",
+    }),
+  }));
+}
+
+/**
+ * Create a Map from an array using a specified key property for fast lookup.
+ * Used in prefecture-team-map for ranking data lookup by prefecture name.
+ */
+export function createLookupMap<T, K extends keyof T>(
+  items: T[],
+  key: K,
+): Map<T[K], T> {
+  return new Map(items.map((item) => [item[key], item]));
+}


### PR DESCRIPTION
# 変更の概要
- 3つのチャートコンポーネントに重複していた日付フォーマットロジックを `formatChartDates` として `src/lib/utils/chart-transforms.ts` に統合
- `prefecture-team-map.tsx` の配列→Map変換を汎用的な `createLookupMap` として切り出し
- 12のユニットテスト（100%カバレッジ）を追加

対象コンポーネント:
- `src/features/action-stats/components/action-stats-chart.tsx` - formatChartDates使用
- `src/features/tiktok-stats/components/tiktok-upload-chart.tsx` - formatChartDates使用
- `src/features/tiktok-stats/components/tiktok-overall-chart.tsx` - formatChartDates使用
- `src/features/prefecture-team/components/prefecture-team-map.tsx` - createLookupMap使用

# 変更の背景
- 同一の日付フォーマットロジック（`toLocaleDateString("ja-JP", { month: "short", day: "numeric" })`）が3箇所に重複していた
- 共通ユーティリティに統合することで保守性向上と重複排除を実現

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました