### PR TITLE
refactor: isValidUrl関数をurl-validation.tsに切り出し

### DIFF
--- a/src/features/user-profile/components/social-badge.tsx
+++ b/src/features/user-profile/components/social-badge.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
+import { isValidUrl } from "@/lib/utils/url-validation";
 
 interface SocialBadgeProps {
   title: string;
@@ -8,15 +9,6 @@ interface SocialBadgeProps {
   logoAlt: string;
   logoSize: number;
 }
-
-const isValidUrl = (url: string) => {
-  try {
-    const parsedUrl = new URL(url);
-    return ["http:", "https:"].includes(parsedUrl.protocol);
-  } catch {
-    return false;
-  }
-};
 
 function SocialBadge({
   title,

--- a/src/lib/utils/url-validation.test.ts
+++ b/src/lib/utils/url-validation.test.ts
@@ -1,0 +1,35 @@
+import { isValidUrl } from "./url-validation";
+
+describe("isValidUrl", () => {
+  it("http URL を有効と判定する", () => {
+    expect(isValidUrl("http://example.com")).toBe(true);
+  });
+
+  it("https URL を有効と判定する", () => {
+    expect(isValidUrl("https://example.com")).toBe(true);
+  });
+
+  it("ftp URL を無効と判定する", () => {
+    expect(isValidUrl("ftp://example.com")).toBe(false);
+  });
+
+  it("javascript: URL を無効と判定する", () => {
+    expect(isValidUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("不正な文字列を無効と判定する", () => {
+    expect(isValidUrl("not-a-url")).toBe(false);
+  });
+
+  it("空文字を無効と判定する", () => {
+    expect(isValidUrl("")).toBe(false);
+  });
+
+  it("パス付きURLを有効と判定する", () => {
+    expect(isValidUrl("https://example.com/path/to/page")).toBe(true);
+  });
+
+  it("クエリパラメータ付きURLを有効と判定する", () => {
+    expect(isValidUrl("https://example.com?key=value&foo=bar")).toBe(true);
+  });
+});

--- a/src/lib/utils/url-validation.ts
+++ b/src/lib/utils/url-validation.ts
@@ -1,0 +1,8 @@
+export function isValidUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return ["http:", "https:"].includes(parsedUrl.protocol);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
# 変更の概要
- `social-badge.tsx`内のローカル`isValidUrl`関数を`src/lib/utils/url-validation.ts`に切り出し
- 元ファイルをimportに変更し、共通ユーティリティとして再利用可能に
- URL検証ロジックのユニットテスト(8ケース)を追加

# 変更の背景
Phase 5 テストカバレッジ向上の一環

# スクリーンショット
- [x] フロントエンドの変更はありません

# CLAへの同意
- [ ] このプルリクエストに含まれるすべてのコードは、プロジェクトのCLAに基づいて提供されることに同意します。