### PR TITLE
chore: PR作成後のCodeRabbitレビュー確認ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ cp .env ../action-board-<branch-name>/
   - 例: `Resolves #123`
   - 複数のissueをクローズする場合は、それぞれ別の行に記載する
     - 例: `Resolves #123`、`Resolves #456`
+- **PR作成後のCodeRabbitレビュー確認（必須）**: PR作成後、CodeRabbitのレビューが届くまで待ってからコメントを確認すること。レビューは通常2〜3分で届く。`gh api repos/{owner}/{repo}/pulls/{number}/comments` でコメントを取得し、空なら少し待って再取得する。重要な指摘（Major/Critical）があれば修正してpushすること。軽微な指摘（Minor）や既存コードとの一貫性を優先すべきものはスキップ可。
 
 ## 開発コマンド
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdのPull Request作成ガイドラインに、PR作成後にCodeRabbitのレビューコメントを自動チェックするルールを追加
- mirai-gikai PR #465 の内容をaction-boardに取り込み

## 追加ルール
PR作成後、`gh api repos/{owner}/{repo}/pulls/{number}/comments` でCodeRabbitのコメントを取得し、Major/Criticalな指摘があれば修正してpushする。

## Test plan
- [x] CLAUDE.mdの変更内容が既存ルールと矛盾しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)