### PR TITLE
refactor: handleLineAuthActionをlineLoginユースケースで置き換え

### DIFF
--- a/src/features/auth/use-cases/line-login.ts
+++ b/src/features/auth/use-cases/line-login.ts
@@ -60,6 +60,7 @@ export async function lineLogin(
   const existingUser = userResults?.[0] || null;
   let userId: string;
   let isNewUser = false;
+  let loginEmail = email;
 
   if (existingUser) {
     const metadata = existingUser.user_metadata as {
@@ -70,6 +71,8 @@ export async function lineLogin(
     if (metadata?.provider === "line") {
       // LINEで作成されたユーザー → ログイン（メタデータ更新）
       userId = existingUser.id;
+      // DB上のemailを使う（ユーザーがメール変更済みの場合に対応）
+      loginEmail = (existingUser.email as string) || email;
       await adminSupabase.auth.admin.updateUserById(userId, {
         user_metadata: {
           ...metadata,
@@ -148,5 +151,5 @@ export async function lineLogin(
     console.error("Failed to set temporary password:", passwordError);
   }
 
-  return { success: true, userId, email, isNewUser, tempPassword };
+  return { success: true, userId, email: loginEmail, isNewUser, tempPassword };
 }


### PR DESCRIPTION
## Summary
- `handleLineAuthAction`（250行）を`lineLogin`ユースケース + `LineApiClientImpl`を使う薄いアダプタ（~60行）に変換
- LINE API呼び出し・ユーザー作成/更新・一時パスワード設定をユースケースに委譲
- 既存ユーザーのログイン時、DB上のemailを返すよう`lineLogin`を修正（メール変更済みユーザー対応）
- 30行追加、183行削除

Resolves #2130

## Test plan
- [ ] 型チェック通過（`tsc --noEmit`）
- [ ] CI全パス（Build & Tests, Unit Tests, Integration Tests）
- [ ] LINEログイン新規登録が正常に動作する
- [ ] LINE既存ユーザーのログインが正常に動作する
- [ ] 紹介コード付きLINEログインが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)