### PR TITLE
refactor: 活動テキスト生成関数をartifact-helpersからutils層に切り出し

### DIFF
--- a/src/features/mission-detail/actions/artifact-helpers.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.ts
@@ -1,4 +1,9 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  buildPosterActivityText,
+  buildPostingActivityText,
+  getArtifactTypeLabel,
+} from "@/features/mission-detail/utils/activity-text-builders";
 import { grantXp } from "@/features/user-level/services/level";
 import { MAX_POSTER_COUNT } from "@/lib/constants/mission-config";
 import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
@@ -73,19 +78,25 @@ const ARTIFACT_PAYLOAD_BUILDERS: Record<
       return nullFields();
     return {
       link_url: null,
-      text_content: `${data.postingCount}枚を${data.locationText}に配布`,
+      text_content: buildPostingActivityText(
+        data.postingCount,
+        data.locationText,
+      ),
       image_storage_path: null,
     };
   },
   [ARTIFACT_TYPES.POSTER.key]: (data) => {
     if (data.requiredArtifactType !== ARTIFACT_TYPES.POSTER.key)
       return nullFields();
-    const locationInfo = `${data.prefecture}${data.city} ${data.boardNumber}`;
-    const nameInfo = data.boardName ? ` (${data.boardName})` : "";
-    const statusInfo = data.boardNote ? ` - 状況: ${data.boardNote}` : "";
     return {
       link_url: null,
-      text_content: `${locationInfo}${nameInfo}に貼付${statusInfo}`,
+      text_content: buildPosterActivityText(
+        data.prefecture,
+        data.city,
+        data.boardNumber,
+        data.boardName,
+        data.boardNote,
+      ),
       image_storage_path: null,
     };
   },
@@ -125,17 +136,8 @@ export function buildArtifactPayload(
   return builder(validatedData);
 }
 
-/**
- * artifact type のラベルを取得する（ログ用）。
- */
-export function getArtifactTypeLabel(artifactType: string): string {
-  for (const type of Object.values(ARTIFACT_TYPES)) {
-    if (type.key === artifactType) {
-      return type.key;
-    }
-  }
-  return "OTHER";
-}
+// getArtifactTypeLabel is re-exported from activity-text-builders
+export { getArtifactTypeLabel };
 
 /**
  * POSTING / POSTER 共通のボーナスXP計算・付与。

--- a/src/features/mission-detail/utils/activity-text-builders.test.ts
+++ b/src/features/mission-detail/utils/activity-text-builders.test.ts
@@ -1,0 +1,79 @@
+import {
+  buildPosterActivityText,
+  buildPostingActivityText,
+  getArtifactTypeLabel,
+} from "./activity-text-builders";
+
+describe("buildPosterActivityText", () => {
+  it("should build text with all fields", () => {
+    expect(
+      buildPosterActivityText(
+        "東京都",
+        "千代田区",
+        "001",
+        "中央掲示板",
+        "良好",
+      ),
+    ).toBe("東京都千代田区 001 (中央掲示板)に貼付 - 状況: 良好");
+  });
+
+  it("should build text without boardName", () => {
+    expect(
+      buildPosterActivityText("大阪府", "大阪市", "002", null, "破損あり"),
+    ).toBe("大阪府大阪市 002に貼付 - 状況: 破損あり");
+  });
+
+  it("should build text without boardNote", () => {
+    expect(
+      buildPosterActivityText("北海道", "札幌市", "003", "駅前", null),
+    ).toBe("北海道札幌市 003 (駅前)に貼付");
+  });
+
+  it("should build text without boardName and boardNote", () => {
+    expect(buildPosterActivityText("福岡県", "福岡市", "004")).toBe(
+      "福岡県福岡市 004に貼付",
+    );
+  });
+
+  it("should handle undefined boardName and boardNote", () => {
+    expect(
+      buildPosterActivityText("京都府", "京都市", "005", undefined, undefined),
+    ).toBe("京都府京都市 005に貼付");
+  });
+});
+
+describe("buildPostingActivityText", () => {
+  it("should build text with count and location", () => {
+    expect(buildPostingActivityText(100, "渋谷区")).toBe("100枚を渋谷区に配布");
+  });
+
+  it("should handle zero count", () => {
+    expect(buildPostingActivityText(0, "新宿区")).toBe("0枚を新宿区に配布");
+  });
+
+  it("should handle large count", () => {
+    expect(buildPostingActivityText(10000, "港区")).toBe("10000枚を港区に配布");
+  });
+
+  it("should handle undefined locationText", () => {
+    expect(buildPostingActivityText(50)).toBe("50枚をに配布");
+  });
+});
+
+describe("getArtifactTypeLabel", () => {
+  it("should return the key for known artifact types", () => {
+    expect(getArtifactTypeLabel("LINK")).toBe("LINK");
+    expect(getArtifactTypeLabel("TEXT")).toBe("TEXT");
+    expect(getArtifactTypeLabel("IMAGE")).toBe("IMAGE");
+    expect(getArtifactTypeLabel("POSTER")).toBe("POSTER");
+    expect(getArtifactTypeLabel("POSTING")).toBe("POSTING");
+  });
+
+  it("should return OTHER for unknown artifact type", () => {
+    expect(getArtifactTypeLabel("UNKNOWN_TYPE")).toBe("OTHER");
+  });
+
+  it("should return OTHER for empty string", () => {
+    expect(getArtifactTypeLabel("")).toBe("OTHER");
+  });
+});

--- a/src/features/mission-detail/utils/activity-text-builders.ts
+++ b/src/features/mission-detail/utils/activity-text-builders.ts
@@ -1,0 +1,40 @@
+import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
+
+/**
+ * ポスター活動のテキストを生成する。
+ */
+export function buildPosterActivityText(
+  prefecture: string,
+  city: string,
+  boardNumber: string,
+  boardName?: string | null,
+  boardNote?: string | null,
+): string {
+  const locationInfo = `${prefecture}${city} ${boardNumber}`;
+  const nameInfo = boardName ? ` (${boardName})` : "";
+  const statusInfo = boardNote ? ` - 状況: ${boardNote}` : "";
+  return `${locationInfo}${nameInfo}に貼付${statusInfo}`;
+}
+
+/**
+ * ポスティング活動のテキストを生成する。
+ */
+export function buildPostingActivityText(
+  postingCount: number,
+  locationText?: string,
+): string {
+  return `${postingCount}枚を${locationText ?? ""}に配布`;
+}
+
+/**
+ * artifact type のラベルを取得する（ログ用）。
+ * ARTIFACT_TYPES に存在するキーならそのまま返し、存在しなければ "OTHER" を返す。
+ */
+export function getArtifactTypeLabel(artifactType: string): string {
+  for (const type of Object.values(ARTIFACT_TYPES)) {
+    if (type.key === artifactType) {
+      return type.key;
+    }
+  }
+  return "OTHER";
+}


### PR DESCRIPTION
# 変更の概要
- `buildPosterActivityText`、`buildPostingActivityText`、`getArtifactTypeLabel` を `artifact-helpers.ts` から `src/features/mission-detail/utils/activity-text-builders.ts` に切り出し
- 元の `artifact-helpers.ts` は切り出した関数を import して使用し、`getArtifactTypeLabel` は後方互換のため re-export
- 各関数のユニットテストを追加（100%カバレッジ、12テスト）

# 変更の背景
- `artifact-helpers.ts` はServer ActionのDB操作を含む重いファイルで、テキスト生成のような純粋関数が混在していた
- 純粋関数をutils層に分離することでテスタビリティと見通しを向上

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- [x] CLAの内容を読み、同意しました