### PR TITLE
test: ミッション達成ユースケースのテストカバレッジ80%達成

### DIFF
--- a/tests/integration/achieve-mission.test.ts
+++ b/tests/integration/achieve-mission.test.ts
@@ -1,6 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { achieveMission } from "@/features/mission-detail/use-cases/achieve-mission";
 import { cancelSubmission } from "@/features/mission-detail/use-cases/cancel-submission";
+import {
+  MAX_POSTER_COUNT,
+  POSTER_POINTS_PER_UNIT,
+  POSTING_POINTS_PER_UNIT,
+} from "@/lib/constants/mission-config";
 import type { Database } from "@/lib/types/supabase";
 import {
   adminClient,
@@ -281,5 +286,293 @@ describe("achieveMission ユースケース", () => {
     // DB確認: XPが減算されている
     const xpAfter = await getTestUserXp(testUserId);
     expect(xpAfter!.xp).toBe(0);
+  });
+
+  test("POSTINGタイプでミッション達成 - posting_activities にレコードが作成される", async () => {
+    testMission = await createTestMission({
+      requiredArtifactType: "POSTING",
+      difficulty: 1,
+      isFeatured: false,
+    });
+
+    const postingCount = 5;
+    const result = await achieveMission(adminClient, testUserClient, {
+      userId: testUserId,
+      missionId: testMission.id,
+      artifactType: "POSTING",
+      artifactData: {
+        missionId: testMission.id,
+        requiredArtifactType: "POSTING",
+        postingCount,
+        locationText: "テスト場所",
+      } as any,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.artifactId).toBeDefined();
+
+    // DB確認: posting_activities にレコードが作成されている
+    const { data: postingActivities } = await adminClient
+      .from("posting_activities")
+      .select("id, posting_count, location_text, mission_artifact_id")
+      .eq("mission_artifact_id", result.artifactId!);
+
+    expect(postingActivities).toHaveLength(1);
+    expect(postingActivities![0].posting_count).toBe(postingCount);
+    expect(postingActivities![0].location_text).toBe("テスト場所");
+
+    // DB確認: ボーナスXPが付与されている（BONUS トランザクション）
+    const { data: bonusXpTransactions } = await adminClient
+      .from("xp_transactions")
+      .select("xp_amount, source_type")
+      .eq("user_id", testUserId)
+      .eq("source_type", "BONUS");
+
+    expect(bonusXpTransactions).toHaveLength(1);
+    const expectedBonusXp = postingCount * POSTING_POINTS_PER_UNIT;
+    expect(bonusXpTransactions![0].xp_amount).toBe(expectedBonusXp);
+
+    // POSTINGミッションではベースXP（MISSION_COMPLETION）は付与されない
+    const { data: missionXpTransactions } = await adminClient
+      .from("xp_transactions")
+      .select("xp_amount, source_type")
+      .eq("user_id", testUserId)
+      .eq("source_type", "MISSION_COMPLETION");
+
+    expect(missionXpTransactions).toHaveLength(0);
+
+    // 合計XP = ボーナスXPのみ
+    expect(result.xpGranted).toBe(expectedBonusXp);
+  });
+
+  test("POSTERタイプでミッション達成 - poster_activities にレコードが作成される", async () => {
+    testMission = await createTestMission({
+      requiredArtifactType: "POSTER",
+      difficulty: 1,
+      isFeatured: false,
+    });
+
+    const result = await achieveMission(adminClient, testUserClient, {
+      userId: testUserId,
+      missionId: testMission.id,
+      artifactType: "POSTER",
+      artifactData: {
+        missionId: testMission.id,
+        requiredArtifactType: "POSTER",
+        prefecture: "東京都",
+        city: "テスト市",
+        boardNumber: "TEST-001",
+        boardName: "テスト掲示板",
+        boardNote: null,
+        boardAddress: "テスト住所",
+        boardLat: "35.6762",
+        boardLong: "139.6503",
+      } as any,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.artifactId).toBeDefined();
+
+    // DB確認: poster_activities にレコードが作成されている
+    const { data: posterActivities } = await adminClient
+      .from("poster_activities")
+      .select(
+        "id, poster_count, prefecture, city, number, name, user_id, mission_artifact_id",
+      )
+      .eq("mission_artifact_id", result.artifactId!);
+
+    expect(posterActivities).toHaveLength(1);
+    expect(posterActivities![0].poster_count).toBe(MAX_POSTER_COUNT);
+    expect(posterActivities![0].prefecture).toBe("東京都");
+    expect(posterActivities![0].city).toBe("テスト市");
+    expect(posterActivities![0].number).toBe("TEST-001");
+    expect(posterActivities![0].name).toBe("テスト掲示板");
+    expect(posterActivities![0].user_id).toBe(testUserId);
+
+    // DB確認: ボーナスXPが付与されている
+    const { data: bonusXpTransactions } = await adminClient
+      .from("xp_transactions")
+      .select("xp_amount, source_type")
+      .eq("user_id", testUserId)
+      .eq("source_type", "BONUS");
+
+    expect(bonusXpTransactions).toHaveLength(1);
+    const expectedBonusXp = MAX_POSTER_COUNT * POSTER_POINTS_PER_UNIT;
+    expect(bonusXpTransactions![0].xp_amount).toBe(expectedBonusXp);
+  });
+
+  test("is_featured=true のPOSTINGミッションでボーナスXPが2倍になる", async () => {
+    testMission = await createTestMission({
+      requiredArtifactType: "POSTING",
+      difficulty: 1,
+      isFeatured: true,
+    });
+
+    const postingCount = 3;
+    const result = await achieveMission(adminClient, testUserClient, {
+      userId: testUserId,
+      missionId: testMission.id,
+      artifactType: "POSTING",
+      artifactData: {
+        missionId: testMission.id,
+        requiredArtifactType: "POSTING",
+        postingCount,
+        locationText: "テスト場所（2倍）",
+      } as any,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    // DB確認: ボーナスXPが2倍で付与されている
+    const { data: bonusXpTransactions } = await adminClient
+      .from("xp_transactions")
+      .select("xp_amount, source_type, description")
+      .eq("user_id", testUserId)
+      .eq("source_type", "BONUS");
+
+    expect(bonusXpTransactions).toHaveLength(1);
+    const basePoints = postingCount * POSTING_POINTS_PER_UNIT;
+    const expectedBonusXp = basePoints * 2; // is_featured=true で2倍
+    expect(bonusXpTransactions![0].xp_amount).toBe(expectedBonusXp);
+    expect(bonusXpTransactions![0].description).toContain("2倍");
+
+    // 合計XP確認
+    expect(result.xpGranted).toBe(expectedBonusXp);
+  });
+});
+
+describe("cancelSubmission ユースケース - 追加テスト", () => {
+  let testMission: TestMission;
+  let testUserId: string;
+  let testUserClient: SupabaseClient<Database>;
+
+  beforeEach(async () => {
+    const { user, client } = await createTestUser();
+    testUserId = user.userId;
+    testUserClient = client;
+    await initializeTestUserLevel(testUserId);
+  });
+
+  afterEach(async () => {
+    if (testMission) {
+      await cleanupTestMission(testMission.id);
+    }
+    if (testUserId) {
+      await cleanupTestXpTransactions(testUserId);
+      await cleanupTestUserLevel(testUserId);
+      await cleanupTestUser(testUserId);
+    }
+  });
+
+  test("POSTINGミッション（ボーナスミッション）の取り消しでボーナスXPも減算される", async () => {
+    // BONUS_MISSION_SLUGS に含まれるスラグを使うため、既存ミッションを一時的にリネーム
+    const bonusSlug = "posting-magazine";
+    const { data: existingMission } = await adminClient
+      .from("missions")
+      .select("id, slug")
+      .eq("slug", bonusSlug)
+      .maybeSingle();
+
+    let originalMissionId: string | null = null;
+    if (existingMission) {
+      originalMissionId = existingMission.id;
+      await adminClient
+        .from("missions")
+        .update({ slug: `${bonusSlug}-backup-${Date.now()}` })
+        .eq("id", originalMissionId);
+    }
+
+    try {
+      testMission = await createTestMission({
+        requiredArtifactType: "POSTING",
+        difficulty: 1,
+        slug: bonusSlug,
+        isFeatured: false,
+      });
+
+      const postingCount = 5;
+      // ミッション達成
+      const achieveResult = await achieveMission(adminClient, testUserClient, {
+        userId: testUserId,
+        missionId: testMission.id,
+        artifactType: "POSTING",
+        artifactData: {
+          missionId: testMission.id,
+          requiredArtifactType: "POSTING",
+          postingCount,
+          locationText: "テスト場所",
+        } as any,
+      });
+      expect(achieveResult.success).toBe(true);
+
+      // XP確認 - ボーナスXPのみが付与されている（POSTINGはベースXPなし）
+      const xpBefore = await getTestUserXp(testUserId);
+      const expectedBonusXp = postingCount * POSTING_POINTS_PER_UNIT;
+      expect(xpBefore!.xp).toBe(expectedBonusXp);
+
+      // achievementのIDを取得
+      const { data: achievements } = await adminClient
+        .from("achievements")
+        .select("id")
+        .eq("user_id", testUserId)
+        .eq("mission_id", testMission.id);
+
+      expect(achievements).toHaveLength(1);
+      const achievementId = achievements![0].id;
+
+      // 取り消し
+      const cancelResult = await cancelSubmission(adminClient, testUserClient, {
+        userId: testUserId,
+        achievementId,
+        missionId: testMission.id,
+      });
+
+      expect(cancelResult.success).toBe(true);
+      if (!cancelResult.success) return;
+      expect(cancelResult.message).toBe("達成を取り消しました。");
+
+      // DB確認: achievementが削除されている
+      const { data: achievementsAfter } = await adminClient
+        .from("achievements")
+        .select("id")
+        .eq("user_id", testUserId)
+        .eq("mission_id", testMission.id);
+
+      expect(achievementsAfter).toHaveLength(0);
+
+      // DB確認: XPが0に戻っている（ボーナスXP分も含めて減算）
+      const xpAfter = await getTestUserXp(testUserId);
+      expect(xpAfter!.xp).toBe(0);
+    } finally {
+      // 既存ミッションのスラグを元に戻す
+      if (originalMissionId) {
+        await adminClient
+          .from("missions")
+          .update({ slug: bonusSlug })
+          .eq("id", originalMissionId);
+      }
+    }
+  });
+
+  test("存在しない achievementId の取り消しはエラーになる", async () => {
+    testMission = await createTestMission({
+      requiredArtifactType: "NONE",
+      difficulty: 1,
+    });
+
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+
+    const cancelResult = await cancelSubmission(adminClient, testUserClient, {
+      userId: testUserId,
+      achievementId: nonExistentId,
+      missionId: testMission.id,
+    });
+
+    expect(cancelResult.success).toBe(false);
+    if (cancelResult.success) return;
+    expect(cancelResult.error).toContain("見つからない");
   });
 });


### PR DESCRIPTION
## Summary
- POSTING/POSTERタイプのミッション達成テストを追加（posting_activities/poster_activitiesレコード作成、ボーナスXP付与の検証）
- is_featured=trueのPOSTINGミッションでボーナスXPが2倍になることを検証するテストを追加
- ボーナスミッション（BONUS_MISSION_SLUGS）の取り消しでボーナスXPも含めて減算されることを検証するテストを追加
- 存在しないachievementIdの取り消しがエラーになることを検証するテストを追加
- cleanupTestMission でposting_activities/poster_activitiesも削除するよう改善

## 依存PR
- feat/mission-usecase ブランチをマージ済み（achieve-mission/cancel-submission ユースケースの基盤）

## Test plan
- [x] 全11テストがローカルで通過（既存6 + 新規5）
- [x] TypeScript型チェック通過
- [x] Biomeフォーマット/リント通過