### PR TITLE
fix: BGM最大音量を半分に調整

### DIFF
--- a/src/components/top/maintenance-winter-effect.tsx
+++ b/src/components/top/maintenance-winter-effect.tsx
@@ -377,6 +377,7 @@ function getDragonHeadPosition(
 // --- BGM再生 (HTML5 Audio) ---
 
 const BGM_SRC = "/audio/maintenance_winter.mp3";
+const BGM_MAX_VOLUME = 0.25;
 
 class JapaneseBGM {
   private audio: HTMLAudioElement;
@@ -388,10 +389,9 @@ class JapaneseBGM {
   }
 
   start() {
-    // フェードイン
     this.audio.volume = 0;
     this.audio.play().catch(() => {});
-    this.fadeToVolume(0.5, 2000);
+    this.fadeToVolume(BGM_MAX_VOLUME, 2000);
   }
 
   private fadeToVolume(target: number, durationMs: number) {
@@ -408,7 +408,7 @@ class JapaneseBGM {
   }
 
   setMuted(muted: boolean) {
-    this.fadeToVolume(muted ? 0 : 0.5, 300);
+    this.fadeToVolume(muted ? 0 : BGM_MAX_VOLUME, 300);
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- BGMの最大音量を 0.5 → 0.25 に変更
- マジックナンバーを `BGM_MAX_VOLUME` 定数に抽出

## Test plan
- [ ] `localhost:3000?preview=maintenance` でBGMが以前より静かに再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * オーディオボリューム制御の内部管理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->