### PR TITLE
refactor: extract currency utility functions from donation-metric

### DIFF
--- a/src/features/metrics/utils/currency-utils.test.ts
+++ b/src/features/metrics/utils/currency-utils.test.ts
@@ -1,0 +1,65 @@
+import { parseCurrencyDisplay, safeYenToMan } from "./currency-utils";
+
+describe("safeYenToMan", () => {
+  it("nullに対して0を返す", () => {
+    expect(safeYenToMan(null)).toBe(0);
+  });
+
+  it("undefinedに対して0を返す", () => {
+    expect(safeYenToMan(undefined)).toBe(0);
+  });
+
+  it("NaNに対して0を返す", () => {
+    expect(safeYenToMan(Number.NaN)).toBe(0);
+  });
+
+  it("負数に対して0を返す", () => {
+    expect(safeYenToMan(-1000)).toBe(0);
+  });
+
+  it("0に対して0を返す", () => {
+    expect(safeYenToMan(0)).toBe(0);
+  });
+
+  it("正数を万単位に変換する", () => {
+    expect(safeYenToMan(50000)).toBe(5);
+  });
+
+  it("大きな値を万単位に変換する", () => {
+    expect(safeYenToMan(123456789)).toBe(12345.6789);
+  });
+
+  it("カスタムdivisorを使用できる", () => {
+    expect(safeYenToMan(1000, 100)).toBe(10);
+  });
+});
+
+describe("parseCurrencyDisplay", () => {
+  it("億万を含む場合、数値部分と万円を分離する", () => {
+    expect(parseCurrencyDisplay("1億456.9万円")).toEqual({
+      number: "1億456.9",
+      unit: "万円",
+    });
+  });
+
+  it("億のみの場合、数値部分と億円を分離する", () => {
+    expect(parseCurrencyDisplay("1億円")).toEqual({
+      number: "1",
+      unit: "億円",
+    });
+  });
+
+  it("万のみの場合、数値部分と万円を分離する", () => {
+    expect(parseCurrencyDisplay("456.9万円")).toEqual({
+      number: "456.9",
+      unit: "万円",
+    });
+  });
+
+  it("整数の万円を処理する", () => {
+    expect(parseCurrencyDisplay("1234万円")).toEqual({
+      number: "1234",
+      unit: "万円",
+    });
+  });
+});

--- a/src/features/metrics/utils/currency-utils.ts
+++ b/src/features/metrics/utils/currency-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * 通貨関連のユーティリティ関数
+ */
+
+const YEN_TO_MAN_DIVISOR = 10000;
+
+/**
+ * 円の値を安全に万単位に変換する
+ * null/undefined/NaN/負数は0を返す
+ *
+ * @param value - 円単位の金額
+ * @param divisor - 除算する値（デフォルト: 10000）
+ * @returns 万単位の金額
+ */
+export function safeYenToMan(
+  value: number | null | undefined,
+  divisor: number = YEN_TO_MAN_DIVISOR,
+): number {
+  if (typeof value !== "number" || Number.isNaN(value) || value < 0) {
+    return 0;
+  }
+  return value / divisor;
+}
+
+/**
+ * フォーマット済み金額文字列から数値部分と単位を分離する
+ *
+ * 例:
+ * - "1億456.9万円" → { number: "1億456.9", unit: "万円" }
+ * - "1億円" → { number: "1", unit: "億円" }
+ * - "456.9万円" → { number: "456.9", unit: "万円" }
+ *
+ * @param formatted - formatAmount()でフォーマットされた金額文字列
+ * @returns 数値部分と単位を含むオブジェクト
+ */
+export function parseCurrencyDisplay(formatted: string): {
+  number: string;
+  unit: string;
+} {
+  if (formatted.includes("億") && formatted.includes("万")) {
+    const withoutManYen = formatted.replace(/万円$/, "");
+    return { number: withoutManYen, unit: "万円" };
+  }
+  if (formatted.includes("億")) {
+    const number = formatted.replace(/億円$/, "");
+    return { number, unit: "億円" };
+  }
+  const number = formatted.replace(/万円$/, "");
+  return { number, unit: "万円" };
+}


### PR DESCRIPTION
# 変更の概要
- `donation-metric.tsx` から通貨関連のユーティリティ関数を `currency-utils.ts` に切り出し
  - `safeYenToMan`: 円の値を安全に万単位に変換（null/undefined/NaN/負数チェック付き）
  - `parseCurrencyDisplay`: フォーマット済み金額文字列から数値部分と単位を分離

# 変更の背景
- コンポーネント内に埋め込まれていた通貨変換ロジックを純粋関数として切り出すことで、テスタビリティと再利用性を向上
- 12件のユニットテストで null, undefined, NaN, 負数, 0, 正数, 億万, 億のみ, 万のみのケースをカバー

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました