### PR TITLE
claude/floating-user-pin-J8dfv

### DIFF
--- a/src/features/map-poster-residential/components/residential-poster-page-client.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-page-client.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import { CONTENT_HEIGHT } from "@/lib/constants/layout";
+import { CONTENT_HEIGHT, HEADER_HEIGHT } from "@/lib/constants/layout";
 import { usePosterPlacementMap } from "../hooks/use-residential-poster-map";
 import {
   fetchCityStats,
@@ -80,6 +80,24 @@ export default function PosterPlacementPageClient({
 
   return (
     <div className="relative w-full" style={{ height: CONTENT_HEIGHT }}>
+      {/* フローティングトグル - sticky でスクロール追従、マップ領域内に制約 */}
+      <div
+        className="sticky z-20 pointer-events-none"
+        style={{ top: `${HEADER_HEIGHT}px`, height: 0 }}
+      >
+        <div className="flex justify-end pr-4 pt-4">
+          <label className="pointer-events-auto flex items-center gap-2 rounded-lg bg-white px-3 py-2 shadow-lg text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showMyPins}
+              onChange={(e) => setShowMyPins(e.target.checked)}
+              className="rounded"
+            />
+            自分のピンを表示
+          </label>
+        </div>
+      </div>
+
       <PosterPlacementMap
         onPinPlaced={handlePinPlaced}
         onPlacementClick={handlePlacementClick}
@@ -88,19 +106,6 @@ export default function PosterPlacementPageClient({
         myPlacements={myPlacements}
         showMyPins={showMyPins}
       />
-
-      {/* トグル UI */}
-      <div className="absolute top-4 right-4 z-20">
-        <label className="flex items-center gap-2 rounded-lg bg-white px-3 py-2 shadow-lg text-sm cursor-pointer">
-          <input
-            type="checkbox"
-            checked={showMyPins}
-            onChange={(e) => setShowMyPins(e.target.checked)}
-            className="rounded"
-          />
-          自分のピンを表示
-        </label>
-      </div>
 
       {isFormOpen && selectedPosition && (
         <PlacementForm

--- a/src/features/map-poster-residential/components/residential-poster-page-client.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-page-client.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
+import { Checkbox } from "@/components/ui/checkbox";
 import { CONTENT_HEIGHT, HEADER_HEIGHT } from "@/lib/constants/layout";
 import { usePosterPlacementMap } from "../hooks/use-residential-poster-map";
 import {
@@ -86,12 +87,14 @@ export default function PosterPlacementPageClient({
         style={{ top: `${HEADER_HEIGHT}px`, height: 0 }}
       >
         <div className="flex justify-end pr-4 pt-4">
-          <label className="pointer-events-auto flex items-center gap-2 rounded-lg bg-white px-3 py-2 shadow-lg text-sm cursor-pointer">
-            <input
-              type="checkbox"
+          <label
+            htmlFor="show-my-pins"
+            className="pointer-events-auto flex items-center gap-2 rounded-lg bg-white px-3 py-2 shadow-lg text-sm cursor-pointer"
+          >
+            <Checkbox
+              id="show-my-pins"
               checked={showMyPins}
-              onChange={(e) => setShowMyPins(e.target.checked)}
-              className="rounded"
+              onCheckedChange={(checked) => setShowMyPins(checked === true)}
             />
             自分のピンを表示
           </label>


### PR DESCRIPTION
ページスクロール時にトグルが画面外に出てしまい、マップ上ではスクロール＝
ズーム操作と競合するため戻れなくなる問題を修正。absolute → sticky に変更し、
マップ領域内でスクロールに追従するようにした。

https://claude.ai/code/session_01P2Sgti2JUrXseLVAM5VKfA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * マップのピン表示トグルをヘッダー下に固定（スクロール時も常に表示）するよう改善しました。
  * トグルの操作性を向上させ、周囲要素によるクリック阻害を防ぐためのポインターイベント調整を行いました。
  * チェックボックスを共通のコンポーネントに置き換え、表示と状態更新の挙動を一貫化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->