### PR TITLE
refactor: extract shared poster filter logic from worker and hook

### DIFF
--- a/src/features/map-poster/hooks/use-poster-board-filter.ts
+++ b/src/features/map-poster/hooks/use-poster-board-filter.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
+import { filterPosterBoards } from "@/features/map-poster/utils/poster-filter-logic";
 import type { Database } from "@/lib/types/supabase";
 
 type PosterBoard = Database["public"]["Tables"]["poster_boards"]["Row"];
@@ -79,25 +80,13 @@ export function usePosterBoardFilter({
   }, []);
 
   const filteredBoards = useMemo(() => {
-    return boards.filter((board) => {
-      // Check if the board's status is enabled
-      if (!filterState.statuses.has(board.status)) {
-        return false;
-      }
-
-      // If "show only mine" is enabled, filter by edited boards
-      if (filterState.showOnlyMine && currentUserId) {
-        if (!userEditedBoardIds || userEditedBoardIds.size === 0) {
-          return false;
-        }
-        // このボードをユーザーが編集したことがあるかチェック
-        if (!userEditedBoardIds.has(board.id)) {
-          return false;
-        }
-      }
-
-      return true;
-    });
+    return filterPosterBoards(
+      boards,
+      filterState.statuses,
+      filterState.showOnlyMine,
+      userEditedBoardIds ?? new Set<string>(),
+      currentUserId,
+    );
   }, [boards, filterState, userEditedBoardIds, currentUserId]);
 
   const activeFilterCount = useMemo(() => {

--- a/src/features/map-poster/utils/poster-filter-logic.test.ts
+++ b/src/features/map-poster/utils/poster-filter-logic.test.ts
@@ -1,0 +1,180 @@
+import { filterPosterBoards } from "./poster-filter-logic";
+
+type TestBoard = {
+  id: string;
+  status: string;
+};
+
+const makeBoard = (id: string, status: string): TestBoard => ({ id, status });
+
+describe("filterPosterBoards", () => {
+  it("returns empty array for empty input", () => {
+    const result = filterPosterBoards([], new Set(["done"]), false, new Set());
+    expect(result).toEqual([]);
+  });
+
+  it("filters boards by status", () => {
+    const boards = [
+      makeBoard("1", "done"),
+      makeBoard("2", "not_yet"),
+      makeBoard("3", "done"),
+      makeBoard("4", "reserved"),
+    ];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done"]),
+      false,
+      new Set(),
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((b) => b.id)).toEqual(["1", "3"]);
+  });
+
+  it("filters by multiple statuses", () => {
+    const boards = [
+      makeBoard("1", "done"),
+      makeBoard("2", "not_yet"),
+      makeBoard("3", "reserved"),
+    ];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done", "reserved"]),
+      false,
+      new Set(),
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((b) => b.id)).toEqual(["1", "3"]);
+  });
+
+  it("returns all boards when all statuses are selected", () => {
+    const boards = [
+      makeBoard("1", "done"),
+      makeBoard("2", "not_yet"),
+      makeBoard("3", "reserved"),
+    ];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done", "not_yet", "reserved"]),
+      false,
+      new Set(),
+    );
+
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns no boards when statusSet is empty", () => {
+    const boards = [makeBoard("1", "done"), makeBoard("2", "not_yet")];
+
+    const result = filterPosterBoards(boards, new Set(), false, new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("filters by showOnlyMine when currentUserId is provided", () => {
+    const boards = [
+      makeBoard("1", "done"),
+      makeBoard("2", "done"),
+      makeBoard("3", "done"),
+    ];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done"]),
+      true,
+      new Set(["1", "3"]),
+      "user-1",
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((b) => b.id)).toEqual(["1", "3"]);
+  });
+
+  it("returns empty when showOnlyMine is true but editedBoardSet is empty", () => {
+    const boards = [makeBoard("1", "done"), makeBoard("2", "done")];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done"]),
+      true,
+      new Set(),
+      "user-1",
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("ignores showOnlyMine when currentUserId is not provided", () => {
+    const boards = [makeBoard("1", "done"), makeBoard("2", "done")];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done"]),
+      true,
+      new Set(["1"]),
+    );
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("combines status filter and showOnlyMine", () => {
+    const boards = [
+      makeBoard("1", "done"),
+      makeBoard("2", "not_yet"),
+      makeBoard("3", "done"),
+      makeBoard("4", "reserved"),
+    ];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done", "reserved"]),
+      true,
+      new Set(["1", "4"]),
+      "user-1",
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((b) => b.id)).toEqual(["1", "4"]);
+  });
+
+  it("excludes boards not in editedBoardSet even if status matches", () => {
+    const boards = [makeBoard("1", "done"), makeBoard("2", "done")];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done"]),
+      true,
+      new Set(["2"]),
+      "user-1",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("2");
+  });
+
+  it("preserves extra properties on boards", () => {
+    const boards = [
+      { id: "1", status: "done", lat: 35.6, long: 139.7, name: "Tokyo" },
+    ];
+
+    const result = filterPosterBoards(
+      boards,
+      new Set(["done"]),
+      false,
+      new Set(),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "1",
+      status: "done",
+      lat: 35.6,
+      long: 139.7,
+      name: "Tokyo",
+    });
+  });
+});

--- a/src/features/map-poster/utils/poster-filter-logic.ts
+++ b/src/features/map-poster/utils/poster-filter-logic.ts
@@ -1,0 +1,37 @@
+/**
+ * ポスター掲示板のフィルタリングに必要な最小限のボード情報
+ */
+interface FilterableBoard {
+  id: string;
+  status: string;
+}
+
+/**
+ * ポスター掲示板をステータスとユーザー編集履歴でフィルタリングする
+ *
+ * Worker と Hook の両方から利用される共通フィルタロジック
+ */
+export function filterPosterBoards<T extends FilterableBoard>(
+  boards: T[],
+  statusSet: Set<string>,
+  showOnlyMine: boolean,
+  editedBoardSet: Set<string>,
+  currentUserId?: string,
+): T[] {
+  return boards.filter((board) => {
+    if (!statusSet.has(board.status)) {
+      return false;
+    }
+
+    if (showOnlyMine && currentUserId) {
+      if (editedBoardSet.size === 0) {
+        return false;
+      }
+      if (!editedBoardSet.has(board.id)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}

--- a/src/features/map-poster/workers/poster-filter.worker.ts
+++ b/src/features/map-poster/workers/poster-filter.worker.ts
@@ -1,4 +1,7 @@
 // Web Worker for filtering poster boards
+// NOTE: Workers cannot use path aliases (@/), so we use a relative import
+import { filterPosterBoards } from "../utils/poster-filter-logic";
+
 type PosterBoard = {
   id: string;
   status: string;
@@ -34,25 +37,13 @@ self.addEventListener("message", (event: MessageEvent<FilterMessage>) => {
   const statusSet = new Set(selectedStatuses);
   const editedBoardSet = new Set(userEditedBoardIds);
 
-  const filteredBoards = boards.filter((board) => {
-    // Check if the board's status is enabled
-    if (!statusSet.has(board.status)) {
-      return false;
-    }
-
-    // If "show only mine" is enabled, filter by edited boards
-    if (showOnlyMine && currentUserId) {
-      if (editedBoardSet.size === 0) {
-        return false;
-      }
-      // Check if user has edited this board
-      if (!editedBoardSet.has(board.id)) {
-        return false;
-      }
-    }
-
-    return true;
-  });
+  const filteredBoards = filterPosterBoards(
+    boards,
+    statusSet,
+    showOnlyMine,
+    editedBoardSet,
+    currentUserId,
+  );
 
   const response: ResultMessage = {
     type: "result",


### PR DESCRIPTION
# 変更の概要
- `poster-filter.worker.ts` と `use-poster-board-filter.ts` に重複していたポスター掲示板フィルタリングロジックを `poster-filter-logic.ts` ユーティリティに統合
- Worker と Hook の両方から共通関数 `filterPosterBoards` をインポートする形に変更
- 11個のユニットテストを追加（空配列、ステータスフィルタ、showOnlyMine、組み合わせフィルタ、ジェネリック型保持をカバー）

# 変更の背景
- Worker と Hook で同一のフィルタリングロジックが重複しており、保守性が低い
- 共通ユーティリティに切り出すことで、ロジックの一貫性を保証し、テストカバレッジを向上させる

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました