### PR TITLE
test: difficulty-styles ユニットテスト追加

### DIFF
--- a/src/features/missions/utils/difficulty-styles.test.ts
+++ b/src/features/missions/utils/difficulty-styles.test.ts
@@ -1,0 +1,51 @@
+import {
+  difficultyLabels,
+  getDifficultyLabel,
+  getDifficultyStyles,
+} from "./difficulty-styles";
+
+describe("getDifficultyStyles", () => {
+  it.each([
+    1, 2, 3, 4, 5, 0, 99,
+  ])("difficulty %i に対して固定CSS文字列を返す", (difficulty) => {
+    expect(getDifficultyStyles(difficulty)).toBe(
+      "text-gray-700 border-gray-400 hover:bg-gray-50",
+    );
+  });
+});
+
+describe("getDifficultyLabel", () => {
+  it.each([
+    [1, "⭐"],
+    [2, "⭐⭐"],
+    [3, "⭐⭐⭐"],
+    [4, "⭐⭐⭐⭐"],
+    [5, "⭐⭐⭐⭐⭐"],
+  ])("difficulty %i → %s を返す", (difficulty, expected) => {
+    expect(getDifficultyLabel(difficulty)).toBe(expected);
+  });
+
+  it.each([
+    0, 6, 99,
+  ])("範囲外の difficulty %i → 数値フォールバック", (difficulty) => {
+    expect(getDifficultyLabel(difficulty)).toBe(difficulty);
+  });
+});
+
+describe("difficultyLabels", () => {
+  it("1-5のキーが全て存在する", () => {
+    for (let i = 1; i <= 5; i++) {
+      expect(difficultyLabels[i]).toBeDefined();
+    }
+  });
+
+  it.each([
+    [1, "⭐"],
+    [2, "⭐⭐"],
+    [3, "⭐⭐⭐"],
+    [4, "⭐⭐⭐⭐"],
+    [5, "⭐⭐⭐⭐⭐"],
+  ])("キー %i が %s に対応する", (key, expected) => {
+    expect(difficultyLabels[key]).toBe(expected);
+  });
+});


### PR DESCRIPTION
# 変更の概要
- `getDifficultyStyles` が任意のdifficultyに対して固定CSS文字列を返すことをテスト
- `getDifficultyLabel` が difficulty 1-5 に対して星絵文字を返し、範囲外は数値フォールバックすることをテスト
- `difficultyLabels` Record に1-5のキーが全て存在し、正しい星絵文字に対応することをテスト

# 変更の背景
Phase 5 テストカバレッジ向上の一環

# スクリーンショット
- [x] フロントエンドの変更はありません

# CLAへの同意
- [ ] このプルリクエストに含まれるすべてのコードは、プロジェクトのCLAに基づいて提供されることに同意します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ミッション難易度スタイルユーティリティの包括的なテストスイートを追加しました。これにより、難易度スタイル、ラベル、およびマッピング機能の動作を検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->