### PR TITLE
refactor: TikTokVideoCard のフォーマット関数を utils に切り出し

### DIFF
--- a/src/features/tiktok/components/tiktok-video-card.tsx
+++ b/src/features/tiktok/components/tiktok-video-card.tsx
@@ -1,44 +1,12 @@
 import { Eye, Heart, MessageCircle, Share2 } from "lucide-react";
 import Link from "next/link";
+import { formatNumberJa } from "@/lib/utils/format-number-ja";
 import type { TikTokVideo, TikTokVideoStats } from "../types";
+import { formatDuration, formatTikTokDate } from "../utils/format-utils";
 import { TikTokIcon } from "./tiktok-icon";
 
 interface TikTokVideoCardProps {
   video: TikTokVideo & { latest_stats?: TikTokVideoStats };
-}
-
-function formatDuration(seconds: number | null): string {
-  if (!seconds) return "";
-  const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
-}
-
-function formatDate(dateStr: string | null): string {
-  if (!dateStr) return "";
-  return new Date(dateStr).toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-function formatNumberJa(num: number | null): string {
-  if (num === null) return "-";
-
-  const absNum = Math.abs(num);
-
-  if (absNum >= 100_000_000) {
-    const value = num / 100_000_000;
-    return value % 1 === 0 ? `${value}億` : `${value.toFixed(1)}億`;
-  }
-
-  if (absNum >= 10_000) {
-    const value = num / 10_000;
-    return value % 1 === 0 ? `${value}万` : `${value.toFixed(1)}万`;
-  }
-
-  return num.toLocaleString();
 }
 
 export function TikTokVideoCard({ video }: TikTokVideoCardProps) {
@@ -83,7 +51,7 @@ export function TikTokVideoCard({ video }: TikTokVideoCardProps) {
         {/* クリエイター名・日付 */}
         <p className="text-xs text-gray-500 truncate">
           {video.creator_username ? `@${video.creator_username}` : "TikTok"} •{" "}
-          {formatDate(video.published_at)}
+          {formatTikTokDate(video.published_at)}
         </p>
 
         {/* 統計 */}

--- a/src/features/tiktok/utils/format-utils.test.ts
+++ b/src/features/tiktok/utils/format-utils.test.ts
@@ -1,0 +1,55 @@
+import { formatDuration, formatTikTokDate } from "./format-utils";
+
+describe("formatDuration", () => {
+  it("null を渡すと空文字を返す", () => {
+    expect(formatDuration(null)).toBe("");
+  });
+
+  it("0 を渡すと空文字を返す", () => {
+    expect(formatDuration(0)).toBe("");
+  });
+
+  it("60秒を 1:00 に変換する", () => {
+    expect(formatDuration(60)).toBe("1:00");
+  });
+
+  it("125秒を 2:05 に変換する", () => {
+    expect(formatDuration(125)).toBe("2:05");
+  });
+
+  it("3661秒を 61:01 に変換する", () => {
+    expect(formatDuration(3661)).toBe("61:01");
+  });
+
+  it("30秒を 0:30 に変換する", () => {
+    expect(formatDuration(30)).toBe("0:30");
+  });
+
+  it("1秒を 0:01 に変換する", () => {
+    expect(formatDuration(1)).toBe("0:01");
+  });
+});
+
+describe("formatTikTokDate", () => {
+  it("null を渡すと空文字を返す", () => {
+    expect(formatTikTokDate(null)).toBe("");
+  });
+
+  it("空文字を渡すと空文字を返す", () => {
+    expect(formatTikTokDate("")).toBe("");
+  });
+
+  it("有効な日付文字列を ja-JP 形式に変換する", () => {
+    const result = formatTikTokDate("2024-01-15T00:00:00Z");
+    expect(result).toMatch(/2024/);
+    expect(result).toMatch(/1/);
+    expect(result).toMatch(/15/);
+  });
+
+  it("別の日付でも正しくフォーマットされる", () => {
+    const result = formatTikTokDate("2023-12-25");
+    expect(result).toMatch(/2023/);
+    expect(result).toMatch(/12/);
+    expect(result).toMatch(/25/);
+  });
+});

--- a/src/features/tiktok/utils/format-utils.ts
+++ b/src/features/tiktok/utils/format-utils.ts
@@ -1,0 +1,15 @@
+export function formatDuration(seconds: number | null): string {
+  if (!seconds) return "";
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+export function formatTikTokDate(dateStr: string | null): string {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}


### PR DESCRIPTION
# 変更の概要
- `tiktok-video-card.tsx` のローカル関数 `formatDuration`, `formatDate` を `src/features/tiktok/utils/format-utils.ts` に切り出し
- 重複していた `formatNumberJa` を `src/lib/utils/format-number-ja.ts` の既存ライブラリ版に統一
- 切り出した関数のユニットテストを追加（100%カバレッジ）

# 変更の背景
Phase 5 テストカバレッジ向上の一環

# スクリーンショット
- [x] フロントエンドの変更はありません

# CLAへの同意
- [ ] このプルリクエストに含まれるすべてのコードは、プロジェクトのCLAに基づいて提供されることに同意します。