### PR TITLE
fix: 新規登録時に外部サービス連携セクションを非表示にする

### DIFF
--- a/src/app/(protected)/settings/profile/page.tsx
+++ b/src/app/(protected)/settings/profile/page.tsx
@@ -76,41 +76,43 @@ export default async function ProfileSettingsPage({
         </div>
       )}
 
-      <div className="w-full max-w-md mt-6 pt-6 border-t border-gray-200">
-        <h3 className="text-sm font-medium text-gray-700 mb-3">
-          外部サービス連携
-        </h3>
-        <div className="space-y-2">
-          {process.env.NEXT_PUBLIC_TIKTOK_CLIENT_KEY && (
-            <Link
-              href="/settings/tiktok"
-              className="flex items-center justify-between p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
-            >
-              <div className="flex items-center gap-3">
-                <TikTokIcon className="w-5 h-5" />
-                <span className="text-sm font-medium text-gray-900">
-                  TikTok連携
-                </span>
-              </div>
-              <ChevronRight className="w-4 h-4 text-gray-400" />
-            </Link>
-          )}
-          {process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID && (
-            <Link
-              href="/settings/youtube"
-              className="flex items-center justify-between p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
-            >
-              <div className="flex items-center gap-3">
-                <YouTubeIcon className="w-5 h-5 text-red-600" />
-                <span className="text-sm font-medium text-gray-900">
-                  YouTube連携
-                </span>
-              </div>
-              <ChevronRight className="w-4 h-4 text-gray-400" />
-            </Link>
-          )}
+      {!isNew && (
+        <div className="w-full max-w-md mt-6 pt-6 border-t border-gray-200">
+          <h3 className="text-sm font-medium text-gray-700 mb-3">
+            外部サービス連携
+          </h3>
+          <div className="space-y-2">
+            {process.env.NEXT_PUBLIC_TIKTOK_CLIENT_KEY && (
+              <Link
+                href="/settings/tiktok"
+                className="flex items-center justify-between p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  <TikTokIcon className="w-5 h-5" />
+                  <span className="text-sm font-medium text-gray-900">
+                    TikTok連携
+                  </span>
+                </div>
+                <ChevronRight className="w-4 h-4 text-gray-400" />
+              </Link>
+            )}
+            {process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID && (
+              <Link
+                href="/settings/youtube"
+                className="flex items-center justify-between p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  <YouTubeIcon className="w-5 h-5 text-red-600" />
+                  <span className="text-sm font-medium text-gray-900">
+                    YouTube連携
+                  </span>
+                </div>
+                <ChevronRight className="w-4 h-4 text-gray-400" />
+              </Link>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {!isNew && <AccountDeletionSection />}
     </div>


### PR DESCRIPTION
# 変更の概要
- 新規ユーザー登録フロー（`/settings/profile?new=true`）で表示されていたYouTube連携・TikTok連携のリンクを非表示にする
- `LoginSection` や `AccountDeletionSection` と同様に `isNew` フラグで制御

# 変更の背景
- 新規登録時のプロフィール設定画面に外部サービス連携（YouTube・TikTok）のリンクが表示されていた
- 登録直後のユーザーにとって不要な導線であり、フォームをシンプルに保つために非表示にする
- 既存ユーザーが設定画面にアクセスした場合は従来通り表示される

# スクリーンショット
- [ ] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プロフィール設定ページにおいて、新規ユーザーモード時には外部サービス（TikTokおよびYouTubeリンク）セクションが表示されなくなりました。既存ユーザーには引き続き表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->