### PR TITLE
chore: push前にbiome・typecheck・unit testを必須チェックとして追加

### DIFF
--- a/.claude/commands/create_pr.md
+++ b/.claude/commands/create_pr.md
@@ -159,9 +159,22 @@ git diff ${TARGET_REMOTE}/develop...HEAD --stat
 
 差分コミットが 0 件の場合は PR 作成を中止する。
 
-### 6. PR作成
+### 6. Push前の必須チェック
 
-#### 6.1 リモートにpush
+pushする前に以下の3つを実行し、全てパスすることを確認する。失敗した場合は修正してからpushに進む。
+
+```bash
+pnpm run biome:check:write
+pnpm run typecheck
+pnpm run test:unit
+```
+
+- `biome:check:write` で自動修正された場合は、変更を追加コミットする
+- `typecheck` や `test:unit` が失敗した場合は修正してコミットする
+
+### 7. PR作成
+
+#### 7.1 リモートにpush
 
 リモートブランチの存在を確認し、適切なpushコマンドを実行：
 
@@ -172,7 +185,7 @@ git ls-remote --heads origin <ブランチ名> | grep -q <ブランチ名> && \
   git push -u origin <ブランチ名>
 ```
 
-#### 6.2 PRタイトルと本文の生成
+#### 7.2 PRタイトルと本文の生成
 
 まず `.github/PULL_REQUEST_TEMPLATE.md` を読み込み、テンプレートに従ってPR本文を生成する。
 
@@ -185,7 +198,7 @@ git ls-remote --heads origin <ブランチ名> | grep -q <ブランチ名> && \
   - `# スクリーンショット`: フロントエンドの変更がない場合はチェックを入れる
   - `# CLAへの同意`: チェックを入れない（ユーザーが確認して入れる）
 
-#### 6.3 gh pr create の実行
+#### 7.3 gh pr create の実行
 
 `.github/PULL_REQUEST_TEMPLATE.md` を読み込み、各セクションを適切に埋めてPRを作成する。
 
@@ -206,7 +219,7 @@ EOF
 )"
 ```
 
-### 7. PR差分の検証
+### 8. PR差分の検証
 
 PR作成後、意図した変更のみが含まれているか必ず確認する：
 
@@ -220,7 +233,7 @@ gh pr diff <PR番号> --name-only
   - `git rebase --onto develop <元のブランチ> <現在のブランチ>` で修正し、force push する
 - 問題がなければ次のステップへ進む
 
-### 8. 完了報告
+### 9. 完了報告
 
 PRのURLを表示：
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,15 @@ cp .env ../action-board-<branch-name>/
 - コード例、SQL、型定義などの詳細な実装内容を含める
 - 検証方法を具体的に記載する
 
+### Push前の必須チェック
+`git push` する前に、以下の3つを必ず実行し、全てパスすることを確認する：
+
+1. `pnpm run biome:check:write` - フォーマット + リント
+2. `pnpm run typecheck` - 型チェック（`tsc --noEmit`）
+3. `pnpm run test:unit` - ユニットテスト
+
+いずれかが失敗した場合は修正してからpushすること。
+
 ### Pull Request作成
 - PRの説明文に `Resolves #issue番号` を必ず記載し、マージ時に対応するissueが自動的にクローズされるようにする
   - 例: `Resolves #123`


### PR DESCRIPTION
# 変更の概要

- CLAUDE.md（AGENTS.md）の作業ルールに「Push前の必須チェック」セクションを追加
- `/create_pr` commandにpush前チェックステップ（ステップ6）を組み込み

## 仕組み化サマリ

### コード修正
- なし（ルール・ワークフローの仕組み化のみ）

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| push前にbiome, tsc, unit testを必ず実行したい | CLAUDE.mdにルール追加 | `AGENTS.md` 作業ルールセクション |
| push前にbiome, tsc, unit testを必ず実行したい | /create_pr commandにステップ追加 | `.claude/commands/create_pr.md` ステップ6 |

### 仕組み化しなかった項目
- なし

# 変更の背景

push前の品質チェック（biome, typecheck, unit test）をプロジェクトルールとして定着させるため。

# スクリーンショット

- [x] フロントエンドの変更はありません

# CLAへの同意

- [ ] このプルリクエストに含まれるすべてのコードは、本プロジェクトのライセンス（AGPL-3.0）の下で提供されることに同意します。