### PR TITLE
refactor: 日付フォームユーティリティをdate-form-utils.tsに切り出し

### DIFF
--- a/src/features/user-settings/components/profile-form.tsx
+++ b/src/features/user-settings/components/profile-form.tsx
@@ -35,10 +35,10 @@ import { updateProfile } from "@/features/user-settings/actions/profile-actions"
 import { PrefectureSelect } from "@/features/user-settings/components/prefecture-select";
 import { AVATAR_MAX_FILE_SIZE, getAvatarUrl } from "@/lib/services/avatar";
 import {
-  formatDateComponents,
-  getDaysInMonth,
-  verifyMinimumAge,
-} from "@/lib/utils/form-date-utils";
+  formatBirthDate,
+  generateDaysArray,
+} from "@/lib/utils/date-form-utils";
+import { verifyMinimumAge } from "@/lib/utils/form-date-utils";
 
 // AvatarUploadコンポーネントを削除し、メインのフォームに統合
 
@@ -101,9 +101,9 @@ export default function ProfileForm({
   const birthYearThreshold = new Date().getFullYear() - 18;
   const years = Array.from({ length: 100 }, (_, i) => birthYearThreshold - i);
   const months = Array.from({ length: 12 }, (_, i) => i + 1);
-  const days = getDaysInMonth(selectedYear, selectedMonth);
+  const days = generateDaysArray(selectedYear, selectedMonth);
 
-  const formattedDate = formatDateComponents(
+  const formattedDate = formatBirthDate(
     selectedYear,
     selectedMonth,
     selectedDay,

--- a/src/lib/utils/date-form-utils.test.ts
+++ b/src/lib/utils/date-form-utils.test.ts
@@ -1,0 +1,55 @@
+import {
+  formatBirthDate,
+  generateDaysArray,
+  getDaysInMonth,
+} from "./date-form-utils";
+
+describe("formatBirthDate", () => {
+  it("引数がnullの場合は空文字列を返す", () => {
+    expect(formatBirthDate(null, 1, 5)).toBe("");
+    expect(formatBirthDate(2000, null, 5)).toBe("");
+    expect(formatBirthDate(2000, 1, null)).toBe("");
+  });
+
+  it("月日を0パディングしてYYYY-MM-DD形式を返す", () => {
+    expect(formatBirthDate(2000, 1, 5)).toBe("2000-01-05");
+  });
+
+  it("2桁の月日はそのまま出力する", () => {
+    expect(formatBirthDate(2024, 12, 31)).toBe("2024-12-31");
+  });
+});
+
+describe("getDaysInMonth", () => {
+  it("うるう年の2月は29を返す", () => {
+    expect(getDaysInMonth(2024, 2)).toBe(29);
+  });
+
+  it("平年の2月は28を返す", () => {
+    expect(getDaysInMonth(2023, 2)).toBe(28);
+  });
+
+  it("4月は30を返す", () => {
+    expect(getDaysInMonth(2024, 4)).toBe(30);
+  });
+
+  it("1月は31を返す", () => {
+    expect(getDaysInMonth(2024, 1)).toBe(31);
+  });
+});
+
+describe("generateDaysArray", () => {
+  it("うるう年の2月は1から29までの配列を返す", () => {
+    const days = generateDaysArray(2024, 2);
+    expect(days).toHaveLength(29);
+    expect(days[0]).toBe(1);
+    expect(days[28]).toBe(29);
+  });
+
+  it("平年の2月は1から28までの配列を返す", () => {
+    const days = generateDaysArray(2023, 2);
+    expect(days).toHaveLength(28);
+    expect(days[0]).toBe(1);
+    expect(days[27]).toBe(28);
+  });
+});

--- a/src/lib/utils/date-form-utils.ts
+++ b/src/lib/utils/date-form-utils.ts
@@ -1,0 +1,17 @@
+export function formatBirthDate(
+  year: number | null,
+  month: number | null,
+  day: number | null,
+): string {
+  if (!year || !month || !day) return "";
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${year}-${pad(month)}-${pad(day)}`;
+}
+
+export function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+export function generateDaysArray(year: number, month: number): number[] {
+  return Array.from({ length: getDaysInMonth(year, month) }, (_, i) => i + 1);
+}


### PR DESCRIPTION
# 変更の概要
- `formatBirthDate`, `getDaysInMonth`, `generateDaysArray`を`src/lib/utils/date-form-utils.ts`に切り出し
- `profile-form.tsx`と`two-step-sign-up-form.tsx`の重複した日付フォーマット・日数計算ロジックを解消
- `two-step-sign-up-form.tsx`のインライン`verifyAge`を`verifyMinimumAge`ユーティリティに置換
- ユニットテスト(9ケース)を追加

# 変更の背景
Phase 5 テストカバレッジ向上の一環

# スクリーンショット
- [x] フロントエンドの変更はありません

# CLAへの同意
- [ ] このプルリクエストに含まれるすべてのコードは、プロジェクトのCLAに基づいて提供されることに同意します。