### PR TITLE
fix: シードデータのアクティブシーズンをseason3に更新

### DIFF
--- a/supabase/seed-after-sync.sql
+++ b/supabase/seed-after-sync.sql
@@ -24,7 +24,7 @@ FROM (VALUES
 ) AS a(id, slug, user_id, created_at)
 JOIN missions m ON m.slug = a.slug
 CROSS JOIN seasons s
-WHERE s.slug = 'season2'
+WHERE s.slug = 'season3'
 ON CONFLICT (id) DO NOTHING;
 
 -- ポスティングのmission_artifactsを作成

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,8 +1,9 @@
 -- シーズンデータを作成（user_levelsで参照するため先に作成）
 INSERT INTO seasons (slug, name, start_date, end_date, is_active)
-VALUES 
+VALUES
   ('season1', 'シーズン１', '2025-06-01 00:00:00+09', '2025-07-19 23:59:59+09', false),
-  ('season2', 'シーズン２', '2025-07-20 00:00:00+09', NULL, true)
+  ('season2', 'シーズン２', '2025-07-20 00:00:00+09', '2026-02-07 23:59:59+09', false),
+  ('season3', '2026春~', '2026-02-09 00:00:00+09', NULL, true)
 ON CONFLICT (slug) DO NOTHING;
 
 -- auth.usersテーブルにユーザーを追加（外部キー制約のため）
@@ -90,9 +91,9 @@ VALUES
   ('6ba7b818-9dad-11d1-80b4-00c04fd430c8', '松本かな', '沖縄県', 'matsumoto_kana', NULL);
 
 -- ユーザーレベル情報（XPとレベル設定）
--- season1のIDを取得してuser_levelsに使用
+-- アクティブシーズン(season3)のIDを取得してuser_levelsに使用
 INSERT INTO user_levels (user_id, xp, level, season_id, updated_at)
-SELECT 
+SELECT
   ul.user_id::uuid,
   ul.xp,
   ul.level,
@@ -100,32 +101,32 @@ SELECT
   ul.updated_at::timestamptz
 FROM (VALUES
   -- 1位: 安野たかひろ（レベル20）
-  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 3325, 20, '2025-06-04T10:00:00Z'),
+  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 3325, 20, '2025-08-04T10:00:00Z'),
   -- 2位: 佐藤太郎（レベル10）
-  ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 900, 10, '2025-06-04T09:30:00Z'),
+  ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 900, 10, '2025-08-04T09:30:00Z'),
   -- 3位: 鈴木美咲（レベル9）
-  ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 740, 9, '2025-06-04T09:00:00Z'),
+  ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 740, 9, '2025-08-04T09:00:00Z'),
   -- 4位: 高橋健一（レベル8）
-  ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 595, 8, '2025-06-04T08:30:00Z'),
+  ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 595, 8, '2025-08-04T08:30:00Z'),
   -- 5位: 伊藤愛子（レベル7）
-  ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 465, 7, '2025-06-04T08:00:00Z'),
+  ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 465, 7, '2025-08-04T08:00:00Z'),
   -- 6位: 山田次郎（レベル6）
-  ('6ba7b813-9dad-11d1-80b4-00c04fd430c8', 350, 6, '2025-06-04T07:30:00Z'),
+  ('6ba7b813-9dad-11d1-80b4-00c04fd430c8', 350, 6, '2025-08-04T07:30:00Z'),
   -- 7位: 中村さくら（レベル5）
-  ('6ba7b814-9dad-11d1-80b4-00c04fd430c8', 250, 5, '2025-06-04T07:00:00Z'),
+  ('6ba7b814-9dad-11d1-80b4-00c04fd430c8', 250, 5, '2025-08-04T07:00:00Z'),
   -- 8位: 小林直人（レベル4）
-  ('6ba7b815-9dad-11d1-80b4-00c04fd430c8', 165, 4, '2025-06-04T06:30:00Z'),
+  ('6ba7b815-9dad-11d1-80b4-00c04fd430c8', 165, 4, '2025-08-04T06:30:00Z'),
   -- 9位: 田中花子（レベル3）
-  ('2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', 95, 3, '2025-06-04T06:00:00Z'),
+  ('2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', 95, 3, '2025-08-04T06:00:00Z'),
   -- 10位: 加藤みゆき（レベル2）
-  ('6ba7b816-9dad-11d1-80b4-00c04fd430c8', 40, 2, '2025-06-04T05:30:00Z'),
+  ('6ba7b816-9dad-11d1-80b4-00c04fd430c8', 40, 2, '2025-08-04T05:30:00Z'),
   -- 11位: 渡辺雄一（レベル1）
-  ('6ba7b817-9dad-11d1-80b4-00c04fd430c8', 0, 1, '2025-06-04T05:00:00Z'),
+  ('6ba7b817-9dad-11d1-80b4-00c04fd430c8', 0, 1, '2025-08-04T05:00:00Z'),
   -- 12位: 松本かな（レベル1、新規参加者）
-  ('6ba7b818-9dad-11d1-80b4-00c04fd430c8', 0, 1, '2025-06-04T04:30:00Z')
+  ('6ba7b818-9dad-11d1-80b4-00c04fd430c8', 0, 1, '2025-08-04T04:30:00Z')
 ) AS ul(user_id, xp, level, updated_at)
 CROSS JOIN seasons s
-WHERE s.slug = 'season2';
+WHERE s.slug = 'season3';
 
 -- ミッション
 INSERT INTO missions (id, title, icon_url, content, difficulty, event_date, required_artifact_type, max_achievement_count, slug)
@@ -215,9 +216,9 @@ FROM (VALUES
 CROSS JOIN seasons s
 WHERE s.slug = 'season1';
 
--- シーズン2用のミッション達成データ
+-- シーズン3用のミッション達成データ（現在のアクティブシーズン）
 INSERT INTO achievements (id, mission_id, user_id, season_id, created_at)
-SELECT 
+SELECT
   a.id::uuid,
   a.mission_id::uuid,
   a.user_id::uuid,
@@ -228,24 +229,24 @@ FROM (VALUES
   ('17ea2e6e-9ccf-4d2d-a3b4-f34d1a612439', 'e2898d7e-903f-4f9a-8b1b-93f783c9afac', '622d6984-2f8a-41df-9ac3-cd4dcceb8d19', '2025-07-21T10:00:00Z'),
   ('27ea2e6e-9ccf-4d2d-a3b4-f34d1a612440', '2246205f-933f-4a86-83af-dbf6bb6cde90', '622d6984-2f8a-41df-9ac3-cd4dcceb8d19', '2025-07-22T14:30:00Z'),
   ('37ea2e6e-9ccf-4d2d-a3b4-f34d1a612441', '3346205f-933f-4a86-83af-dbf6bb6cde91', '622d6984-2f8a-41df-9ac3-cd4dcceb8d19', '2025-07-23T16:45:00Z'),
-  
+
   -- 田中花子の達成
   ('953bcc49-56c4-4913-8ce4-f6d721e3c4ef', '2246205f-933f-4a86-83af-dbf6bb6cde90', '2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', '2025-07-21T15:00:00Z'),
-  
+
   -- 佐藤太郎の達成（2位らしく積極的）
   ('47ea2e6e-9ccf-4d2d-a3b4-f34d1a612442', 'e2898d7e-903f-4f9a-8b1b-93f783c9afac', 'f47ac10b-58cc-4372-a567-0e02b2c3d479', '2025-07-21T11:00:00Z'),
   ('57ea2e6e-9ccf-4d2d-a3b4-f34d1a612443', 'e5348472-d054-4ef4-81af-772c6323b669', 'f47ac10b-58cc-4372-a567-0e02b2c3d479', '2025-07-22T13:00:00Z'),
-  
+
   -- 鈴木美咲の達成
   ('67ea2e6e-9ccf-4d2d-a3b4-f34d1a612444', 'e2898d7e-903f-4f9a-8b1b-93f783c9afac', '6ba7b810-9dad-11d1-80b4-00c04fd430c8', '2025-07-21T12:00:00Z'),
   ('77ea2e6e-9ccf-4d2d-a3b4-f34d1a612445', '3346205f-933f-4a86-83af-dbf6bb6cde91', '6ba7b810-9dad-11d1-80b4-00c04fd430c8', '2025-07-22T09:00:00Z')
 ) AS a(id, mission_id, user_id, created_at)
 CROSS JOIN seasons s
-WHERE s.slug = 'season2';
+WHERE s.slug = 'season3';
 
--- XPトランザクション履歴（シーズン2のミッション達成に対応）
+-- XPトランザクション履歴（シーズン3のミッション達成に対応）
 INSERT INTO xp_transactions (id, user_id, xp_amount, source_type, source_id, description, created_at, season_id)
-SELECT 
+SELECT
   xt.id::uuid,
   xt.user_id::uuid,
   xt.xp_amount,
@@ -255,28 +256,28 @@ SELECT
   xt.created_at::timestamptz,
   s.id as season_id
 FROM (VALUES
-  -- 安野たかひろのXP履歴（シーズン2で合計3325 XP）
+  -- 安野たかひろのXP履歴（シーズン3で合計3325 XP）
   ('11ea2e6e-9ccf-4d2d-a3b4-f34d1a612439', '622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 50, 'MISSION_COMPLETION', '17ea2e6e-9ccf-4d2d-a3b4-f34d1a612439', 'ミッション「ゴミ拾いをしよう」達成', '2025-07-21T10:00:00Z'),
   ('22ea2e6e-9ccf-4d2d-a3b4-f34d1a612440', '622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 100, 'MISSION_COMPLETION', '27ea2e6e-9ccf-4d2d-a3b4-f34d1a612440', 'ミッション「活動ブログを書こう」達成', '2025-07-22T14:30:00Z'),
   ('33ea2e6e-9ccf-4d2d-a3b4-f34d1a612441', '622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 200, 'MISSION_COMPLETION', '37ea2e6e-9ccf-4d2d-a3b4-f34d1a612441', 'ミッション「今日のベストショット」達成', '2025-07-23T16:45:00Z'),
   ('44ea2e6e-9ccf-4d2d-a3b4-f34d1a612442', '622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 2975, 'BONUS', NULL, '初期ボーナスXP', '2025-07-20T09:00:00Z'),
-  
-  -- 佐藤太郎のXP履歴（シーズン2で合計900 XP）
+
+  -- 佐藤太郎のXP履歴（シーズン3で合計900 XP）
   ('55ea2e6e-9ccf-4d2d-a3b4-f34d1a612443', 'f47ac10b-58cc-4372-a567-0e02b2c3d479', 50, 'MISSION_COMPLETION', '47ea2e6e-9ccf-4d2d-a3b4-f34d1a612442', 'ミッション「ゴミ拾いをしよう」達成', '2025-07-21T11:00:00Z'),
   ('66ea2e6e-9ccf-4d2d-a3b4-f34d1a612444', 'f47ac10b-58cc-4372-a567-0e02b2c3d479', 50, 'MISSION_COMPLETION', '57ea2e6e-9ccf-4d2d-a3b4-f34d1a612443', 'ミッション「Xのニックネーム」達成', '2025-07-22T13:00:00Z'),
   ('77ea2e6e-9ccf-4d2d-a3b4-f34d1a612445', 'f47ac10b-58cc-4372-a567-0e02b2c3d479', 800, 'BONUS', NULL, '初期ボーナスXP', '2025-07-20T10:00:00Z'),
-  
-  -- 田中花子のXP履歴（シーズン2で合計95 XP）
+
+  -- 田中花子のXP履歴（シーズン3で合計95 XP）
   ('88ea2e6e-9ccf-4d2d-a3b4-f34d1a612446', '2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', 100, 'MISSION_COMPLETION', '953bcc49-56c4-4913-8ce4-f6d721e3c4ef', 'ミッション「活動ブログを書こう」達成', '2025-07-21T15:00:00Z'),
   ('99ea2e6e-9ccf-4d2d-a3b4-f34d1a612447', '2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', -5, 'BONUS', NULL, '調整', '2025-07-20T12:00:00Z'),
-  
-  -- 鈴木美咲のXP履歴（シーズン2で合計740 XP）
+
+  -- 鈴木美咲のXP履歴（シーズン3で合計740 XP）
   ('aa2e2e6e-9ccf-4d2d-a3b4-f34d1a612450', '6ba7b810-9dad-11d1-80b4-00c04fd430c8', 50, 'MISSION_COMPLETION', '67ea2e6e-9ccf-4d2d-a3b4-f34d1a612444', 'ミッション「ゴミ拾いをしよう」達成', '2025-07-21T12:00:00Z'),
   ('bb2e2e6e-9ccf-4d2d-a3b4-f34d1a612451', '6ba7b810-9dad-11d1-80b4-00c04fd430c8', 200, 'MISSION_COMPLETION', '77ea2e6e-9ccf-4d2d-a3b4-f34d1a612445', 'ミッション「今日のベストショット」達成', '2025-07-22T09:00:00Z'),
   ('cc2e2e6e-9ccf-4d2d-a3b4-f34d1a612452', '6ba7b810-9dad-11d1-80b4-00c04fd430c8', 490, 'BONUS', NULL, '初期ボーナスXP', '2025-07-20T08:00:00Z')
 ) AS xt(id, user_id, xp_amount, source_type, source_id, description, created_at)
 CROSS JOIN seasons s
-WHERE s.slug = 'season2';
+WHERE s.slug = 'season3';
   
 -- ミッション成果物のサンプルデータ
 --INSERT INTO mission_artifacts (achievement_id, user_id, artifact_type, link_url, description) 
@@ -417,50 +418,50 @@ FROM (VALUES
   ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'ALL', NULL, 3, 'season1', '2025-07-18T09:00:00Z', true),
   ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '神奈川県', 1, 'season1', '2025-07-18T09:00:00Z', true),
 
-  -- シーズン2のバッジ（現在のシーズン）
+  -- シーズン3のバッジ（現在のシーズン）
   -- 安野たかひろ - 総合1位、デイリー3位、東京都1位、ミッション「ゴミ拾い」1位
-  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'ALL', NULL, 1, 'season2', '2025-08-10T10:00:00Z', false),
-  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'DAILY', NULL, 3, 'season2', '2025-08-12T10:00:00Z', false),
-  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'PREFECTURE', '東京都', 1, 'season2', '2025-08-10T10:00:00Z', false),
-  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'MISSION', 'seed-cleanup', 1, 'season2', '2025-08-11T10:00:00Z', false),
-  
+  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'ALL', NULL, 1, 'season3', '2025-08-10T10:00:00Z', false),
+  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'DAILY', NULL, 3, 'season3', '2025-08-12T10:00:00Z', false),
+  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'PREFECTURE', '東京都', 1, 'season3', '2025-08-10T10:00:00Z', false),
+  ('622d6984-2f8a-41df-9ac3-cd4dcceb8d19', 'MISSION', 'seed-cleanup', 1, 'season3', '2025-08-11T10:00:00Z', false),
+
   -- 佐藤太郎 - 総合2位、デイリー1位、東京都2位
-  ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 'ALL', NULL, 2, 'season2', '2025-08-10T09:30:00Z', false),
-  ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 'DAILY', NULL, 1, 'season2', '2025-08-13T09:30:00Z', false),
-  ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 'PREFECTURE', '東京都', 2, 'season2', '2025-08-10T09:30:00Z', false),
-  
+  ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 'ALL', NULL, 2, 'season3', '2025-08-10T09:30:00Z', false),
+  ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 'DAILY', NULL, 1, 'season3', '2025-08-13T09:30:00Z', false),
+  ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 'PREFECTURE', '東京都', 2, 'season3', '2025-08-10T09:30:00Z', false),
+
   -- 鈴木美咲 - 総合3位、神奈川県1位、ミッション「活動ブログ」2位
-  ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'ALL', NULL, 3, 'season2', '2025-08-10T09:00:00Z', false),
-  ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '神奈川県', 1, 'season2', '2025-08-10T09:00:00Z', false),
-  ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'MISSION', 'seed-activity-blog', 2, 'season2', '2025-08-11T09:00:00Z', false),
-  
+  ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'ALL', NULL, 3, 'season3', '2025-08-10T09:00:00Z', false),
+  ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '神奈川県', 1, 'season3', '2025-08-10T09:00:00Z', false),
+  ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'MISSION', 'seed-activity-blog', 2, 'season3', '2025-08-11T09:00:00Z', false),
+
   -- 高橋健一 - 総合4位、大阪府1位
-  ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 'ALL', NULL, 4, 'season2', '2025-08-10T08:30:00Z', false),
-  ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '大阪府', 1, 'season2', '2025-08-10T08:30:00Z', false),
-  
+  ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 'ALL', NULL, 4, 'season3', '2025-08-10T08:30:00Z', false),
+  ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '大阪府', 1, 'season3', '2025-08-10T08:30:00Z', false),
+
   -- 伊藤愛子 - 総合5位、愛知県1位、デイリー2位
-  ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 'ALL', NULL, 5, 'season2', '2025-08-10T08:00:00Z', false),
-  ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '愛知県', 1, 'season2', '2025-08-10T08:00:00Z', false),
-  ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 'DAILY', NULL, 2, 'season2', '2025-08-13T08:00:00Z', false),
-  
+  ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 'ALL', NULL, 5, 'season3', '2025-08-10T08:00:00Z', false),
+  ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '愛知県', 1, 'season3', '2025-08-10T08:00:00Z', false),
+  ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 'DAILY', NULL, 2, 'season3', '2025-08-13T08:00:00Z', false),
+
   -- 田中花子 - 大阪府2位、ミッション「ベストショット」3位
-  ('2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', 'PREFECTURE', '大阪府', 2, 'season2', '2025-08-10T06:00:00Z', false),
-  ('2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', 'MISSION', 'seed-best-shot', 3, 'season2', '2025-08-11T06:00:00Z', false),
-  
+  ('2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', 'PREFECTURE', '大阪府', 2, 'season3', '2025-08-10T06:00:00Z', false),
+  ('2c23c05b-8e25-4d0d-9e68-d3be74e4ae8f', 'MISSION', 'seed-best-shot', 3, 'season3', '2025-08-11T06:00:00Z', false),
+
   -- 山田次郎 - 福岡県1位
-  ('6ba7b813-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '福岡県', 1, 'season2', '2025-08-10T07:30:00Z', false),
-  
+  ('6ba7b813-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '福岡県', 1, 'season3', '2025-08-10T07:30:00Z', false),
+
   -- 中村さくら - 北海道1位
-  ('6ba7b814-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '北海道', 1, 'season2', '2025-08-10T07:00:00Z', false),
-  
+  ('6ba7b814-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '北海道', 1, 'season3', '2025-08-10T07:00:00Z', false),
+
   -- 小林直人 - 京都府1位
-  ('6ba7b815-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '京都府', 1, 'season2', '2025-08-10T06:30:00Z', false),
-  
+  ('6ba7b815-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '京都府', 1, 'season3', '2025-08-10T06:30:00Z', false),
+
   -- 渡辺雄一 - 広島県1位
-  ('6ba7b817-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '広島県', 1, 'season2', '2025-08-10T05:00:00Z', false),
-  
+  ('6ba7b817-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '広島県', 1, 'season3', '2025-08-10T05:00:00Z', false),
+
   -- 松本かな - 沖縄県1位
-  ('6ba7b818-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '沖縄県', 1, 'season2', '2025-08-10T04:30:00Z', false)
+  ('6ba7b818-9dad-11d1-80b4-00c04fd430c8', 'PREFECTURE', '沖縄県', 1, 'season3', '2025-08-10T04:30:00Z', false)
 ) AS b(user_id, badge_type, sub_type, rank, slug, achieved_at, is_notified)
 CROSS JOIN seasons s
 WHERE s.slug = b.slug;
@@ -491,7 +492,7 @@ SELECT
     '6ba7b817-9dad-11d1-80b4-00c04fd430c8',
     '6ba7b818-9dad-11d1-80b4-00c04fd430c8'
   ])[1 + (i % 12)]::uuid as user_id,
-  (SELECT id FROM seasons WHERE slug = 'season2') as season_id,
+  (SELECT id FROM seasons WHERE slug = 'season3') as season_id,
   -- 各日の9:00〜21:00の間のランダムな時刻
   (CURRENT_DATE - ((i / 15) || ' days')::interval) +
   ((9 + (i % 12)) || ' hours')::interval +


### PR DESCRIPTION
# 変更の概要
- シードデータ（`seed.sql`, `seed-after-sync.sql`）のアクティブシーズン参照を `season2` → `season3` に更新
- seasons定義に `season3` を追加し、`season2` を `is_active=false` に変更
- user_levels, achievements, xp_transactions, user_badges の現シーズンデータ参照を `season3` に更新
- 日付をseason3開始日（2026-02-09）以降に調整

# 変更の背景
- Season 3開始マイグレーション（#2110）により、アクティブシーズンが `season3` に変更されたが、シードデータは `season2` を参照したままだった
- これにより `supabase db reset` 後のローカル環境でシーズンデータの不整合が発生し、e2eテストが失敗していた

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ヘッダーの高さを調整しました。

* **チア**
  * シーズンのデータベース参照をシーズン3に更新しました。タイムスタンプとシーズン関連のデータも対応するように更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->