### PR TITLE
fix: メンテナンスモードを終了する

### DIFF
--- a/src/lib/utils/maintenance-mode.test.ts
+++ b/src/lib/utils/maintenance-mode.test.ts
@@ -4,20 +4,27 @@ import {
   shouldShowMaintenance,
 } from "./maintenance-mode";
 
+const SAMPLE_START_AT = new Date("2026-02-07T14:59:00.000Z");
+
 describe("maintenance-mode", () => {
-  it("JST 23:58:59 ではメンテナンス未開始", () => {
+  it("開始時刻前ではメンテナンス未開始", () => {
     const now = new Date("2026-02-07T14:58:59.000Z");
-    expect(isMaintenanceActive(now)).toBe(false);
+    expect(isMaintenanceActive(now, SAMPLE_START_AT)).toBe(false);
   });
 
-  it("JST 23:59:00 でメンテナンス開始", () => {
+  it("開始時刻でメンテナンス開始", () => {
     const now = new Date("2026-02-07T14:59:00.000Z");
-    expect(isMaintenanceActive(now)).toBe(true);
+    expect(isMaintenanceActive(now, SAMPLE_START_AT)).toBe(true);
   });
 
   it("開始時刻がnullならメンテナンスは無効", () => {
     const now = new Date("2026-02-07T14:59:00.000Z");
     expect(isMaintenanceActive(now, null)).toBe(false);
+  });
+
+  it("デフォルト（MAINTENANCE_START_AT=null）ではメンテナンス無効", () => {
+    const now = new Date();
+    expect(isMaintenanceActive(now)).toBe(false);
   });
 
   it("開始前でも preview=maintenance なら表示する", () => {

--- a/src/lib/utils/maintenance-mode.ts
+++ b/src/lib/utils/maintenance-mode.ts
@@ -2,9 +2,7 @@
  * メンテナンスモード判定ユーティリティ
  */
 
-export const MAINTENANCE_START_AT: Date | null = new Date(
-  "2026-02-07T23:59:00+09:00",
-);
+export const MAINTENANCE_START_AT: Date | null = null;
 
 /**
  * メンテナンス開始時刻を過ぎているかを判定する。


### PR DESCRIPTION
## Summary
- `MAINTENANCE_START_AT` を `null` に設定し、メンテナンスモードを解除
- テストを明示的な日時引数を渡す形式に更新し、デフォルト `null` のテストケースを追加

## Test plan
- [x] `maintenance-mode.test.ts` 全テスト通過
- [x] `maintenance.test.ts` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * メンテナンス モードのデフォルト自動起動機能を削除しました。メンテナンス モードは今後、明示的に設定されない限り無効になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->