### PR TITLE
refactor: metrics + action-stats + youtube-stats + tiktok-stats の loaders パターン適用

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -9,7 +9,7 @@ import {
   getDailyActionHistory,
   getDailyActiveUsersHistory,
   getMissionActionRanking,
-} from "@/features/action-stats/services/action-stats-service";
+} from "@/features/action-stats/loaders/action-stats-loaders";
 import {
   getPeriodEndDate,
   getPeriodStartDate,

--- a/src/app/tiktok_stats/page.tsx
+++ b/src/app/tiktok_stats/page.tsx
@@ -11,7 +11,7 @@ import {
   getTikTokVideoCount,
   getTikTokVideosWithStats,
   getVideoCountByDate,
-} from "@/features/tiktok-stats/services/tiktok-stats-service";
+} from "@/features/tiktok-stats/loaders/tiktok-stats-loaders";
 import {
   getPeriodEndDate,
   getPeriodStartDate,

--- a/src/app/youtube_stats/page.tsx
+++ b/src/app/youtube_stats/page.tsx
@@ -11,7 +11,7 @@ import {
   getYouTubeStatsSummary,
   getYouTubeVideoCount,
   getYouTubeVideosWithStats,
-} from "@/features/youtube-stats/services/youtube-stats-service";
+} from "@/features/youtube-stats/loaders/youtube-stats-loaders";
 import {
   getPeriodEndDate,
   getPeriodStartDate,

--- a/src/features/action-stats/loaders/action-stats-loaders.ts
+++ b/src/features/action-stats/loaders/action-stats-loaders.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import {
+  getActionStatsSummary as getActionStatsSummaryService,
+  getDailyActionHistory as getDailyActionHistoryService,
+  getDailyActiveUsersHistory as getDailyActiveUsersHistoryService,
+  getMissionActionRanking as getMissionActionRankingService,
+} from "../services/action-stats-service";
+
+export async function getActionStatsSummary(startDate?: Date, endDate?: Date) {
+  return getActionStatsSummaryService(startDate, endDate);
+}
+
+export async function getDailyActionHistory(startDate?: Date, endDate?: Date) {
+  return getDailyActionHistoryService(startDate, endDate);
+}
+
+export async function getDailyActiveUsersHistory(
+  startDate?: Date,
+  endDate?: Date,
+) {
+  return getDailyActiveUsersHistoryService(startDate, endDate);
+}
+
+export async function getMissionActionRanking(
+  startDate?: Date,
+  endDate?: Date,
+  limit?: number,
+) {
+  return getMissionActionRankingService(startDate, endDate, limit);
+}

--- a/src/features/metrics/components/metrics-index.tsx
+++ b/src/features/metrics/components/metrics-index.tsx
@@ -2,10 +2,10 @@ import { Separator } from "@/components/ui/separator";
 import {
   fetchAchievementData,
   fetchSupporterData,
-} from "@/features/metrics/services/get-metrics";
+} from "@/features/metrics/loaders/metrics-loaders";
 import type { AchievementData } from "@/features/metrics/types/metrics-types";
-import { getTikTokStatsSummary } from "@/features/tiktok-stats/services/tiktok-stats-service";
-import { getYouTubeStatsSummary } from "@/features/youtube-stats/services/youtube-stats-service";
+import { getTikTokStatsSummary } from "@/features/tiktok-stats/loaders/tiktok-stats-loaders";
+import { getYouTubeStatsSummary } from "@/features/youtube-stats/loaders/youtube-stats-loaders";
 import { formatUpdateTime } from "@/lib/utils/metrics-formatter";
 import { AchievementMetric } from "./achievement-metric";
 import { MetricsLayout } from "./metrics-layout";

--- a/src/features/metrics/loaders/metrics-loaders.ts
+++ b/src/features/metrics/loaders/metrics-loaders.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import {
+  fetchAchievementData as fetchAchievementDataService,
+  fetchAllMetricsData as fetchAllMetricsDataService,
+  fetchDonationData as fetchDonationDataService,
+  fetchRegistrationData as fetchRegistrationDataService,
+  fetchSupporterData as fetchSupporterDataService,
+} from "../services/get-metrics";
+
+export async function fetchSupporterData() {
+  return fetchSupporterDataService();
+}
+
+export async function fetchDonationData() {
+  return fetchDonationDataService();
+}
+
+export async function fetchAchievementData(startDate?: Date) {
+  return fetchAchievementDataService(startDate);
+}
+
+export async function fetchRegistrationData() {
+  return fetchRegistrationDataService();
+}
+
+export async function fetchAllMetricsData() {
+  return fetchAllMetricsDataService();
+}

--- a/src/features/tiktok-stats/loaders/tiktok-stats-loaders.ts
+++ b/src/features/tiktok-stats/loaders/tiktok-stats-loaders.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import {
+  getOverallStatsHistory as getOverallStatsHistoryService,
+  getTikTokStatsSummary as getTikTokStatsSummaryService,
+  getTikTokVideoCount as getTikTokVideoCountService,
+  getTikTokVideosWithStats as getTikTokVideosWithStatsService,
+  getVideoCountByDate as getVideoCountByDateService,
+} from "../services/tiktok-stats-service";
+import type { SortType } from "../types";
+
+export async function getTikTokVideosWithStats(
+  limit: number,
+  offset: number,
+  sortBy: SortType,
+  startDate?: Date,
+  endDate?: Date,
+) {
+  return getTikTokVideosWithStatsService(
+    limit,
+    offset,
+    sortBy,
+    startDate,
+    endDate,
+  );
+}
+
+export async function getTikTokVideoCount(startDate?: Date, endDate?: Date) {
+  return getTikTokVideoCountService(startDate, endDate);
+}
+
+export async function getTikTokStatsSummary(startDate?: Date, endDate?: Date) {
+  return getTikTokStatsSummaryService(startDate, endDate);
+}
+
+export async function getOverallStatsHistory(startDate?: Date, endDate?: Date) {
+  return getOverallStatsHistoryService(startDate, endDate);
+}
+
+export async function getVideoCountByDate(startDate?: Date, endDate?: Date) {
+  return getVideoCountByDateService(startDate, endDate);
+}

--- a/src/features/youtube-stats/loaders/youtube-stats-loaders.ts
+++ b/src/features/youtube-stats/loaders/youtube-stats-loaders.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import {
+  getOverallStatsHistory as getOverallStatsHistoryService,
+  getVideoCountByDate as getVideoCountByDateService,
+  getYouTubeStatsSummary as getYouTubeStatsSummaryService,
+  getYouTubeVideoCount as getYouTubeVideoCountService,
+  getYouTubeVideosWithStats as getYouTubeVideosWithStatsService,
+} from "../services/youtube-stats-service";
+import type { SortType } from "../types";
+
+export async function getYouTubeVideosWithStats(
+  limit: number,
+  offset: number,
+  sortBy: SortType,
+  startDate?: Date,
+  endDate?: Date,
+) {
+  return getYouTubeVideosWithStatsService(
+    limit,
+    offset,
+    sortBy,
+    startDate,
+    endDate,
+  );
+}
+
+export async function getYouTubeVideoCount(startDate?: Date, endDate?: Date) {
+  return getYouTubeVideoCountService(startDate, endDate);
+}
+
+export async function getYouTubeStatsSummary(startDate?: Date, endDate?: Date) {
+  return getYouTubeStatsSummaryService(startDate, endDate);
+}
+
+export async function getOverallStatsHistory(startDate?: Date, endDate?: Date) {
+  return getOverallStatsHistoryService(startDate, endDate);
+}
+
+export async function getVideoCountByDate(startDate?: Date, endDate?: Date) {
+  return getVideoCountByDateService(startDate, endDate);
+}


### PR DESCRIPTION
## Summary
- metrics, action-stats, youtube-stats, tiktok-stats の4機能に loaders レイヤーを新規作成
- コンポーネント（page.tsx, metrics-index.tsx）からの services 直接 import を loaders 経由に変更
- loaders は `"use server"` を付与した薄いラッパーで、service 関数をそのまま呼び出す

## 変更内容

### 新規作成ファイル
- `src/features/metrics/loaders/metrics-loaders.ts`
- `src/features/action-stats/loaders/action-stats-loaders.ts`
- `src/features/youtube-stats/loaders/youtube-stats-loaders.ts`
- `src/features/tiktok-stats/loaders/tiktok-stats-loaders.ts`

### import 変更対象
- `src/app/stats/page.tsx` - action-stats の import を loaders 経由に
- `src/app/youtube_stats/page.tsx` - youtube-stats の import を loaders 経由に
- `src/app/tiktok_stats/page.tsx` - tiktok-stats の import を loaders 経由に
- `src/features/metrics/components/metrics-index.tsx` - metrics, youtube-stats, tiktok-stats の import を loaders 経由に

## Test plan
- [x] `pnpm run typecheck` 通過
- [x] `pnpm run biome:check:write` 通過