### PR TITLE
claude/add-required-field-validation-1a2Z1

### DIFF
--- a/src/features/map-poster-residential/components/residential-poster-form.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-form.tsx
@@ -73,10 +73,8 @@ export function PlacementForm({
 }: PlacementFormProps) {
   const [attempted, setAttempted] = useState(false);
 
-  const hasRequiredFields = !!(address && placedDate && locationType);
   const canSubmit =
     mode === "edit" || (confirmedOrdinance && confirmedLandowner);
-  const isFormReady = hasRequiredFields && canSubmit;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -253,7 +251,7 @@ export function PlacementForm({
         <div className="flex gap-2">
           <Button
             type="submit"
-            disabled={isSubmitting || !isFormReady}
+            disabled={isSubmitting || !canSubmit}
             className="flex-1"
           >
             {isSubmitting ? (

--- a/src/features/map-poster-residential/components/residential-poster-form.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -70,11 +71,15 @@ export function PlacementForm({
   onCancel,
   onDelete,
 }: PlacementFormProps) {
+  const [attempted, setAttempted] = useState(false);
+
   const canSubmit =
     mode === "edit" || (confirmedOrdinance && confirmedLandowner);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    setAttempted(true);
+    if (!placedDate || !locationType) return;
     if (!canSubmit) return;
     onSubmit();
   };
@@ -143,6 +148,9 @@ export function PlacementForm({
             value={placedDate}
             onChange={(e) => onPlacedDateChange(e.target.value)}
           />
+          {attempted && !placedDate && (
+            <p className="mt-1 text-red-600 text-xs">必須入力欄です</p>
+          )}
         </div>
 
         <div className="mb-4">
@@ -169,6 +177,9 @@ export function PlacementForm({
               ))}
             </SelectContent>
           </Select>
+          {attempted && !locationType && (
+            <p className="mt-1 text-red-600 text-xs">必須入力欄です</p>
+          )}
         </div>
 
         <div className="mb-4">

--- a/src/features/map-poster-residential/components/residential-poster-form.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-form.tsx
@@ -79,7 +79,7 @@ export function PlacementForm({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setAttempted(true);
-    if (!placedDate || !locationType) return;
+    if (!address || !placedDate || !locationType) return;
     if (!canSubmit) return;
     onSubmit();
   };
@@ -116,6 +116,9 @@ export function PlacementForm({
               onChange={(e) => onAddressChange(e.target.value)}
               placeholder="住所を入力"
             />
+          )}
+          {attempted && !isLoadingAddress && !address && (
+            <p className="mt-1 text-red-600 text-xs">必須入力欄です</p>
           )}
         </div>
 

--- a/src/features/map-poster-residential/components/residential-poster-form.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-form.tsx
@@ -73,8 +73,10 @@ export function PlacementForm({
 }: PlacementFormProps) {
   const [attempted, setAttempted] = useState(false);
 
+  const hasRequiredFields = !!(address && placedDate && locationType);
   const canSubmit =
     mode === "edit" || (confirmedOrdinance && confirmedLandowner);
+  const isFormReady = hasRequiredFields && canSubmit;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -251,7 +253,7 @@ export function PlacementForm({
         <div className="flex gap-2">
           <Button
             type="submit"
-            disabled={isSubmitting || !canSubmit}
+            disabled={isSubmitting || !isFormReady}
             className="flex-1"
           >
             {isSubmitting ? (


### PR DESCRIPTION
登録ボタン押下時に「貼った日付」と「種別」が空の場合、送信をブロックし
各フィールドの下に「必須入力欄です」を赤字で表示する。

https://claude.ai/code/session_01NMfSFLiwMFs58uTM3q2gnJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 必須項目（日付と場所タイプ）の検証機能を追加しました。フォーム送信時に未入力項目を検出し、各フィールド下に入力必須メッセージが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->