### PR TITLE
refactor: extract membership and contribution helper functions

### DIFF
--- a/src/features/party-membership/services/memberships.ts
+++ b/src/features/party-membership/services/memberships.ts
@@ -2,6 +2,10 @@ import "server-only";
 
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import type { PartyMembership } from "../types";
+import {
+  buildMembershipMap,
+  deduplicateUserIds,
+} from "../utils/membership-helpers";
 
 type MembershipMap = Record<string, PartyMembership>;
 
@@ -30,7 +34,7 @@ export async function getPartyMembership(
 export async function getPartyMembershipMap(
   userIds: string[],
 ): Promise<MembershipMap> {
-  const uniqueIds = Array.from(new Set(userIds.filter(Boolean)));
+  const uniqueIds = deduplicateUserIds(userIds);
   if (uniqueIds.length === 0) {
     return {};
   }
@@ -46,10 +50,5 @@ export async function getPartyMembershipMap(
     return {};
   }
 
-  return (data ?? []).reduce<MembershipMap>((acc, membership) => {
-    if (membership?.user_id) {
-      acc[membership.user_id] = membership;
-    }
-    return acc;
-  }, {});
+  return buildMembershipMap(data ?? []);
 }

--- a/src/features/party-membership/utils/membership-helpers.test.ts
+++ b/src/features/party-membership/utils/membership-helpers.test.ts
@@ -1,0 +1,61 @@
+import type { PartyMembership } from "../types";
+import { buildMembershipMap, deduplicateUserIds } from "./membership-helpers";
+
+describe("deduplicateUserIds", () => {
+  it("removes duplicate IDs", () => {
+    const result = deduplicateUserIds(["a", "b", "a", "c", "b"]);
+    expect(result).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters out empty strings", () => {
+    const result = deduplicateUserIds(["a", "", "b", ""]);
+    expect(result).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array when input is empty", () => {
+    const result = deduplicateUserIds([]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("buildMembershipMap", () => {
+  const makeMembership = (userId: string): PartyMembership =>
+    ({
+      user_id: userId,
+      plan: "standard",
+    }) as unknown as PartyMembership;
+
+  it("converts array to map keyed by user_id", () => {
+    const memberships = [makeMembership("user-1"), makeMembership("user-2")];
+    const result = buildMembershipMap(memberships);
+    expect(Object.keys(result)).toEqual(["user-1", "user-2"]);
+    expect(result["user-1"]!.user_id).toBe("user-1");
+    expect(result["user-2"]!.user_id).toBe("user-2");
+  });
+
+  it("returns empty object for empty array", () => {
+    expect(buildMembershipMap([])).toEqual({});
+  });
+
+  it("skips entries with null user_id", () => {
+    const memberships = [
+      makeMembership("user-1"),
+      { user_id: null, plan: "standard" } as unknown as PartyMembership,
+    ];
+    const result = buildMembershipMap(memberships);
+    expect(Object.keys(result)).toEqual(["user-1"]);
+  });
+
+  it("last entry wins when duplicate user_ids exist", () => {
+    const first = {
+      user_id: "user-1",
+      plan: "basic",
+    } as unknown as PartyMembership;
+    const second = {
+      user_id: "user-1",
+      plan: "premium",
+    } as unknown as PartyMembership;
+    const result = buildMembershipMap([first, second]);
+    expect(result["user-1"]).toBe(second);
+  });
+});

--- a/src/features/party-membership/utils/membership-helpers.ts
+++ b/src/features/party-membership/utils/membership-helpers.ts
@@ -1,0 +1,24 @@
+import type { PartyMembership } from "../types";
+
+type MembershipMap = Record<string, PartyMembership>;
+
+/**
+ * ユーザーID配列から重複と空値を除去する
+ */
+export function deduplicateUserIds(userIds: string[]): string[] {
+  return Array.from(new Set(userIds.filter(Boolean)));
+}
+
+/**
+ * メンバーシップ配列をuser_idをキーとするMapに変換する
+ */
+export function buildMembershipMap(
+  memberships: PartyMembership[],
+): MembershipMap {
+  return memberships.reduce<MembershipMap>((acc, membership) => {
+    if (membership?.user_id) {
+      acc[membership.user_id] = membership;
+    }
+    return acc;
+  }, {});
+}

--- a/src/features/prefecture-team/services/get-prefecture-team-ranking.ts
+++ b/src/features/prefecture-team/services/get-prefecture-team-ranking.ts
@@ -6,6 +6,7 @@ import type {
   PrefectureTeamRanking,
   UserPrefectureContribution,
 } from "../types/prefecture-team-types";
+import { calculateContributionPercent } from "../utils/contribution-utils";
 import {
   type PrefectureTeamRankingRow,
   transformToXpPerCapitaRanking,
@@ -93,10 +94,10 @@ export async function getUserPrefectureContribution(
 
     const contribution = data[0];
 
-    const contributionPercent =
-      contribution.prefecture_total_xp > 0
-        ? (contribution.user_xp / contribution.prefecture_total_xp) * 100
-        : 0;
+    const contributionPercent = calculateContributionPercent(
+      contribution.user_xp,
+      contribution.prefecture_total_xp,
+    );
 
     return {
       prefecture: contribution.prefecture,

--- a/src/features/prefecture-team/utils/contribution-utils.test.ts
+++ b/src/features/prefecture-team/utils/contribution-utils.test.ts
@@ -1,0 +1,19 @@
+import { calculateContributionPercent } from "./contribution-utils";
+
+describe("calculateContributionPercent", () => {
+  it("returns 0 when totalXp is 0", () => {
+    expect(calculateContributionPercent(100, 0)).toBe(0);
+  });
+
+  it("returns 0 when totalXp is negative", () => {
+    expect(calculateContributionPercent(100, -10)).toBe(0);
+  });
+
+  it("calculates correct percentage", () => {
+    expect(calculateContributionPercent(25, 100)).toBe(25);
+  });
+
+  it("returns 100 when user has all XP", () => {
+    expect(calculateContributionPercent(500, 500)).toBe(100);
+  });
+});

--- a/src/features/prefecture-team/utils/contribution-utils.ts
+++ b/src/features/prefecture-team/utils/contribution-utils.ts
@@ -1,0 +1,12 @@
+/**
+ * ユーザーXPの都道府県合計XPに対する貢献パーセントを計算する
+ */
+export function calculateContributionPercent(
+  userXp: number,
+  totalXp: number,
+): number {
+  if (totalXp <= 0) {
+    return 0;
+  }
+  return (userXp / totalXp) * 100;
+}


### PR DESCRIPTION
# 変更の概要
- `party-membership/services/memberships.ts` から `deduplicateUserIds` と `buildMembershipMap` を `utils/membership-helpers.ts` に切り出し
- `prefecture-team/services/get-prefecture-team-ranking.ts` から貢献パーセント計算ロジックを `utils/contribution-utils.ts` の `calculateContributionPercent` に切り出し
- 切り出した関数に対して合計11件のユニットテストを追加（カバレッジ100%）

# 変更の背景
- Service層にインラインで書かれていた純粋なロジックをutils層に分離し、テスタビリティと再利用性を向上させる

## テスト内容
- `deduplicateUserIds`: 重複排除、空文字フィルタ、空配列（3件）
- `buildMembershipMap`: 配列からMap変換、空配列、null user_id、重複user_id（4件）
- `calculateContributionPercent`: 0除算、負の値、正常計算、100%（4件）

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました