### PR TITLE
claude/review-issue-2201-U2QCI

### DIFF
--- a/supabase/migrations/20260415075545_fix_supabase_security_issues.sql
+++ b/supabase/migrations/20260415075545_fix_supabase_security_issues.sql
@@ -1,0 +1,26 @@
+-- Supabaseセキュリティリンターの指摘事項を修正
+-- ref: https://github.com/team-mirai-volunteer/action-board/issues/2201
+
+-- =============================================================================
+-- 1. SECURITY DEFINER ビューを SECURITY INVOKER に変更
+-- =============================================================================
+-- ビューがビュー作成者（postgres）の権限ではなく、クエリ実行者の権限で
+-- 動作するようにする。これにより基底テーブルのRLSポリシーが正しく適用される。
+
+ALTER VIEW public.activity_timeline_view SET (security_invoker = true);
+ALTER VIEW public.mission_category_view SET (security_invoker = true);
+ALTER VIEW public.mission_achievement_count_view SET (security_invoker = true);
+ALTER VIEW public.user_ranking_view SET (security_invoker = true);
+ALTER VIEW public.quiz_questions_with_category SET (security_invoker = true);
+ALTER VIEW public.mission_quiz_with_links SET (security_invoker = true);
+ALTER VIEW public.poster_board_latest_editors SET (security_invoker = true);
+
+-- =============================================================================
+-- 2. staging_poster_boards テーブルにRLSを有効化
+-- =============================================================================
+-- このテーブルは poster_data/load-csv.ts からpostgresロールで直接DB接続して
+-- TRUNCATE/INSERTされる中継用テーブル。ユーザーやアプリケーションコードからは
+-- アクセスされないため、ポリシーを作成せずRLSのみ有効化することで全アクセスを
+-- 拒否する（postgresロール・service_roleはRLSをバイパスするため動作に影響なし）。
+
+ALTER TABLE public.staging_poster_boards ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
7つのビューを SECURITY DEFINER から SECURITY INVOKER に変更し、
staging_poster_boards テーブルにRLSを有効化する。

- activity_timeline_view 等7ビューに security_invoker = true を設定
- staging_poster_boards にRLSを有効化（CSV loaderはpostgresロールで
  接続するためRLSをバイパスし動作に影響なし）

Resolves #2201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * データベースのセキュリティ設定を強化しました。複数のビューと テーブルに対してセキュリティ権限の設定を更新し、ユーザーデータの アクセス制御をより厳格にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->