### PR TITLE
check type-gen in CI

### DIFF
--- a/.github/workflows/check_gen_types.yaml
+++ b/.github/workflows/check_gen_types.yaml
@@ -53,9 +53,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate types
-        run: |
-          supabase gen types typescript --local > src/lib/types/supabase.ts
-          pnpm biome check --write src/lib/types/supabase.ts
+        run: pnpm run types
 
       - name: Check for diff
         run: |

--- a/.github/workflows/check_gen_types.yaml
+++ b/.github/workflows/check_gen_types.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: Start Supabase
         run: supabase start -x studio,postgres-meta,imgproxy,mailpit,logflare,vector
         env:
+          SITE_URL: http://localhost:3000
+          ADDITIONAL_REDIRECT_URLS: http://localhost:3000/auth/callback
+          ENABLE_CONFIRMATIONS: false
           SMTP_ENABLED: false
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
@@ -42,8 +45,7 @@ jobs:
 
       - name: Generate types and check for diff
         run: |
-          npx supabase gen types typescript --local > src/lib/types/supabase.ts
-          pnpm biome check --write src/lib/types/supabase.ts
+          pnpm run types
 
           if git diff --exit-code src/lib/types/supabase.ts; then
             echo "Generated types are up-to-date."

--- a/.github/workflows/check_gen_types.yaml
+++ b/.github/workflows/check_gen_types.yaml
@@ -24,6 +24,16 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
+      # 環境変数を設定（ローカルSupabaseの接続情報）
+      - name: Set Supabase environment variables
+        run: |
+          echo "NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH" >> $GITHUB_ENV
+          echo "SUPABASE_SERVICE_ROLE_KEY=sb_secret_N7UND0UgjKTVK-Uodkm0Hg_xSvEMPvz" >> $GITHUB_ENV
+          echo "DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres" >> $GITHUB_ENV
+          echo "ENABLE_CONFIRMATIONS=false" >> $GITHUB_ENV
+          echo "SITE_URL=http://localhost:3000" >> $GITHUB_ENV
+
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
@@ -32,9 +42,6 @@ jobs:
       - name: Start Supabase
         run: supabase start -x studio,postgres-meta,imgproxy,mailpit,logflare,vector
         env:
-          SITE_URL: http://localhost:3000
-          ADDITIONAL_REDIRECT_URLS: http://localhost:3000/auth/callback
-          ENABLE_CONFIRMATIONS: false
           SMTP_ENABLED: false
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
@@ -42,9 +49,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Verify Supabase is running
-        run: supabase status
 
       - name: Generate types
         run: pnpm run types

--- a/.github/workflows/check_gen_types.yaml
+++ b/.github/workflows/check_gen_types.yaml
@@ -51,7 +51,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate types
-        run: pnpm run types
+        run: |
+          supabase gen types typescript --local > src/lib/types/supabase.ts
+          pnpm biome check --write src/lib/types/supabase.ts
 
       - name: Check for diff
         run: |

--- a/.github/workflows/check_gen_types.yaml
+++ b/.github/workflows/check_gen_types.yaml
@@ -43,10 +43,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate types and check for diff
-        run: |
-          pnpm run types
+      - name: Verify Supabase is running
+        run: supabase status
 
+      - name: Generate types
+        run: pnpm run types
+
+      - name: Check for diff
+        run: |
           if git diff --exit-code src/lib/types/supabase.ts; then
             echo "Generated types are up-to-date."
           else
@@ -62,5 +66,7 @@ jobs:
             echo ""
             echo "  pnpm run types"
             echo ""
+            echo "--- Diff ---"
+            git diff src/lib/types/supabase.ts
             exit 1
           fi

--- a/.github/workflows/check_gen_types.yaml
+++ b/.github/workflows/check_gen_types.yaml
@@ -25,6 +25,8 @@ jobs:
           cache: 'pnpm'
 
       # 環境変数を設定（ローカルSupabaseの接続情報）
+      # supabase start と supabase gen types の両方が config.toml の env() を参照するため
+      # GITHUB_ENV で全ステップに公開する
       - name: Set Supabase environment variables
         run: |
           echo "NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321" >> $GITHUB_ENV
@@ -33,6 +35,8 @@ jobs:
           echo "DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres" >> $GITHUB_ENV
           echo "ENABLE_CONFIRMATIONS=false" >> $GITHUB_ENV
           echo "SITE_URL=http://localhost:3000" >> $GITHUB_ENV
+          echo "SMTP_ENABLED=false" >> $GITHUB_ENV
+          echo "BQ_USER_PASSWORD=bq_user_password" >> $GITHUB_ENV
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
@@ -42,10 +46,8 @@ jobs:
       - name: Start Supabase
         run: supabase start -x studio,postgres-meta,imgproxy,mailpit,logflare,vector
         env:
-          SMTP_ENABLED: false
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
-          BQ_USER_PASSWORD: bq_user_password
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/check_gen_types.yaml
+++ b/.github/workflows/check_gen_types.yaml
@@ -1,0 +1,64 @@
+name: Check generated types are up-to-date
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-gen-types:
+    name: Check Supabase generated types
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase
+        run: supabase start -x studio,postgres-meta,imgproxy,mailpit,logflare,vector
+        env:
+          SMTP_ENABLED: false
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+          BQ_USER_PASSWORD: bq_user_password
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate types and check for diff
+        run: |
+          npx supabase gen types typescript --local > src/lib/types/supabase.ts
+          pnpm biome check --write src/lib/types/supabase.ts
+
+          if git diff --exit-code src/lib/types/supabase.ts; then
+            echo "Generated types are up-to-date."
+          else
+            echo ""
+            echo "============================================"
+            echo "ERROR: Generated types are out of date!"
+            echo "============================================"
+            echo ""
+            echo "The committed src/lib/types/supabase.ts does not match"
+            echo "what 'supabase gen types' produces from the current schema."
+            echo ""
+            echo "Run the following command locally and commit the result:"
+            echo ""
+            echo "  pnpm run types"
+            echo ""
+            exit 1
+          fi

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -632,74 +632,6 @@ export type Database = {
         };
         Relationships: [];
       };
-      residential_poster_placements: {
-        Row: {
-          address: string | null;
-          city: string | null;
-          count: number;
-          created_at: string;
-          id: string;
-          is_deleted: boolean;
-          is_removed: boolean;
-          lat: number;
-          lng: number;
-          location_type: string | null;
-          memo: string | null;
-          mission_artifact_id: string | null;
-          placed_date: string | null;
-          postcode: string | null;
-          prefecture: string | null;
-          updated_at: string;
-          user_id: string;
-        };
-        Insert: {
-          address?: string | null;
-          city?: string | null;
-          count?: number;
-          created_at?: string;
-          id?: string;
-          is_deleted?: boolean;
-          is_removed?: boolean;
-          lat: number;
-          lng: number;
-          location_type?: string | null;
-          memo?: string | null;
-          mission_artifact_id?: string | null;
-          placed_date?: string | null;
-          postcode?: string | null;
-          prefecture?: string | null;
-          updated_at?: string;
-          user_id: string;
-        };
-        Update: {
-          address?: string | null;
-          city?: string | null;
-          count?: number;
-          created_at?: string;
-          id?: string;
-          is_deleted?: boolean;
-          is_removed?: boolean;
-          lat?: number;
-          lng?: number;
-          location_type?: string | null;
-          memo?: string | null;
-          mission_artifact_id?: string | null;
-          placed_date?: string | null;
-          postcode?: string | null;
-          prefecture?: string | null;
-          updated_at?: string;
-          user_id?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "residential_poster_placements_mission_artifact_id_fkey";
-            columns: ["mission_artifact_id"];
-            isOneToOne: false;
-            referencedRelation: "mission_artifacts";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       posting_activities: {
         Row: {
           created_at: string;
@@ -1015,6 +947,74 @@ export type Database = {
             columns: ["mission_id"];
             isOneToOne: false;
             referencedRelation: "missions";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      residential_poster_placements: {
+        Row: {
+          address: string | null;
+          city: string | null;
+          count: number;
+          created_at: string;
+          id: string;
+          is_deleted: boolean;
+          is_removed: boolean;
+          lat: number;
+          lng: number;
+          location_type: string | null;
+          memo: string | null;
+          mission_artifact_id: string | null;
+          placed_date: string | null;
+          postcode: string | null;
+          prefecture: string | null;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          address?: string | null;
+          city?: string | null;
+          count?: number;
+          created_at?: string;
+          id?: string;
+          is_deleted?: boolean;
+          is_removed?: boolean;
+          lat: number;
+          lng: number;
+          location_type?: string | null;
+          memo?: string | null;
+          mission_artifact_id?: string | null;
+          placed_date?: string | null;
+          postcode?: string | null;
+          prefecture?: string | null;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          address?: string | null;
+          city?: string | null;
+          count?: number;
+          created_at?: string;
+          id?: string;
+          is_deleted?: boolean;
+          is_removed?: boolean;
+          lat?: number;
+          lng?: number;
+          location_type?: string | null;
+          memo?: string | null;
+          mission_artifact_id?: string | null;
+          placed_date?: string | null;
+          postcode?: string | null;
+          prefecture?: string | null;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "residential_poster_placements_mission_artifact_id_fkey";
+            columns: ["mission_artifact_id"];
+            isOneToOne: false;
+            referencedRelation: "mission_artifacts";
             referencedColumns: ["id"];
           },
         ];
@@ -1835,17 +1835,6 @@ export type Database = {
         };
         Relationships: [];
       };
-      residential_poster_city_stats: {
-        Row: {
-          avg_lat: number | null;
-          avg_lng: number | null;
-          city: string | null;
-          placement_count: number | null;
-          prefecture: string | null;
-          total_count: number | null;
-        };
-        Relationships: [];
-      };
       quiz_questions_with_category: {
         Row: {
           category_description: string | null;
@@ -1896,6 +1885,17 @@ export type Database = {
             referencedColumns: ["id"];
           },
         ];
+      };
+      residential_poster_city_stats: {
+        Row: {
+          avg_lat: number | null;
+          avg_lng: number | null;
+          city: string | null;
+          placement_count: number | null;
+          prefecture: string | null;
+          total_count: number | null;
+        };
+        Relationships: [];
       };
       user_ranking_view: {
         Row: {


### PR DESCRIPTION
Adds a new workflow that starts local Supabase, regenerates types, and
fails if src/lib/types/supabase.ts differs from what's committed. This
ensures developers (and coding agents) run `pnpm run types` after
schema changes.

https://claude.ai/code/session_017cB7HTazoruarKqfKiaWxu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores（その他）**
  * プルリクエストで自動生成されたTypeScript型定義が最新の状態であることを自動検証するワークフローを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->