### PR TITLE
fix: SessionEndフックのtmpディレクトリ未作成エラーを修正

### DIFF
--- a/.claude/hooks/capture-learnings.sh
+++ b/.claude/hooks/capture-learnings.sh
@@ -30,4 +30,5 @@ if [ -f "$SNAPSHOT" ]; then
 fi
 
 # 現在のMEMORY.mdをスナップショットとして保存（次回比較用）
+mkdir -p "$(dirname "$SNAPSHOT")"
 cp "$MEMORY_FILE" "$SNAPSHOT"


### PR DESCRIPTION
## Summary
- SessionEndフック（`capture-learnings.sh`）でMEMORY.mdのスナップショット保存先ディレクトリ（`.claude/tmp/`）が存在しない場合に`cp`コマンドが失敗する問題を修正
- スナップショット保存前に`mkdir -p`でディレクトリを確保するようにした

## Test plan
- [ ] `.claude/tmp/`が存在しない状態でセッション終了→フックがエラーなく完了すること
- [ ] `.claude/tmp/`が既に存在する状態でセッション終了→既存の動作に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)