### PR TITLE
refactor: extract form date utility functions from profile-form

### DIFF
--- a/src/lib/utils/form-date-utils.test.ts
+++ b/src/lib/utils/form-date-utils.test.ts
@@ -1,0 +1,98 @@
+import {
+  formatDateComponents,
+  getDaysInMonth,
+  verifyMinimumAge,
+} from "./form-date-utils";
+
+describe("formatDateComponents", () => {
+  it("年月日をYYYY-MM-DD形式にフォーマットする", () => {
+    expect(formatDateComponents(2024, 3, 5)).toBe("2024-03-05");
+  });
+
+  it("月と日を2桁にパディングする", () => {
+    expect(formatDateComponents(2024, 1, 1)).toBe("2024-01-01");
+  });
+
+  it("2桁の月日はそのまま出力する", () => {
+    expect(formatDateComponents(2024, 12, 31)).toBe("2024-12-31");
+  });
+
+  it("yearがnullの場合は空文字列を返す", () => {
+    expect(formatDateComponents(null, 3, 5)).toBe("");
+  });
+
+  it("monthがnullの場合は空文字列を返す", () => {
+    expect(formatDateComponents(2024, null, 5)).toBe("");
+  });
+
+  it("dayがnullの場合は空文字列を返す", () => {
+    expect(formatDateComponents(2024, 3, null)).toBe("");
+  });
+});
+
+describe("getDaysInMonth", () => {
+  it("1月は31日を返す", () => {
+    const days = getDaysInMonth(2024, 1);
+    expect(days).toHaveLength(31);
+    expect(days[0]).toBe(1);
+    expect(days[30]).toBe(31);
+  });
+
+  it("うるう年の2月は29日を返す", () => {
+    const days = getDaysInMonth(2024, 2);
+    expect(days).toHaveLength(29);
+  });
+
+  it("平年の2月は28日を返す", () => {
+    const days = getDaysInMonth(2023, 2);
+    expect(days).toHaveLength(28);
+  });
+
+  it("4月は30日を返す", () => {
+    const days = getDaysInMonth(2024, 4);
+    expect(days).toHaveLength(30);
+  });
+});
+
+describe("verifyMinimumAge", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-06-15"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("空文字列の場合はisValid: falseでmessage: nullを返す", () => {
+    expect(verifyMinimumAge("", 18)).toEqual({
+      isValid: false,
+      message: null,
+    });
+  });
+
+  it("18歳以上の場合はisValid: trueを返す", () => {
+    expect(verifyMinimumAge("2008-06-15", 18)).toEqual({
+      isValid: true,
+      message: null,
+    });
+  });
+
+  it("17歳の場合はisValid: falseとメッセージを返す（もうすぐ）", () => {
+    const result = verifyMinimumAge("2008-06-16", 18);
+    expect(result.isValid).toBe(false);
+    expect(result.message).toContain("もうすぐ");
+  });
+
+  it("15歳の場合はあと3年のメッセージを返す", () => {
+    const result = verifyMinimumAge("2011-01-01", 18);
+    expect(result.isValid).toBe(false);
+    expect(result.message).toContain("あと3年で");
+  });
+
+  it("異なる最低年齢（20歳）で判定できる", () => {
+    const result = verifyMinimumAge("2008-06-15", 20);
+    expect(result.isValid).toBe(false);
+    expect(result.message).toContain("20歳以上");
+  });
+});

--- a/src/lib/utils/form-date-utils.ts
+++ b/src/lib/utils/form-date-utils.ts
@@ -1,0 +1,49 @@
+import { calculateAge } from "@/lib/utils/utils";
+
+/**
+ * 年/月/日の数値から "YYYY-MM-DD" 形式の文字列を生成する
+ * いずれかがnullの場合は空文字列を返す
+ */
+export function formatDateComponents(
+  year: number | null,
+  month: number | null,
+  day: number | null,
+): string {
+  if (!year || !month || !day) return "";
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${year}-${pad(month)}-${pad(day)}`;
+}
+
+/**
+ * 指定された年月の日数を配列として返す
+ * 例: getDaysInMonth(2024, 2) => [1, 2, ..., 29] (うるう年)
+ */
+export function getDaysInMonth(year: number, month: number): number[] {
+  const daysCount = new Date(year, month, 0).getDate();
+  return Array.from({ length: daysCount }, (_, i) => i + 1);
+}
+
+/**
+ * 生年月日が指定された最低年齢以上かを判定する
+ * @returns isValid: 年齢条件を満たすか, message: エラーメッセージ（条件を満たす場合はnull）
+ */
+export function verifyMinimumAge(
+  birthdate: string,
+  minimumAge: number,
+): { isValid: boolean; message: string | null } {
+  if (!birthdate) {
+    return { isValid: false, message: null };
+  }
+
+  const age = calculateAge(birthdate);
+  if (age < minimumAge) {
+    const yearsToWait = minimumAge - age;
+    const waitText = yearsToWait > 1 ? `あと${yearsToWait}年で` : "もうすぐ";
+    return {
+      isValid: false,
+      message: `${minimumAge}歳以上の方のみご登録いただけます。${waitText}登録できますので、その日を楽しみにお待ちください！`,
+    };
+  }
+
+  return { isValid: true, message: null };
+}


### PR DESCRIPTION
# 変更の概要
- `profile-form.tsx` からフォーム日付関連のユーティリティ関数を `form-date-utils.ts` に切り出し
  - `formatDateComponents`: year/month/day から "YYYY-MM-DD" 形式の文字列を生成（パディング付き）
  - `getDaysInMonth`: 年月から日数配列を生成（うるう年対応）
  - `verifyMinimumAge`: 生年月日と最低年齢から年齢条件判定（configurable minimum age）

# 変更の背景
- コンポーネント内に埋め込まれていた日付フォーマットと年齢検証ロジックを純粋関数として切り出すことで、テスタビリティと再利用性を向上
- 既存の `calculateAge` 関数（lib/utils/utils.ts）を内部で利用
- 15件のユニットテストで null値, パディング, うるう年, 18歳境界, under18メッセージ, カスタム最低年齢をカバー

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました