### PR TITLE
feat: Season 3 (2026春~) を開始

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -153,7 +153,7 @@ missions:
     difficulty: 4
     required_artifact_type: LINK
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     featured_importance: 100
     is_hidden: true
     artifact_label: ショート動画のURL（TikTok）
@@ -168,7 +168,7 @@ missions:
     difficulty: 4
     required_artifact_type: LINK
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     featured_importance: 20
     is_hidden: false
     artifact_label: 動画のURL（Youtube, TikTokなど）
@@ -323,7 +323,7 @@ missions:
     difficulty: 3
     required_artifact_type: TEXT
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     featured_importance: 100
     is_hidden: false
     artifact_label: 参加した街頭演説の場所と日付
@@ -383,7 +383,7 @@ missions:
     difficulty: 2
     required_artifact_type: POSTING
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     is_hidden: true
     artifact_label: ポスティング情報
     ogp_image_url: null
@@ -405,7 +405,7 @@ missions:
     difficulty: 2
     required_artifact_type: POSTING
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     is_hidden: true
     artifact_label: ポスティング情報
     ogp_image_url: null
@@ -427,7 +427,7 @@ missions:
     difficulty: 1
     required_artifact_type: YOUTUBE
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     featured_importance: 11
     is_hidden: false
     artifact_label: あなたが高評価したYouTube動画のURL
@@ -693,7 +693,7 @@ missions:
     difficulty: 5
     required_artifact_type: NONE
     max_achievement_count: 1
-    is_featured: true
+    is_featured: false
     featured_importance: 100
     is_hidden: true
     artifact_label: null
@@ -727,7 +727,7 @@ missions:
     difficulty: 2
     required_artifact_type: YOUTUBE_COMMENT
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     featured_importance: 10
     is_hidden: false
     artifact_label: null
@@ -794,7 +794,7 @@ missions:
     difficulty: 5
     required_artifact_type: TEXT
     max_achievement_count: 1
-    is_featured: true
+    is_featured: false
     featured_importance: 110
     is_hidden: true
     artifact_label: 「参加します または 参加しました」のテキスト
@@ -817,9 +817,9 @@ missions:
     difficulty: 5
     required_artifact_type: NONE
     max_achievement_count: 1
-    is_featured: true
+    is_featured: false
     featured_importance: 100
-    is_hidden: false
+    is_hidden: true
     artifact_label: null
     ogp_image_url: null
   - slug: share-vstudio-video
@@ -838,7 +838,7 @@ missions:
     difficulty: 4
     required_artifact_type: LINK
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     featured_importance: 100
     is_hidden: false
     artifact_label: 動画や投稿のURL

--- a/supabase/migrations/20260209120000_start_season3.sql
+++ b/supabase/migrations/20260209120000_start_season3.sql
@@ -1,0 +1,25 @@
+-- =============================================
+-- Season 3 開始マイグレーション
+-- =============================================
+
+-- 1. season2 を終了
+UPDATE seasons
+SET is_active = false,
+    end_date = '2026-02-07 23:59:59+09',
+    updated_at = now()
+WHERE slug = 'season2';
+
+-- 2. season3 を作成
+INSERT INTO seasons (id, slug, name, start_date, end_date, is_active, created_at, updated_at)
+VALUES (
+  gen_random_uuid(),
+  'season3',
+  '2026春~',
+  '2026-02-09 00:00:00+09',
+  NULL,
+  true,
+  now(),
+  now()
+);
+
+-- ミッションの is_featured / is_hidden 変更は missions.yaml で管理


### PR DESCRIPTION
## Summary
- season2を終了 (`end_date: 2026-02-07 23:59:59 JST`, `is_active: false`)
- season3を新規作成 (`slug: season3`, `name: 2026春~`, `start_date: 2026-02-09`, `is_active: true`)
- 全ミッションの注目フラグ (`is_featured`) を解除（missions.yaml）
- 「期日前投票をしよう！」(`early-vote-2026-shugiin`) を非表示に（missions.yaml）

## 変更ファイル
- `supabase/migrations/20260209120000_start_season3.sql` - シーズン切り替えSQL
- `mission_data/missions.yaml` - ミッション設定変更

## Test plan
- [ ] マイグレーション適用後、`seasons`テーブルでseason2が`is_active=false`、season3が`is_active=true`であること
- [ ] ランキングページが新シーズン（空の状態）で表示されること
- [ ] `/seasons/season2/ranking` で過去シーズンのランキングが閲覧できること
- [ ] 注目ミッションセクションが非表示になること
- [ ] 「期日前投票をしよう！」がミッション一覧に表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * シーズン3が開始されました。

* **変更**
  * シーズン2が終了しました。
  * 複数のミッションのフィーチャー状態が更新されました。
  * 一部のミッションが非表示に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->