### PR TITLE
ci: Next.jsビルドキャッシュを追加

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -66,6 +66,15 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install chromium
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**', 'app/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
+
       - name: Build Next.js
         run: pnpm run build
 


### PR DESCRIPTION
# 変更の概要
- `.next/cache` を `actions/cache` でキャッシュし、Next.jsビルドのwebpackコンパイルを高速化
- `restore-keys` で部分一致も有効にし、ソース変更時も前回キャッシュを活用可能

# 変更の背景
- #2136 でSupabase起動をバックグラウンド化したが、Next.jsビルドにキャッシュがなく毎回約70秒のフルコンパイルが発生している
- CIログに `No build cache found. Please configure build caching for faster rebuilds` の警告が出ていた
- キャッシュヒット時はコンパイル時間が70秒→10-20秒に短縮される見込み

# スクリーンショット

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [ ] CLAの内容を読み、同意しました