### PR TITLE
本番デプロイ 02/08 00:57

### DIFF
--- a/src/components/top/maintenance-winter-effect.tsx
+++ b/src/components/top/maintenance-winter-effect.tsx
@@ -386,9 +386,12 @@ class JapaneseBGM {
     this.audio = new Audio(BGM_SRC);
     this.audio.loop = true;
     this.audio.volume = 0;
+    this.audio.preload = "auto";
   }
 
   start() {
+    // 音声ファイル先頭に約3秒の無音があるためスキップ
+    this.audio.currentTime = 3;
     this.audio.volume = 0;
     this.audio.play().catch(() => {});
     this.fadeToVolume(BGM_MAX_VOLUME, 2000);
@@ -1014,19 +1017,19 @@ export default function MaintenanceWinterEffect() {
     })();
   }, []);
 
-  // BGM cleanup
+  // BGM preload on mount & cleanup
   useEffect(() => {
+    const bgm = new JapaneseBGM();
+    bgmRef.current = bgm;
     return () => {
-      bgmRef.current?.dispose();
+      bgm.dispose();
     };
   }, []);
 
   // Audio handlers (fireworks.tsx pattern: full-screen tap)
   const handleClick = useCallback(() => {
     if (!audioStarted) {
-      const bgm = new JapaneseBGM();
-      bgm.start();
-      bgmRef.current = bgm;
+      bgmRef.current?.start();
       setAudioStarted(true);
     } else {
       const newMuted = !isMuted;


### PR DESCRIPTION
* fix: BGM最大音量を半分(0.5→0.25)に調整



* fix: BGM音声をマウント時にプリロードしてタップ時のラグを解消

Audio要素をタップ時ではなくコンポーネントマウント時に作成し、
preload="auto"で5.8MBのmp3を事前読み込みすることで再生開始までの遅延を軽減。



* fix: BGM先頭の無音3秒をスキップして再生開始



---------

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# スクリーンショット
- フロントエンドの変更がある場合は、変更前後のスクリーンショットを貼ってください

- [ ] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました