### PR TITLE
fix: 都道府県チームパワーカードのスマホ表示で左右余白を追加

### DIFF
--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -87,7 +87,7 @@ export default async function Home({
       {/* 都道府県対抗ランキング導線 */}
       {user != null && (
         <section className="py-4 md:py-8">
-          <div className="w-full max-w-lg mx-auto">
+          <div className="w-full max-w-lg mx-auto px-4">
             <PrefectureTeamCard />
           </div>
         </section>


### PR DESCRIPTION
## Summary
- トップページの都道府県チームパワーカードがスマホで画面いっぱいに広がっていた問題を修正
- ラッパーの `div` に `px-4` を追加し、左右に適切な余白を確保

## Changes
- `src/app/home.tsx`: `w-full max-w-lg mx-auto` → `w-full max-w-lg mx-auto px-4`

## Test plan
- [ ] スマホ表示でカードの左右に余白が入ることを確認
- [ ] PC表示で `max-w-lg` の制約が引き続き効いていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)