### PR TITLE
docs: AGENTS.mdに認可ルールを追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,14 @@ const { data } = await supabase.from("table").select(); // NG: 直接アクセ�
 - **`createClient()` / `getAuth()` / `getStorage()`**: 認証操作（`supabase.auth.*`）やStorage操作に使用。cookie連携あり。
 - **`createAdminClient()`**: DB操作（`supabase.from(...)`）に使用。service_roleでRLSバイパス。
 - **`createAdminClient()` で `supabase.auth.*` を呼んではいけない**（cookieが読めずセッション取得失敗）
+- **クライアントコンポーネントからDB操作を呼ぶ場合**: `actions/`（mutation）または `loaders/`（読み取り）経由。`services/` を直接importしない。
+
+### 認可（Authorization）のルール
+
+- **userIdは必ずサーバーサイドでセッションから取得する**。クライアントからuserIdを引数で受け取ってはいけない（改ざん可能なため）。
+- **認可チェックはactions層で行う**。services層はデータ操作に専念し、認可ロジックを混在させない。
+- **リソースの所有者チェックは専用の認可関数に分離する**。サービス関数のクエリに `.eq("user_id", userId)` を埋め込むのではなく、`authorizeXxxOwner()` のような関数で事前に所有権を検証する。
+
 
 ### 主要技術スタック
 - **フレームワーク**: Next.js 15 with App Router


### PR DESCRIPTION
## Summary
- AGENTS.mdに認可（Authorization）のルールを追記
  - userIdはサーバーサイドでセッションから取得する（クライアントから受け取らない）
  - 認可チェックはactions層で行い、services層はデータ操作に専念する
  - リソース所有者チェックは`authorizeXxxOwner()`のような専用関数に分離する
- クライアントコンポーネントからDB操作を呼ぶ場合のルールを追記（actions/loaders経由）

## Test plan
- ドキュメントのみの変更のため、動作テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)