### PR TITLE
fix: YouTube同期バッチで個別ユーザー失敗時にジョブ全体を失敗にしない

### DIFF
--- a/scripts/sync-youtube-likes.ts
+++ b/scripts/sync-youtube-likes.ts
@@ -10,6 +10,7 @@
 import "dotenv/config";
 
 import {
+  isExpectedTokenError,
   isTokenExpired,
   refreshAccessToken,
 } from "@/features/youtube/services/google-auth";
@@ -33,12 +34,6 @@ interface SyncResult {
   totalXpGranted?: number;
   error?: string;
   isExpectedError?: boolean;
-}
-
-/** トークン更新失敗など、個別ユーザー起因の想定内エラーかどうかを判定する */
-function isExpectedUserError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("トークンの更新に失敗");
 }
 
 function parseArgs() {
@@ -136,7 +131,7 @@ async function main() {
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      const expected = isExpectedUserError(error);
+      const expected = isExpectedTokenError(error);
       if (expected) {
         console.warn(`  Warning: ${errorMessage}`);
       } else {


### PR DESCRIPTION
## Summary
- `sync-youtube-likes`: 1ユーザーでも失敗すると`process.exit(1)`していたのを、全ユーザーが失敗した場合のみエラー終了に変更
- `sync-youtube-comments`: 個別エラーを`console.error`→`console.warn`に変更し、`process.exit(1)`を削除（fatal errorのみ終了）

## Background
Daily YouTube Videos Sync ワークフローの`sync-likes`ジョブが、削除済みGoogleアカウント（`asa-5656`）のトークン更新失敗により、219ユーザー中218成功にも関わらずジョブ全体が失敗していた。

個別ユーザーのGoogle認証エラーは想定内であり、ワークフロー全体を失敗にすべきではない。

## Test plan
- [ ] sync-likesで1ユーザーが失敗しても他のユーザーの同期は正常に完了し、exit code 0で終了すること
- [ ] sync-likesで全ユーザーが失敗した場合はexit code 1で終了すること
- [ ] sync-commentsで個別エラーがwarnログとして出力されること
- [ ] 次回のDaily YouTube Videos Syncワークフローが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)