### PR TITLE
fix: SessionEndフックで.claude/tmp/が存在しない場合のエラーを修正

### DIFF
--- a/.claude/hooks/capture-learnings.sh
+++ b/.claude/hooks/capture-learnings.sh
@@ -30,4 +30,5 @@ if [ -f "$SNAPSHOT" ]; then
 fi
 
 # 現在のMEMORY.mdをスナップショットとして保存（次回比較用）
+mkdir -p "$(dirname "$SNAPSHOT")"
 cp "$MEMORY_FILE" "$SNAPSHOT"


### PR DESCRIPTION
## Summary
- `capture-learnings.sh` でスナップショット保存先ディレクトリ（`.claude/tmp/`）が存在しない場合に `mkdir -p` で作成するように修正

## Test plan
- [x] `.claude/tmp/` が存在しない状態でSessionEndフックが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)