### PR TITLE
feat: LineApiClient実装とlineLoginユースケースを追加

### DIFF
--- a/src/features/auth/services/line-api-client.ts
+++ b/src/features/auth/services/line-api-client.ts
@@ -1,0 +1,37 @@
+import type {
+  LineApiClient,
+  LineTokenResponse,
+} from "../types/line-api-client";
+
+export class LineApiClientImpl implements LineApiClient {
+  constructor(
+    private readonly clientId: string,
+    private readonly clientSecret: string,
+  ) {}
+
+  async exchangeCodeForTokens(
+    code: string,
+    redirectUri: string,
+  ): Promise<LineTokenResponse> {
+    const response = await fetch("https://api.line.me/oauth2/v2.1/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Failed to get access token: ${response.status} ${errorBody}`,
+      );
+    }
+
+    return response.json();
+  }
+}

--- a/src/features/auth/use-cases/line-login.ts
+++ b/src/features/auth/use-cases/line-login.ts
@@ -1,0 +1,144 @@
+import { randomBytes } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getOrInitializeUserLevel } from "@/features/user-level/services/level";
+import { parseIdTokenPayload } from "@/lib/utils/jwt-utils";
+import type { LineApiClient } from "../types/line-api-client";
+
+export type LineLoginInput = {
+  code: string;
+  redirectUri: string;
+  dateOfBirth?: string;
+};
+
+export type LineLoginResult =
+  | {
+      success: true;
+      userId: string;
+      email: string;
+      isNewUser: boolean;
+      tempPassword: string;
+    }
+  | { success: false; error: string };
+
+export async function lineLogin(
+  adminSupabase: SupabaseClient,
+  lineApiClient: LineApiClient,
+  input: LineLoginInput,
+): Promise<LineLoginResult> {
+  // 1. LINE APIでトークンと交換
+  const tokens = await lineApiClient.exchangeCodeForTokens(
+    input.code,
+    input.redirectUri,
+  );
+
+  // 2. IDトークンからユーザー情報を取得
+  if (!tokens.id_token) {
+    return { success: false, error: "IDトークンが取得できませんでした" };
+  }
+  const userInfo = parseIdTokenPayload(tokens.id_token);
+  const lineUserId = userInfo.sub as string;
+  if (!lineUserId) {
+    return { success: false, error: "LINEユーザーIDが取得できませんでした" };
+  }
+
+  const email = (userInfo.email as string) || `line-${lineUserId}@line.local`;
+  const name = (userInfo.name as string) || "LINEユーザー";
+  const image = userInfo.picture as string | undefined;
+
+  // 3. 既存ユーザーチェック
+  const { data: userResults, error: userFetchError } = await adminSupabase.rpc(
+    "get_user_by_line_id",
+    {
+      line_user_id: lineUserId,
+    },
+  );
+
+  if (userFetchError) {
+    throw new Error("Failed to check user existence");
+  }
+
+  const existingUser = userResults?.[0] || null;
+  let userId: string;
+  let isNewUser = false;
+
+  if (existingUser) {
+    const metadata = existingUser.user_metadata as {
+      provider?: string;
+      picture?: string;
+    };
+
+    if (metadata?.provider === "line") {
+      // LINEで作成されたユーザー → ログイン（メタデータ更新）
+      userId = existingUser.id;
+      await adminSupabase.auth.admin.updateUserById(userId, {
+        user_metadata: {
+          ...metadata,
+          line_user_id: lineUserId,
+          line_linked_at: new Date().toISOString(),
+          picture: image || metadata?.picture,
+        },
+      });
+    } else {
+      // email+passwordで作成されたユーザー → エラー
+      return {
+        success: false,
+        error: "このメールアドレスは既に登録されています。",
+      };
+    }
+  } else {
+    // 新規ユーザー
+    if (!input.dateOfBirth) {
+      return {
+        success: false,
+        error:
+          "新規ユーザー登録には各種同意と生年月日が必要です。サインアップページから登録してください。",
+      };
+    }
+
+    const { data: newUser, error: createError } =
+      await adminSupabase.auth.admin.createUser({
+        email,
+        email_confirm: true,
+        user_metadata: {
+          sub: "",
+          name,
+          email,
+          provider: "line",
+          line_user_id: lineUserId,
+          date_of_birth: input.dateOfBirth,
+          email_verified: true,
+          line_linked_at: new Date().toISOString(),
+          phone_verified: false,
+          picture: image,
+        },
+      });
+
+    if (createError || !newUser.user) {
+      throw new Error(`Failed to create user: ${createError?.message}`);
+    }
+
+    userId = newUser.user.id;
+    isNewUser = true;
+
+    // subフィールドを設定
+    await adminSupabase.auth.admin.updateUserById(userId, {
+      user_metadata: { ...newUser.user.user_metadata, sub: userId },
+    });
+
+    // ユーザーレベル初期化
+    await getOrInitializeUserLevel(userId);
+  }
+
+  // 4. 一時パスワードを設定
+  const tempPassword = randomBytes(32).toString("base64");
+  const { error: passwordError } =
+    await adminSupabase.auth.admin.updateUserById(userId, {
+      password: tempPassword,
+    });
+
+  if (passwordError) {
+    console.error("Failed to set temporary password:", passwordError);
+  }
+
+  return { success: true, userId, email, isNewUser, tempPassword };
+}


### PR DESCRIPTION
## Summary

- `LineApiClientImpl`: `LineApiClient` インターフェースの本番実装（LINE OAuth2トークン交換）
- `lineLogin` ユースケース: `handleLineAuthAction` からビジネスロジック（トークン交換→ユーザー検索/作成→一時パスワード設定）を抽出
- SupabaseClient と LineApiClient を引数で受け取り、Next.js非依存で統合テストから直接呼び出し可能

Resolves #2130 (partial - Task 3)

## Test plan

- [x] `pnpm run typecheck` パス
- [x] `pnpm run biome:check:write` パス
- [x] `pnpm run test:unit` 全テストパス (1933)
- [ ] Task 5 のシナリオテストで統合テスト実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * LINE ログイン機能が実装されました。LINE アカウントで認証できるようになります。
  * LINE ログイン時に新規ユーザーアカウントの自動作成に対応しました。
  * 既存ユーザーの LINE アカウントとのリンク機能が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->