### PR TITLE
refactor: ページネーションURL生成とシャッフル配列ユーティリティの切り出し

### DIFF
--- a/src/features/missions/components/quiz-component.tsx
+++ b/src/features/missions/components/quiz-component.tsx
@@ -16,6 +16,7 @@ import {
   getMissionLinksAction,
   type MissionLink,
 } from "@/features/mission-detail/actions/quiz-actions";
+import { shuffleArray } from "@/lib/utils/array-utils";
 
 interface QuizQuestion {
   id: string;
@@ -81,16 +82,6 @@ export default function QuizComponent({
   // クライアントサイドかどうかを判定
   const [isClient, setIsClient] = useState(false);
 
-  // 配列をシャッフルする関数
-  const shuffleArray = useCallback(<T,>(array: T[]): T[] => {
-    const shuffled = [...array];
-    for (let i = shuffled.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-    }
-    return shuffled;
-  }, []);
-
   // 選択肢をシャッフルした問題を作成する関数（クライアントサイドでのみシャッフル）
   const createShuffledQuestion = useCallback(
     (question: QuizQuestion, shouldShuffle = true): ShuffledQuizQuestion => {
@@ -124,7 +115,7 @@ export default function QuizComponent({
         shuffledToOriginalMapping,
       };
     },
-    [shuffleArray, isClient],
+    [isClient],
   );
 
   // 初期状態では常にローディング状態にして、クライアントサイドでシャッフル完了後に表示

--- a/src/features/tiktok-stats/components/tiktok-video-list.tsx
+++ b/src/features/tiktok-stats/components/tiktok-video-list.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { createPaginationUrl } from "@/lib/utils/pagination-utils";
 import type { TikTokVideoWithStats } from "../types";
 import { TikTokVideoCard } from "./tiktok-video-card";
 
@@ -26,16 +27,8 @@ export function TikTokVideoList({
   const hasNextPage = currentPage < totalPages;
   const hasPrevPage = currentPage > 1;
 
-  const createPageUrl = (page: number) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (page === 1) {
-      params.delete("page");
-    } else {
-      params.set("page", page.toString());
-    }
-    const query = params.toString();
-    return `${pathname}${query ? `?${query}` : ""}`;
-  };
+  const createPageUrl = (page: number) =>
+    createPaginationUrl(pathname, searchParams, page);
 
   if (videos.length === 0) {
     return (

--- a/src/lib/utils/array-utils.test.ts
+++ b/src/lib/utils/array-utils.test.ts
@@ -1,4 +1,4 @@
-import { chunk } from "./array-utils";
+import { chunk, shuffleArray } from "./array-utils";
 
 describe("chunk", () => {
   it("should return empty array for empty input", () => {
@@ -32,5 +32,29 @@ describe("chunk", () => {
     const objects = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const result = chunk(objects, 2);
     expect(result).toEqual([[{ id: 1 }, { id: 2 }], [{ id: 3 }]]);
+  });
+});
+
+describe("shuffleArray", () => {
+  it("should return empty array for empty input", () => {
+    expect(shuffleArray([])).toEqual([]);
+  });
+
+  it("should return single element array unchanged", () => {
+    expect(shuffleArray([42])).toEqual([42]);
+  });
+
+  it("should contain the same elements after shuffle", () => {
+    const original = [1, 2, 3, 4, 5];
+    const result = shuffleArray(original);
+    expect(result).toHaveLength(original.length);
+    expect(result.sort()).toEqual([...original].sort());
+  });
+
+  it("should not mutate the original array", () => {
+    const original = [1, 2, 3, 4, 5];
+    const copy = [...original];
+    shuffleArray(original);
+    expect(original).toEqual(copy);
   });
 });

--- a/src/lib/utils/array-utils.ts
+++ b/src/lib/utils/array-utils.ts
@@ -8,3 +8,16 @@ export function chunk<T>(array: T[], size: number): T[][] {
   }
   return chunks;
 }
+
+/**
+ * Fisher-Yatesアルゴリズムで配列をシャッフルする。
+ * 元の配列は変更せず、新しい配列を返す。
+ */
+export function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}

--- a/src/lib/utils/pagination-utils.test.ts
+++ b/src/lib/utils/pagination-utils.test.ts
@@ -1,0 +1,33 @@
+import { createPaginationUrl } from "./pagination-utils";
+
+describe("createPaginationUrl", () => {
+  it("should delete page param when page is 1", () => {
+    const params = new URLSearchParams("page=3&sort=asc");
+    const result = createPaginationUrl("/videos", params, 1);
+    expect(result).toBe("/videos?sort=asc");
+  });
+
+  it("should set page param when page > 1", () => {
+    const params = new URLSearchParams("sort=asc");
+    const result = createPaginationUrl("/videos", params, 2);
+    expect(result).toBe("/videos?sort=asc&page=2");
+  });
+
+  it("should preserve existing search params", () => {
+    const params = new URLSearchParams("category=music&sort=desc");
+    const result = createPaginationUrl("/videos", params, 3);
+    expect(result).toBe("/videos?category=music&sort=desc&page=3");
+  });
+
+  it("should return pathname only when page is 1 and no other params", () => {
+    const params = new URLSearchParams("page=5");
+    const result = createPaginationUrl("/videos", params, 1);
+    expect(result).toBe("/videos");
+  });
+
+  it("should return pathname without query when no params exist and page is 1", () => {
+    const params = new URLSearchParams();
+    const result = createPaginationUrl("/tiktok", params, 1);
+    expect(result).toBe("/tiktok");
+  });
+});

--- a/src/lib/utils/pagination-utils.ts
+++ b/src/lib/utils/pagination-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * ページネーション用のURL文字列を生成する。
+ * page=1 のときは page パラメータを削除する。
+ */
+export function createPaginationUrl(
+  pathname: string,
+  searchParams: URLSearchParams,
+  page: number,
+): string {
+  const params = new URLSearchParams(searchParams.toString());
+  if (page === 1) {
+    params.delete("page");
+  } else {
+    params.set("page", page.toString());
+  }
+  const query = params.toString();
+  return `${pathname}${query ? `?${query}` : ""}`;
+}


### PR DESCRIPTION
# 変更の概要
- `createPaginationUrl` を `tiktok-video-list.tsx` から `src/lib/utils/pagination-utils.ts` に切り出し
- `shuffleArray`（Fisher-Yatesアルゴリズム）を `quiz-component.tsx` から `src/lib/utils/array-utils.ts` に追加
- 各関数のユニットテストを追加（100%カバレッジ）

# 変更の背景
- ページネーションURL生成ロジックがコンポーネント内にインラインで定義されており、再利用性が低かった
- Fisher-Yatesシャッフルが `useCallback` でラップされた状態でコンポーネント内に埋め込まれていた
- 純粋関数として切り出すことで、テスタビリティと再利用性を向上

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました