### PR TITLE
ci: Codecovに統合テストのカバレッジを追加

### DIFF
--- a/.github/workflows/supabase_integration_test.yaml
+++ b/.github/workflows/supabase_integration_test.yaml
@@ -61,3 +61,14 @@ jobs:
           name: jest-supabase-integration-report
           path: jest-report/
           retention-days: 30
+
+      - name: Upload integration coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-integration/lcov.info
+          flags: integrationtests
+          name: codecov-integration-tests
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,10 @@ flags:
     paths:
       - src/
     carryforward: true
+  integrationtests:
+    paths:
+      - src/
+    carryforward: true
 
 ignore:
   - "**/*.test.ts"

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ const config = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   collectCoverage: true,
   collectCoverageFrom: [
-    "<rootDir>/src/features/**/{services,actions,utils}/*.{ts,tsx}",
+    "<rootDir>/src/features/**/{services,actions,utils,use-cases}/*.{ts,tsx}",
     "<rootDir>/src/lib/{services,utils}/*.{ts,tsx}",
   ],
   coverageReporters: ["html", "text", "lcov"],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:ci:unit": "jest --ci --reporters=default --reporters=jest-junit --testPathIgnorePatterns='tests/supabase/' --testPathIgnorePatterns='tests/integration/'",
     "test:ci:supabase": "jest --ci --reporters=default --reporters=jest-junit --testMatch='**/tests/supabase/**/*.test.ts' --testEnvironment=node --coverage=false",
     "test:ci:playwright": "CI=true playwright test",
-    "test:ci:integration": "jest --ci --passWithNoTests --reporters=default --reporters=jest-junit --testMatch='**/tests/integration/**/*.test.ts' --testEnvironment=node --coverage=false",
+    "test:ci:integration": "jest --ci --passWithNoTests --reporters=default --reporters=jest-junit --testMatch='**/tests/integration/**/*.test.ts' --testEnvironment=node --coverageDirectory='./coverage-integration'",
     "test:ci:e2e": "pnpm run test:ci:playwright",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",


### PR DESCRIPTION
## Summary
- `jest.config.js` の `collectCoverageFrom` に `use-cases/` ディレクトリを追加
- 統合テスト（`test:ci:integration`）のカバレッジ収集を有効化し、出力先を `coverage-integration/` に分離
- `supabase_integration_test.yaml` に Codecov アップロードステップを追加（flag: `integrationtests`）
- `codecov.yml` に `integrationtests` フラグを定義（`carryforward: true`）

これにより、PRコメントで unit test + integration test の合算カバレッジが表示され、Codecov上でフラグごとのフィルタも可能になります。

## 変更の詳細
- RLS テスト（`test:ci:supabase`）はDB構造テストのためカバレッジ対象外のまま
- integration test の coverage 出力は `./coverage-integration/` に分離し、unit test の `./coverage/` と衝突しない

## Test plan
- [ ] CIでunit testのCodecovアップロードが引き続き動作すること
- [ ] CIでintegration testのカバレッジが収集されCodecovにアップロードされること
- [ ] Codecov PRコメントに `integrationtests` フラグが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)