### PR TITLE
refactor: 全体ランキングのXP表示を短縮表記に変更

### DIFF
--- a/src/features/ranking/components/current-user-card.tsx
+++ b/src/features/ranking/components/current-user-card.tsx
@@ -1,3 +1,4 @@
+import { formatNumberJa } from "@/lib/utils/format-number-ja";
 import type { UserRanking } from "../types/ranking-types";
 import { BaseCurrentUserCard } from "./base-current-user-card";
 import { LevelBadge } from "./ranking-level-badge";
@@ -32,7 +33,7 @@ export const CurrentUserCard: React.FC<CurrentUserCardProps> = ({
       <div className="flex items-center gap-2 mb-1">
         <LevelBadge level={displayUser.level} />
         <div className="text-lg font-bold">
-          {displayUser.xp.toLocaleString()}pt
+          {formatNumberJa(displayUser.xp)}pt
         </div>
       </div>
     </BaseCurrentUserCard>

--- a/src/features/ranking/components/ranking-item.tsx
+++ b/src/features/ranking/components/ranking-item.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 // TOPページ用のランキングコンポーネント
 import { UserNameWithBadge } from "@/features/party-membership/components/user-name-with-badge";
+import { formatNumberJa } from "@/lib/utils/format-number-ja";
 import type { UserMissionRanking, UserRanking } from "../types/ranking-types";
 import { getLevelBadgeColor } from "../utils/level-badge-styles";
 import { getRankIcon } from "./ranking-icon";
@@ -64,7 +65,7 @@ export function RankingItem({
             Lv.{user.level}
           </Badge>
           <div className="font-bold text-lg justify-self-end">
-            {(user.xp ?? 0).toLocaleString()}pt
+            {formatNumberJa(user.xp ?? 0)}pt
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary
- 全体ランキングのXP表示を `toLocaleString()`（カンマ区切り）から `formatNumberJa()`（万・億の短縮表記）に変更
- 対象: 自分のランクカード (`current-user-card.tsx`) とランキングリスト各行 (`ranking-item.tsx`)
- 表示例: `15,000pt` → `1.5万pt`

## Test plan
- [ ] 全体ランキングページでXPが短縮表記（万pt）で表示されることを確認
- [ ] 1万未満のXPはカンマ区切りのまま表示されることを確認
- [ ] ミッション別ランキングのポイント表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)