### PR TITLE
本番デプロイ 02/23 21:20

### DIFF
--- a/src/features/ranking/components/base-current-user-card.tsx
+++ b/src/features/ranking/components/base-current-user-card.tsx
@@ -17,12 +17,14 @@ interface BaseCurrentUserCardProps {
     party_membership?: PartyMembership | null;
   } | null;
   title?: string;
+  level?: number;
   children: React.ReactNode;
 }
 
 export const BaseCurrentUserCard: React.FC<BaseCurrentUserCardProps> = ({
   currentUser,
   title = "あなたのランク",
+  level,
   children,
 }) => {
   if (!currentUser) {
@@ -58,8 +60,15 @@ export const BaseCurrentUserCard: React.FC<BaseCurrentUserCardProps> = ({
                   nameClassName="font-semibold text-gray-900"
                   badgeSize={18}
                 />
-                <div className="text-sm text-gray-600">
-                  {displayUser.address_prefecture}
+                <div className="flex items-center gap-1 mt-0.5">
+                  <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded-full">
+                    {displayUser.address_prefecture}
+                  </span>
+                  {level != null && (
+                    <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded-full">
+                      Lv.{level}
+                    </span>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/features/ranking/components/base-ranking.tsx
+++ b/src/features/ranking/components/base-ranking.tsx
@@ -9,6 +9,7 @@ interface BaseRankingProps {
   detailsHref?: string;
   showDetailedInfo?: boolean;
   detailsLinkText?: string;
+  columns?: 3 | 4;
 }
 
 export const BaseRanking: React.FC<BaseRankingProps> = ({
@@ -17,6 +18,7 @@ export const BaseRanking: React.FC<BaseRankingProps> = ({
   detailsHref,
   showDetailedInfo = false,
   detailsLinkText = "トップ100を見る",
+  columns = 4,
 }) => {
   return (
     <div className="flex flex-col gap-6">
@@ -25,7 +27,13 @@ export const BaseRanking: React.FC<BaseRankingProps> = ({
           {title}
         </h2>
         {children.length > 0 ? (
-          <div className="grid grid-cols-[auto_1fr_auto_auto] gap-x-3">
+          <div
+            className={
+              columns === 3
+                ? "grid grid-cols-[auto_1fr_auto] gap-x-3"
+                : "grid grid-cols-[auto_1fr_auto_auto] gap-x-3"
+            }
+          >
             {children}
           </div>
         ) : (

--- a/src/features/ranking/components/current-user-card-prefecture.test.tsx
+++ b/src/features/ranking/components/current-user-card-prefecture.test.tsx
@@ -14,9 +14,11 @@ jest.mock("./ranking-level-badge", () => ({
 jest.mock("./base-current-user-card", () => ({
   BaseCurrentUserCard: ({
     currentUser,
+    level,
     children,
   }: {
     currentUser: any;
+    level?: number;
     children: React.ReactNode;
   }) => {
     if (!currentUser) return null;
@@ -44,6 +46,7 @@ jest.mock("./base-current-user-card", () => ({
                   </div>
                   <div className="text-sm text-gray-600">
                     {currentUser.address_prefecture || "未設定"}
+                    {level != null && <span> Lv.{level}</span>}
                   </div>
                 </div>
               </div>
@@ -105,7 +108,7 @@ describe("CurrentUserCardPrefecture", () => {
       expect(screen.getByTestId("user-icon")).toBeInTheDocument();
     });
 
-    it("レベルバッジが表示される", () => {
+    it("レベルが都道府県の横に表示される", () => {
       render(
         <CurrentUserCardPrefecture
           currentUser={mockUser}
@@ -113,7 +116,6 @@ describe("CurrentUserCardPrefecture", () => {
         />,
       );
 
-      expect(screen.getByTestId("level-badge")).toBeInTheDocument();
       expect(screen.getByText("Lv.30")).toBeInTheDocument();
     });
   });
@@ -177,7 +179,7 @@ describe("CurrentUserCardPrefecture", () => {
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
 
-      expect(screen.getByText("123,456pt")).toBeInTheDocument();
+      expect(screen.getByText("12.3万pt")).toBeInTheDocument();
     });
 
     it("大きな数値も正しくフォーマットされる", () => {
@@ -186,7 +188,7 @@ describe("CurrentUserCardPrefecture", () => {
         <CurrentUserCardPrefecture currentUser={user} prefecture="東京都" />,
       );
 
-      expect(screen.getByText("1,000,000pt")).toBeInTheDocument();
+      expect(screen.getByText("100万pt")).toBeInTheDocument();
     });
   });
 

--- a/src/features/ranking/components/current-user-card-prefecture.tsx
+++ b/src/features/ranking/components/current-user-card-prefecture.tsx
@@ -1,6 +1,6 @@
+import { formatNumberJa } from "@/lib/utils/format-number-ja";
 import type { UserRanking } from "../types/ranking-types";
 import { BaseCurrentUserCard } from "./base-current-user-card";
-import { LevelBadge } from "./ranking-level-badge";
 
 interface CurrentUserCardProps {
   currentUser: UserRanking | null;
@@ -30,12 +30,9 @@ export const CurrentUserCardPrefecture: React.FC<CurrentUserCardProps> = ({
   };
 
   return (
-    <BaseCurrentUserCard currentUser={userForCard}>
-      <div className="flex items-center gap-2 mb-1">
-        <LevelBadge level={displayUser.level} />
-        <div className="text-lg font-bold">
-          {displayUser.xp.toLocaleString()}pt
-        </div>
+    <BaseCurrentUserCard currentUser={userForCard} level={displayUser.level}>
+      <div className="text-lg font-bold">
+        {formatNumberJa(displayUser.xp)}pt
       </div>
     </BaseCurrentUserCard>
   );

--- a/src/features/ranking/components/current-user-card.test.tsx
+++ b/src/features/ranking/components/current-user-card.test.tsx
@@ -111,6 +111,7 @@ describe("CurrentUserCard", () => {
 
       expect(screen.getByText("テストユーザー")).toBeInTheDocument();
       expect(screen.getByText("東京都")).toBeInTheDocument();
+      expect(screen.getByText("Lv.25")).toBeInTheDocument();
       expect(screen.getByText("2,500pt")).toBeInTheDocument();
       expect(screen.getByText("5")).toBeInTheDocument();
       expect(mockUserNameWithBadge).toHaveBeenCalledWith(
@@ -128,10 +129,9 @@ describe("CurrentUserCard", () => {
       expect(screen.getByTestId("user-icon")).toBeInTheDocument();
     });
 
-    it("レベルバッジが表示される", () => {
+    it("レベルが都道府県の横に表示される", () => {
       render(<CurrentUserCard currentUser={mockUser} />);
 
-      expect(screen.getByTestId("level-badge")).toBeInTheDocument();
       expect(screen.getByText("Lv.25")).toBeInTheDocument();
     });
   });

--- a/src/features/ranking/components/current-user-card.tsx
+++ b/src/features/ranking/components/current-user-card.tsx
@@ -1,7 +1,6 @@
 import { formatNumberJa } from "@/lib/utils/format-number-ja";
 import type { UserRanking } from "../types/ranking-types";
 import { BaseCurrentUserCard } from "./base-current-user-card";
-import { LevelBadge } from "./ranking-level-badge";
 
 interface CurrentUserCardProps {
   currentUser: UserRanking | null;
@@ -29,12 +28,9 @@ export const CurrentUserCard: React.FC<CurrentUserCardProps> = ({
   };
 
   return (
-    <BaseCurrentUserCard currentUser={userForCard}>
-      <div className="flex items-center gap-2 mb-1">
-        <LevelBadge level={displayUser.level} />
-        <div className="text-lg font-bold">
-          {formatNumberJa(displayUser.xp)}pt
-        </div>
+    <BaseCurrentUserCard currentUser={userForCard} level={displayUser.level}>
+      <div className="text-lg font-bold">
+        {formatNumberJa(displayUser.xp)}pt
       </div>
     </BaseCurrentUserCard>
   );

--- a/src/features/ranking/components/ranking-item.test.tsx
+++ b/src/features/ranking/components/ranking-item.test.tsx
@@ -122,8 +122,8 @@ describe("RankingItem", () => {
 
       expect(screen.getByText("テストユーザー")).toBeInTheDocument();
       expect(screen.getByText("東京都")).toBeInTheDocument();
-      expect(screen.getByText("1,500pt")).toBeInTheDocument();
       expect(screen.getByText("Lv.15")).toBeInTheDocument();
+      expect(screen.getByText("1,500pt")).toBeInTheDocument();
       expect(mockUserNameWithBadge).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "テストユーザー",
@@ -198,7 +198,7 @@ describe("RankingItem", () => {
       expect(screen.getByText("5回達成")).toBeInTheDocument();
     });
 
-    it("ミッション別ランキングの場合はレベル表示されない", () => {
+    it("ミッション別ランキングの場合もレベルが表示される", () => {
       render(
         <RankingItem
           user={mockUserRanking}
@@ -208,7 +208,8 @@ describe("RankingItem", () => {
         />,
       );
 
-      expect(screen.queryByText("Lv.15")).not.toBeInTheDocument();
+      expect(screen.getByText("東京都")).toBeInTheDocument();
+      expect(screen.getByText("Lv.15")).toBeInTheDocument();
     });
 
     it("userWithMissionがnullの場合は0ptが表示される", () => {
@@ -253,44 +254,36 @@ describe("RankingItem", () => {
       expect(screen.getByText("0pt")).toBeInTheDocument();
     });
 
-    it("レベルがnullの場合はLv.nullが表示される", () => {
+    it("レベルがnullの場合はLv.が表示される", () => {
       const user = { ...mockUserRanking, level: null };
       render(<RankingItem user={user} />);
 
+      expect(screen.getByText("東京都")).toBeInTheDocument();
       expect(screen.getByText("Lv.")).toBeInTheDocument();
     });
   });
 
-  describe("レベルバッジの色分岐", () => {
-    const renderWithLevel = (level: number | null) =>
-      render(<RankingItem user={{ ...mockUserRanking, level }} />);
-
-    it("level>=40 の分岐を通る", () => {
-      renderWithLevel(40);
+  describe("ポイント表示のスタイル", () => {
+    it("一般ランキングではemeraldバッジでptが表示される", () => {
+      render(<RankingItem user={mockUserRanking} />);
       const badge = screen.getByTestId("badge");
       expect(badge).toHaveClass("bg-emerald-100 text-emerald-700");
-      expect(screen.getByText("Lv.40")).toBeInTheDocument();
+      expect(screen.getByText("1,500pt")).toBeInTheDocument();
     });
 
-    it("level>=30 の分岐を通る", () => {
-      renderWithLevel(30);
+    it("ミッションランキングではemeraldバッジでptが表示され回数はプレーンテキスト", () => {
+      render(
+        <RankingItem
+          user={mockUserRanking}
+          userWithMission={mockUserMissionRanking}
+          mission={{ id: "test", name: "test" }}
+          badgeText="5回"
+        />,
+      );
       const badge = screen.getByTestId("badge");
       expect(badge).toHaveClass("bg-emerald-100 text-emerald-700");
-      expect(screen.getByText("Lv.30")).toBeInTheDocument();
-    });
-
-    it("level>=20 の分岐を通る", () => {
-      renderWithLevel(20);
-      const badge = screen.getByTestId("badge");
-      expect(badge).toHaveClass("bg-emerald-100 text-emerald-700");
-      expect(screen.getByText("Lv.20")).toBeInTheDocument();
-    });
-
-    it("level<10 の分岐を通る", () => {
-      renderWithLevel(5);
-      const badge = screen.getByTestId("badge");
-      expect(badge).toHaveClass("text-emerald-700 bg-emerald-100");
-      expect(screen.getByText("Lv.5")).toBeInTheDocument();
+      expect(screen.getByText("2,500pt")).toBeInTheDocument();
+      expect(screen.getByText("5回")).toBeInTheDocument();
     });
   });
 });

--- a/src/features/ranking/components/ranking-item.tsx
+++ b/src/features/ranking/components/ranking-item.tsx
@@ -4,7 +4,6 @@ import { Badge } from "@/components/ui/badge";
 import { UserNameWithBadge } from "@/features/party-membership/components/user-name-with-badge";
 import { formatNumberJa } from "@/lib/utils/format-number-ja";
 import type { UserMissionRanking, UserRanking } from "../types/ranking-types";
-import { getLevelBadgeColor } from "../utils/level-badge-styles";
 import { getRankIcon } from "./ranking-icon";
 
 interface RankingItemProps {
@@ -38,7 +37,14 @@ export function RankingItem({
           nameClassName="font-bold text-lg"
           badgeSize={20}
         />
-        <div className="text-sm text-gray-600">{user.address_prefecture}</div>
+        <div className="flex items-center gap-1 mt-0.5">
+          <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded-full">
+            {user.address_prefecture}
+          </span>
+          <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded-full">
+            Lv.{user.level}
+          </span>
+        </div>
         {showDetailedInfo && (
           <div className="text-xs text-gray-500 mt-1">ID: {user.user_id}</div>
         )}
@@ -46,28 +52,17 @@ export function RankingItem({
       {/* ミッション別ランキングの場合はポイントと達成回数を表示 */}
       {mission ? (
         <>
-          <Badge
-            className={
-              "bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full w-fit justify-self-end"
-            }
-          >
+          <span className="text-sm text-gray-600 font-bold justify-self-end">
             {badgeText}
-          </Badge>
-          <span className="font-bold text-lg justify-self-end">
-            {(userWithMission?.total_points ?? 0).toLocaleString()}pt
           </span>
+          <Badge className="bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full w-fit justify-self-end font-bold">
+            {(userWithMission?.total_points ?? 0).toLocaleString()}pt
+          </Badge>
         </>
       ) : (
-        <>
-          <Badge
-            className={`${getLevelBadgeColor(user.level)} px-3 py-1 rounded-full w-fit justify-self-end`}
-          >
-            Lv.{user.level}
-          </Badge>
-          <div className="font-bold text-lg justify-self-end">
-            {formatNumberJa(user.xp ?? 0)}pt
-          </div>
-        </>
+        <Badge className="bg-emerald-100 text-emerald-700 px-3 py-1 rounded-full w-fit justify-self-end font-bold">
+          {formatNumberJa(user.xp ?? 0)}pt
+        </Badge>
       )}
     </Link>
   );

--- a/src/features/ranking/components/ranking-prefecture.tsx
+++ b/src/features/ranking/components/ranking-prefecture.tsx
@@ -34,6 +34,7 @@ export async function RankingPrefecture({
       title={title}
       detailsHref={`/ranking/ranking-prefecture?prefecture=${prefecture}`}
       showDetailedInfo={showDetailedInfo}
+      columns={3}
     >
       {rankings.map((user) => (
         <RankingItem key={user.user_id} user={user} />

--- a/src/features/ranking/components/ranking-top.tsx
+++ b/src/features/ranking/components/ranking-top.tsx
@@ -28,6 +28,7 @@ export async function RankingTop({
       title={title ?? `🏅${periodLabel}トップ${limit}`}
       detailsHref="/ranking"
       showDetailedInfo={showDetailedInfo}
+      columns={3}
     >
       {rankings.map((user) => (
         <RankingItem key={user.user_id} user={user} />


### PR DESCRIPTION
…obile-layout

fix: ランキングカードのモバイル表示でユーザー名の表示エリアを拡大

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# スクリーンショット
- フロントエンドの変更がある場合は、変更前後のスクリーンショットを貼ってください

- [ ] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました