### PR TITLE
fix: 全体ランキングXP短縮表記のテスト期待値を修正

### DIFF
--- a/src/features/ranking/components/current-user-card.test.tsx
+++ b/src/features/ranking/components/current-user-card.test.tsx
@@ -181,14 +181,14 @@ describe("CurrentUserCard", () => {
       const user = { ...mockUser, xp: 123456 };
       render(<CurrentUserCard currentUser={user} />);
 
-      expect(screen.getByText("123,456pt")).toBeInTheDocument();
+      expect(screen.getByText("12.3万pt")).toBeInTheDocument();
     });
 
     it("大きな数値も正しくフォーマットされる", () => {
       const user = { ...mockUser, xp: 1000000 };
       render(<CurrentUserCard currentUser={user} />);
 
-      expect(screen.getByText("1,000,000pt")).toBeInTheDocument();
+      expect(screen.getByText("100万pt")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- #2092 で導入した `formatNumberJa` による短縮表記に合わせ、テストの期待値を修正
- `123,456pt` → `12.3万pt`、`1,000,000pt` → `100万pt`

## Test plan
- [x] `current-user-card.test.tsx` の全テスト通過確認済み
- [x] `ranking-item.test.tsx` の全テスト通過確認済み（変更不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)