### PR TITLE
fix: ミッション達成ダイアログのOG画像表示エラーを修正

### DIFF
--- a/src/features/mission-detail/components/mission-complete-dialog.tsx
+++ b/src/features/mission-detail/components/mission-complete-dialog.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -43,7 +42,8 @@ export function MissionCompleteDialog({ isOpen, onClose, mission }: Props) {
           <DialogDescription className="text-center">
             {message}
           </DialogDescription>
-          <Image
+          {/* OG画像はAPIルートで動的生成されるため、Next.js Image Optimizationを使わない */}
+          <img
             src={
               mission.ogp_image_url
                 ? mission.ogp_image_url


### PR DESCRIPTION
## Summary
- ミッション達成ダイアログで OG画像が「"url" parameter is not allowed」エラーで表示されない問題を修正
- Next.js `Image` コンポーネントが内部APIルート (`/api/missions/*/og?type=complete`) を Image Optimization 経由で読み込もうとし、`next.config.ts` の `remotePatterns` に含まれないため 400 エラーになっていた
- 動的生成されるOG画像にImage Optimizationは不要なため、標準の `<img>` タグに変更

## Test plan
- [ ] ミッション達成ダイアログを開き、OG画像が正しく表示されることを確認
- [ ] `ogp_image_url` が設定されたミッションでも画像が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 画像表示の技術的な実装を更新しました。ミッション詳細ダイアログの画像表示機能は変わっていません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->