### PR TITLE
refactor: extract isTokenExpired and parseOAuthScopes into oauth-utils

### DIFF
--- a/src/features/tiktok/actions/tiktok-video-actions.ts
+++ b/src/features/tiktok/actions/tiktok-video-actions.ts
@@ -3,6 +3,7 @@
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
 import { logger } from "@/lib/utils/logger";
+import { isTokenExpired } from "@/lib/utils/oauth-utils";
 import {
   getUserTikTokVideos,
   syncUserTikTokVideos,
@@ -42,7 +43,7 @@ export async function syncMyTikTokVideosAction(): Promise<TikTokSyncResult> {
     }
 
     // トークンの有効期限をチェック
-    if (new Date(connection.tokenExpiresAt) < new Date()) {
+    if (isTokenExpired(connection.tokenExpiresAt)) {
       // トークンが期限切れの場合、リフレッシュを試みる
       logger.debug("TikTok access token expired, attempting refresh...");
       const refreshResult = await refreshTikTokTokenAction();

--- a/src/features/youtube/actions/youtube-auth-actions.ts
+++ b/src/features/youtube/actions/youtube-auth-actions.ts
@@ -3,6 +3,7 @@
 import { headers } from "next/headers";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
+import { parseOAuthScopes } from "@/lib/utils/oauth-utils";
 import {
   exchangeCodeForToken,
   fetchChannelInfo,
@@ -113,7 +114,7 @@ export async function handleYouTubeLinkAction(
           token_expires_at: new Date(
             Date.now() + tokens.expires_in * 1000,
           ).toISOString(),
-          scopes: tokens.scope ? tokens.scope.split(" ") : null,
+          scopes: tokens.scope ? parseOAuthScopes(tokens.scope) : null,
         },
         {
           onConflict: "user_id",

--- a/src/lib/utils/oauth-utils.test.ts
+++ b/src/lib/utils/oauth-utils.test.ts
@@ -1,0 +1,57 @@
+import { isTokenExpired, parseOAuthScopes } from "./oauth-utils";
+
+describe("isTokenExpired", () => {
+  it("過去の日時は期限切れと判定する", () => {
+    const pastDate = new Date(Date.now() - 60 * 1000).toISOString();
+    expect(isTokenExpired(pastDate)).toBe(true);
+  });
+
+  it("未来の日時は有効と判定する", () => {
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    expect(isTokenExpired(futureDate)).toBe(false);
+  });
+
+  it("Date型の引数も受け付ける", () => {
+    const pastDate = new Date(Date.now() - 60 * 1000);
+    expect(isTokenExpired(pastDate)).toBe(true);
+
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+    expect(isTokenExpired(futureDate)).toBe(false);
+  });
+
+  it("ISO 8601文字列を正しくパースする", () => {
+    expect(isTokenExpired("2020-01-01T00:00:00.000Z")).toBe(true);
+    expect(isTokenExpired("2099-12-31T23:59:59.000Z")).toBe(false);
+  });
+
+  it("境界値: 1秒前は期限切れ", () => {
+    const justPast = new Date(Date.now() - 1000).toISOString();
+    expect(isTokenExpired(justPast)).toBe(true);
+  });
+});
+
+describe("parseOAuthScopes", () => {
+  it("スペース区切りの文字列を配列に分割する", () => {
+    expect(parseOAuthScopes("read write profile")).toEqual([
+      "read",
+      "write",
+      "profile",
+    ]);
+  });
+
+  it("単一スコープの場合は1要素の配列を返す", () => {
+    expect(parseOAuthScopes("read")).toEqual(["read"]);
+  });
+
+  it("nullの場合は空配列を返す", () => {
+    expect(parseOAuthScopes(null)).toEqual([]);
+  });
+
+  it("undefinedの場合は空配列を返す", () => {
+    expect(parseOAuthScopes(undefined)).toEqual([]);
+  });
+
+  it("空文字の場合は空配列を返す", () => {
+    expect(parseOAuthScopes("")).toEqual([]);
+  });
+});

--- a/src/lib/utils/oauth-utils.ts
+++ b/src/lib/utils/oauth-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * トークンの有効期限が切れているかどうかを判定する
+ */
+export function isTokenExpired(expiresAt: string | Date): boolean {
+  return new Date(expiresAt) < new Date();
+}
+
+/**
+ * OAuthスコープ文字列をスペース区切りで配列にパースする
+ */
+export function parseOAuthScopes(
+  scopeString: string | null | undefined,
+): string[] {
+  if (!scopeString) {
+    return [];
+  }
+  return scopeString.split(" ");
+}


### PR DESCRIPTION
# 変更の概要
- トークン有効期限チェック (`isTokenExpired`) を `src/lib/utils/oauth-utils.ts` に切り出し
- OAuthスコープ文字列パース (`parseOAuthScopes`) を同ファイルに切り出し
- TikTok動画アクションとYouTube認証アクションから共通関数を利用するよう変更
- 両ユーティリティのテストを追加（計10テストケース）

# 変更の背景
- TikTokとYouTubeでOAuth関連のインラインロジックが散在しており、テストも書きづらい状態だった
- トークン期限チェックやスコープパースは汎用的な処理であり、共通ユーティリティとして切り出すことで再利用性とテスタビリティを向上

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました