### PR TITLE
test: OAuth連携解除・プロフィール更新の追加テストでカバレッジ向上

### DIFF
--- a/tests/integration/tiktok-auth.test.ts
+++ b/tests/integration/tiktok-auth.test.ts
@@ -142,6 +142,24 @@ describe("TikTok認証ユースケース", () => {
   });
 
   describe("unlinkTikTokAccount", () => {
+    test("連携していないユーザーのunlinkも成功する", async () => {
+      const { user } = await createTestUser();
+      createdUserIds.push(user.userId);
+
+      // 連携していない状態でunlinkを呼ぶ（deleteは0件でもエラーにならない）
+      const result = await unlinkTikTokAccount(adminClient, user.userId);
+      expect(result.success).toBe(true);
+
+      // DBにレコードがないことを確認
+      const { data: connection } = await adminClient
+        .from("tiktok_user_connections")
+        .select("*")
+        .eq("user_id", user.userId)
+        .maybeSingle();
+
+      expect(connection).toBeNull();
+    });
+
     test("連携解除でレコードが削除される", async () => {
       const { user } = await createTestUser();
       createdUserIds.push(user.userId);

--- a/tests/integration/youtube-auth.test.ts
+++ b/tests/integration/youtube-auth.test.ts
@@ -193,6 +193,24 @@ describe("YouTube OAuth ユースケース", () => {
   });
 
   describe("unlinkYouTubeAccount", () => {
+    test("連携していないユーザーのunlinkも成功する", async () => {
+      const { user } = await createTestUser();
+      createdUserIds.push(user.userId);
+
+      // 連携していない状態でunlinkを呼ぶ（deleteは0件でもエラーにならない）
+      const result = await unlinkYouTubeAccount(adminClient, user.userId);
+      expect(result.success).toBe(true);
+
+      // DBにレコードがないことを確認
+      const { data: connection } = await adminClient
+        .from("youtube_user_connections")
+        .select("*")
+        .eq("user_id", user.userId)
+        .maybeSingle();
+
+      expect(connection).toBeNull();
+    });
+
     test("連携解除でレコードが削除される", async () => {
       const { user } = await createTestUser();
       createdUserIds.push(user.userId);


### PR DESCRIPTION
## Summary
- TikTok/YouTube: 連携していないユーザーのunlinkテスト追加（エラーにならないことを確認）
- Profile: バリデーションエラー3件（空ニックネーム、無効生年月日形式、emailなし新規ユーザー）追加

## 目的
use-caseファイルのcodeocvパッチカバレッジを80%以上に引き上げる。

## 追加テスト
- `tiktok-auth.test.ts`: +1テスト（計7テスト）
- `youtube-auth.test.ts`: +1テスト（計8テスト）
- `update-profile.test.ts`: +3テスト（計10テスト）

## Test plan
- [x] pnpm run test:integration 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)