### PR TITLE
feat: 私有地ポスターフォームに種別・日付・郵便番号バリデーションを追加

### DIFF
--- a/src/features/map-poster/use-cases/get-poster-board-stats.ts
+++ b/src/features/map-poster/use-cases/get-poster-board-stats.ts
@@ -1,10 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/types/supabase";
 import type { BoardStatus } from "../types/poster-types";
-import {
-  countBoardsByStatus,
-  createEmptyStatusCounts,
-} from "../utils/poster-stats";
+import { createEmptyStatusCounts } from "../utils/poster-stats";
 
 type PrefectureName = NonNullable<
   Database["public"]["Tables"]["poster_boards"]["Row"]["prefecture"]

--- a/src/features/mission-detail/actions/actions.ts
+++ b/src/features/mission-detail/actions/actions.ts
@@ -186,11 +186,13 @@ const residentialPosterArtifactSchema = baseMissionFormSchema.extend({
     .max(MAX_RESIDENTIAL_POSTER_COUNT, {
       message: `掲示枚数は${MAX_RESIDENTIAL_POSTER_COUNT}枚以下で入力してください`,
     }),
+  locationType: z.string().nonempty({ message: "種別を選択してください" }),
+  placedDate: z.string().nonempty({ message: "日付を入力してください" }),
   locationText: z
     .string()
-    .optional()
-    .refine((val) => !val || /^\d{7}$/.test(val), {
-      message: "郵便番号は7桁の数字で入力してください",
+    .nonempty({ message: "郵便番号を入力してください" })
+    .refine((val) => /^\d{7}$/.test(val), {
+      message: "郵便番号はハイフンなし7桁で入力をお願いします",
     }),
 });
 
@@ -269,6 +271,8 @@ export const achieveMissionAction = async (formData: FormData) => {
   const residentialPosterCount = formData
     .get("residentialPosterCount")
     ?.toString();
+  const locationType = formData.get("locationType")?.toString();
+  const placedDate = formData.get("placedDate")?.toString();
   // ポスター用データの取得
   const prefecture = formData.get("prefecture")?.toString();
   const city = formData.get("city")?.toString();
@@ -295,6 +299,8 @@ export const achieveMissionAction = async (formData: FormData) => {
     postingCount,
     locationText,
     residentialPosterCount,
+    locationType,
+    placedDate,
     prefecture,
     city,
     boardNumber,

--- a/src/features/mission-detail/actions/artifact-helpers.test.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.test.ts
@@ -163,10 +163,12 @@ describe("buildArtifactPayload", () => {
       });
     });
 
-    test("RESIDENTIAL_POSTER type → text_contentに「私有地ポスター掲示: X枚 郵便番号」形式の文字列を設定", () => {
+    test("RESIDENTIAL_POSTER type → text_contentに「私有地ポスター掲示: X枚 種別 日付 郵便番号」形式の文字列を設定", () => {
       const data = baseFormData({
         requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
         residentialPosterCount: 3,
+        locationType: "home",
+        placedDate: "2026-04-16",
         locationText: "1540017",
       });
       const result = buildArtifactPayload(
@@ -175,23 +177,7 @@ describe("buildArtifactPayload", () => {
       );
       expect(result).toEqual({
         link_url: null,
-        text_content: "私有地ポスター掲示: 3枚 1540017",
-        image_storage_path: null,
-      });
-    });
-
-    test("RESIDENTIAL_POSTER type → locationText未指定の場合", () => {
-      const data = baseFormData({
-        requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
-        residentialPosterCount: 1,
-      });
-      const result = buildArtifactPayload(
-        ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
-        data,
-      );
-      expect(result).toEqual({
-        link_url: null,
-        text_content: "私有地ポスター掲示: 1枚",
+        text_content: "私有地ポスター掲示: 3枚 home 2026-04-16 1540017",
         image_storage_path: null,
       });
     });

--- a/src/features/mission-detail/actions/artifact-helpers.test.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.test.ts
@@ -177,7 +177,7 @@ describe("buildArtifactPayload", () => {
       );
       expect(result).toEqual({
         link_url: null,
-        text_content: "私有地ポスター掲示: 3枚 home 2026-04-16 1540017",
+        text_content: "私有地ポスター掲示: 3枚 自宅 2026-04-16 1540017",
         image_storage_path: null,
       });
     });

--- a/src/features/mission-detail/actions/artifact-helpers.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { LOCATION_TYPES } from "@/features/map-poster-residential/constants/location-types";
 import {
   buildPosterActivityText,
   buildPostingActivityText,
@@ -103,10 +104,13 @@ const ARTIFACT_PAYLOAD_BUILDERS: Record<
   [ARTIFACT_TYPES.RESIDENTIAL_POSTER.key]: (data) => {
     if (data.requiredArtifactType !== ARTIFACT_TYPES.RESIDENTIAL_POSTER.key)
       return nullFields();
+    const locationTypeLabel =
+      LOCATION_TYPES.find((t) => t.value === data.locationType)?.label ??
+      data.locationType;
     return {
       link_url: null,
       text_content:
-        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${data.locationType} ${data.placedDate} ${data.locationText}`.trim(),
+        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${locationTypeLabel} ${data.placedDate} ${data.locationText}`.trim(),
       image_storage_path: null,
     };
   },

--- a/src/features/mission-detail/actions/artifact-helpers.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.ts
@@ -106,7 +106,7 @@ const ARTIFACT_PAYLOAD_BUILDERS: Record<
     return {
       link_url: null,
       text_content:
-        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${data.locationText ?? ""}`.trim(),
+        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${data.locationType} ${data.placedDate} ${data.locationText}`.trim(),
       image_storage_path: null,
     };
   },

--- a/src/features/mission-detail/components/mission-form-wrapper.test.tsx
+++ b/src/features/mission-detail/components/mission-form-wrapper.test.tsx
@@ -1,0 +1,210 @@
+import type { User } from "@supabase/supabase-js";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Tables } from "@/lib/types/supabase";
+import { MissionFormWrapper } from "./mission-form-wrapper";
+
+// Mock lucide-react icons used by this component (AlertCircle only)
+jest.mock("lucide-react", () => ({
+  AlertCircle: () => <div data-testid="alert-icon" />,
+}));
+
+// Mock hooks
+jest.mock("@/features/missions/hooks/use-mission-submission", () => ({
+  useMissionSubmission: jest.fn(() => ({
+    buttonLabel: "達成を記録する",
+    isButtonDisabled: false,
+    hasReachedUserMaxAchievements: false,
+  })),
+}));
+
+jest.mock("@/features/missions/hooks/use-quiz-mission", () => ({
+  useQuizMission: jest.fn(() => ({
+    quizCategory: null,
+    quizKey: 0,
+    isSubmitting: false,
+    handleQuizComplete: jest.fn(),
+    handleQuizSubmit: jest.fn(),
+  })),
+}));
+
+// Mock server action
+jest.mock("@/features/mission-detail/actions/actions", () => ({
+  achieveMissionAction: jest.fn(() => Promise.resolve({ success: true })),
+}));
+
+// Mock child components
+jest.mock(
+  "@/features/mission-detail/components/mission-complete-dialog",
+  () => ({
+    MissionCompleteDialog: () => <div data-testid="mission-complete-dialog" />,
+  }),
+);
+
+jest.mock("@/features/mission-detail/components/main-link-button", () => ({
+  MainLinkButton: () => <div data-testid="main-link-button" />,
+}));
+
+jest.mock("@/features/missions/components/quiz-component", () => ({
+  __esModule: true,
+  default: () => <div data-testid="quiz-component" />,
+}));
+
+jest.mock("@/features/user-level/components/xp-progress-toast-content", () => ({
+  XpProgressToastContent: () => <div data-testid="xp-progress-toast-content" />,
+}));
+
+jest.mock("sonner", () => ({
+  toast: { custom: jest.fn(), dismiss: jest.fn() },
+}));
+
+// Mock ArtifactForm - capture onValidityChange so tests can trigger it
+let capturedOnValidityChange: ((isValid: boolean) => void) | undefined;
+jest.mock("@/features/missions/components/artifact-form", () => ({
+  ArtifactForm: ({
+    onValidityChange,
+    disabled,
+  }: {
+    onValidityChange?: (isValid: boolean) => void;
+    disabled: boolean;
+  }) => {
+    capturedOnValidityChange = onValidityChange;
+    return (
+      <div data-testid="artifact-form" data-disabled={disabled}>
+        <button
+          type="button"
+          onClick={() => onValidityChange?.(false)}
+          data-testid="trigger-invalid"
+        >
+          trigger invalid
+        </button>
+        <button
+          type="button"
+          onClick={() => onValidityChange?.(true)}
+          data-testid="trigger-valid"
+        >
+          trigger valid
+        </button>
+      </div>
+    );
+  },
+}));
+
+const baseMission: Tables<"missions"> = {
+  id: "test-mission-1",
+  title: "テストミッション",
+  content: "テストミッションの内容",
+  difficulty: 1,
+  icon_url: "/test-icon.svg",
+  event_date: null,
+  max_achievement_count: null,
+  is_featured: false,
+  is_hidden: false,
+  featured_importance: null,
+  artifact_label: "テストラベル",
+  ogp_image_url: null,
+  created_at: "2025-06-22T00:00:00Z",
+  updated_at: "2025-06-22T00:00:00Z",
+  slug: "test-mission-1",
+  required_artifact_type: "RESIDENTIAL_POSTER",
+};
+
+const baseAuthUser = { id: "test-user-id" } as User;
+
+describe("MissionFormWrapper", () => {
+  beforeEach(() => {
+    capturedOnValidityChange = undefined;
+  });
+
+  it("RESIDENTIAL_POSTERミッションでArtifactFormとSubmitButtonが描画される", () => {
+    render(
+      <MissionFormWrapper
+        mission={baseMission}
+        authUser={baseAuthUser}
+        userAchievementCount={0}
+      />,
+    );
+
+    expect(screen.getByTestId("artifact-form")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "達成を記録する" }),
+    ).toBeInTheDocument();
+  });
+
+  it("ArtifactFormにonValidityChangeが渡される", () => {
+    render(
+      <MissionFormWrapper
+        mission={baseMission}
+        authUser={baseAuthUser}
+        userAchievementCount={0}
+      />,
+    );
+
+    expect(capturedOnValidityChange).toBeDefined();
+    expect(typeof capturedOnValidityChange).toBe("function");
+  });
+
+  it("onValidityChange(false)が呼ばれるとSubmitButtonがdisabledになる", () => {
+    render(
+      <MissionFormWrapper
+        mission={baseMission}
+        authUser={baseAuthUser}
+        userAchievementCount={0}
+      />,
+    );
+
+    // 初期状態: SubmitButtonは有効
+    const submitButton = screen.getByRole("button", {
+      name: "達成を記録する",
+    });
+    expect(submitButton).not.toBeDisabled();
+
+    // ArtifactFormがinvalidを通知
+    fireEvent.click(screen.getByTestId("trigger-invalid"));
+
+    // SubmitButtonがdisabledになる
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("onValidityChange(true)で再度有効化される", () => {
+    render(
+      <MissionFormWrapper
+        mission={baseMission}
+        authUser={baseAuthUser}
+        userAchievementCount={0}
+      />,
+    );
+
+    const submitButton = screen.getByRole("button", {
+      name: "達成を記録する",
+    });
+
+    // invalid → disabled
+    fireEvent.click(screen.getByTestId("trigger-invalid"));
+    expect(submitButton).toBeDisabled();
+
+    // valid → not disabled
+    fireEvent.click(screen.getByTestId("trigger-valid"));
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it("max達成数に達した場合フォームは描画されない", () => {
+    const {
+      useMissionSubmission,
+    } = require("@/features/missions/hooks/use-mission-submission");
+    (useMissionSubmission as jest.Mock).mockReturnValueOnce({
+      buttonLabel: "達成を記録する",
+      isButtonDisabled: false,
+      hasReachedUserMaxAchievements: true,
+    });
+
+    render(
+      <MissionFormWrapper
+        mission={{ ...baseMission, max_achievement_count: 1 }}
+        authUser={baseAuthUser}
+        userAchievementCount={1}
+      />,
+    );
+
+    expect(screen.queryByTestId("artifact-form")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/mission-detail/components/mission-form-wrapper.tsx
+++ b/src/features/mission-detail/components/mission-form-wrapper.tsx
@@ -12,6 +12,7 @@ import { MainLinkButton } from "@/features/mission-detail/components/main-link-b
 import { MissionCompleteDialog } from "@/features/mission-detail/components/mission-complete-dialog";
 import { ArtifactForm } from "@/features/missions/components/artifact-form";
 import QuizComponent from "@/features/missions/components/quiz-component";
+import { ResidentialPosterMissionForm } from "@/features/missions/components/residential-poster-form";
 import { useMissionSubmission } from "@/features/missions/hooks/use-mission-submission";
 import { useQuizMission } from "@/features/missions/hooks/use-quiz-mission";
 import { XpProgressToastContent } from "@/features/user-level/components/xp-progress-toast-content";
@@ -235,6 +236,24 @@ export function MissionFormWrapper({
             </div>
           )}
         </div>
+      );
+    }
+
+    // 私有地ポスターミッションの場合（専用バリデーション付きフォーム）
+    if (
+      mission.required_artifact_type === ARTIFACT_TYPES.RESIDENTIAL_POSTER.key
+    ) {
+      return (
+        <ResidentialPosterMissionForm
+          key={formKey}
+          mission={mission}
+          buttonLabel={buttonLabel}
+          isButtonDisabled={isButtonDisabled}
+          isSubmitting={isSubmitting}
+          errorMessage={errorMessage}
+          onSubmit={handleSubmit}
+          formRef={formRef}
+        />
       );
     }
 

--- a/src/features/mission-detail/components/mission-form-wrapper.tsx
+++ b/src/features/mission-detail/components/mission-form-wrapper.tsx
@@ -12,7 +12,6 @@ import { MainLinkButton } from "@/features/mission-detail/components/main-link-b
 import { MissionCompleteDialog } from "@/features/mission-detail/components/mission-complete-dialog";
 import { ArtifactForm } from "@/features/missions/components/artifact-form";
 import QuizComponent from "@/features/missions/components/quiz-component";
-import { ResidentialPosterMissionForm } from "@/features/missions/components/residential-poster-form";
 import { useMissionSubmission } from "@/features/missions/hooks/use-mission-submission";
 import { useQuizMission } from "@/features/missions/hooks/use-quiz-mission";
 import { XpProgressToastContent } from "@/features/user-level/components/xp-progress-toast-content";
@@ -50,6 +49,7 @@ export function MissionFormWrapper({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [formKey, setFormKey] = useState(0);
+  const [isArtifactFormValid, setIsArtifactFormValid] = useState(true);
   const formRef = useRef<HTMLFormElement>(null);
 
   // XPアニメーション関連の状態
@@ -239,24 +239,6 @@ export function MissionFormWrapper({
       );
     }
 
-    // 私有地ポスターミッションの場合（専用バリデーション付きフォーム）
-    if (
-      mission.required_artifact_type === ARTIFACT_TYPES.RESIDENTIAL_POSTER.key
-    ) {
-      return (
-        <ResidentialPosterMissionForm
-          key={formKey}
-          mission={mission}
-          buttonLabel={buttonLabel}
-          isButtonDisabled={isButtonDisabled}
-          isSubmitting={isSubmitting}
-          errorMessage={errorMessage}
-          onSubmit={handleSubmit}
-          formRef={formRef}
-        />
-      );
-    }
-
     // 通常のアーティファクト提出ミッションの場合（YouTube含む）
     return (
       <form ref={formRef} action={handleSubmit} className="flex flex-col gap-4">
@@ -271,11 +253,12 @@ export function MissionFormWrapper({
           key={formKey}
           mission={mission}
           disabled={isButtonDisabled || isSubmitting}
+          onValidityChange={setIsArtifactFormValid}
         />
         <SubmitButton
           pendingText="登録中..."
           size="lg"
-          disabled={isButtonDisabled || isSubmitting}
+          disabled={isButtonDisabled || isSubmitting || !isArtifactFormValid}
         >
           {buttonLabel}
         </SubmitButton>

--- a/src/features/missions/components/artifact-form.test.tsx
+++ b/src/features/missions/components/artifact-form.test.tsx
@@ -103,6 +103,25 @@ describe("ArtifactForm", () => {
     // 詳細はPosterForm.test.tsxで確認
   });
 
+  it("RESIDENTIAL_POSTERタイプの場合は私有地ポスター入力フォームが表示される", () => {
+    const mission = {
+      ...baseMission,
+      required_artifact_type: "RESIDENTIAL_POSTER" as const,
+    };
+
+    render(<ArtifactForm mission={mission} disabled={false} />);
+
+    expect(
+      screen.getByText("原則ポスター掲示マップ上での報告をお願いします。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "ポスター掲示マップで報告できない場合は以下のフォームに入力してください。",
+      ),
+    ).toBeInTheDocument();
+    // 詳細はresidential-poster-form.test.tsxで確認
+  });
+
   it("disabledがtrueの場合は入力フィールドが無効化される", () => {
     const mission = { ...baseMission, required_artifact_type: "LINK" as const };
 

--- a/src/features/missions/components/artifact-form.tsx
+++ b/src/features/missions/components/artifact-form.tsx
@@ -9,7 +9,6 @@ import { ARTIFACT_TYPES, getArtifactConfig } from "@/lib/types/artifact-types";
 import type { Tables } from "@/lib/types/supabase";
 import { PosterForm } from "./poster-form";
 import { PostingForm } from "./posting-form";
-import { ResidentialPosterMissionForm } from "./residential-poster-form";
 import { YouTubeCommentForm } from "./youtube-comment-form";
 import { YouTubeForm } from "./youtube-form";
 
@@ -118,11 +117,6 @@ export function ArtifactForm({ mission, disabled }: ArtifactFormProps) {
         {/* ポスター入力フォーム */}
         {artifactConfig.key === ARTIFACT_TYPES.POSTER.key && (
           <PosterForm disabled={disabled} />
-        )}
-
-        {/* 私有地ポスター入力フォーム */}
-        {artifactConfig.key === ARTIFACT_TYPES.RESIDENTIAL_POSTER.key && (
-          <ResidentialPosterMissionForm disabled={disabled} />
         )}
 
         {/* YouTube入力フォーム */}

--- a/src/features/missions/components/artifact-form.tsx
+++ b/src/features/missions/components/artifact-form.tsx
@@ -9,12 +9,14 @@ import { ARTIFACT_TYPES, getArtifactConfig } from "@/lib/types/artifact-types";
 import type { Tables } from "@/lib/types/supabase";
 import { PosterForm } from "./poster-form";
 import { PostingForm } from "./posting-form";
+import { ResidentialPosterMissionForm } from "./residential-poster-form";
 import { YouTubeCommentForm } from "./youtube-comment-form";
 import { YouTubeForm } from "./youtube-form";
 
 type ArtifactFormProps = {
   mission: Tables<"missions">;
   disabled: boolean;
+  onValidityChange?: (isValid: boolean) => void;
 };
 
 type GeolocationData = {
@@ -24,7 +26,11 @@ type GeolocationData = {
   altitude?: number;
 };
 
-export function ArtifactForm({ mission, disabled }: ArtifactFormProps) {
+export function ArtifactForm({
+  mission,
+  disabled,
+  onValidityChange,
+}: ArtifactFormProps) {
   const [_artifactImagePath, _setArtifactImagePath] = useState<
     string | undefined
   >(undefined);
@@ -117,6 +123,14 @@ export function ArtifactForm({ mission, disabled }: ArtifactFormProps) {
         {/* ポスター入力フォーム */}
         {artifactConfig.key === ARTIFACT_TYPES.POSTER.key && (
           <PosterForm disabled={disabled} />
+        )}
+
+        {/* 私有地ポスター入力フォーム */}
+        {artifactConfig.key === ARTIFACT_TYPES.RESIDENTIAL_POSTER.key && (
+          <ResidentialPosterMissionForm
+            disabled={disabled}
+            onValidityChange={onValidityChange}
+          />
         )}
 
         {/* YouTube入力フォーム */}

--- a/src/features/missions/components/residential-poster-form.test.tsx
+++ b/src/features/missions/components/residential-poster-form.test.tsx
@@ -86,6 +86,27 @@ describe("ResidentialPosterMissionForm", () => {
     expect(mapButton).not.toBeDisabled();
   });
 
+  it("マップボタンをクリックすると新規タブで私有地ポスターマップが開く", () => {
+    const windowOpenSpy = jest
+      .spyOn(window, "open")
+      .mockImplementation(() => null);
+
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const mapButton = screen.getByRole("button", {
+      name: /私有地ポスターマップを開く/,
+    });
+    fireEvent.click(mapButton);
+
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      "/map/poster-residential",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    windowOpenSpy.mockRestore();
+  });
+
   it("disabled=trueの場合はすべての入力フィールドが無効化される", () => {
     render(<ResidentialPosterMissionForm disabled={true} />);
 

--- a/src/features/missions/components/residential-poster-form.test.tsx
+++ b/src/features/missions/components/residential-poster-form.test.tsx
@@ -1,0 +1,271 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ResidentialPosterMissionForm } from "./residential-poster-form";
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  ChevronDown: () => <div data-testid="chevron-down" />,
+  Check: () => <div data-testid="check" />,
+}));
+
+// Mock UI components
+jest.mock("@/components/ui/select", () => {
+  const { useState } = require("react");
+  return {
+    Select: ({ children, value, onValueChange, disabled }: any) => {
+      const [internalValue, setInternalValue] = useState(value || "");
+      return (
+        <div
+          data-testid="select"
+          data-value={internalValue}
+          data-disabled={disabled}
+        >
+          <button
+            type="button"
+            onClick={() => {
+              if (onValueChange && !disabled) {
+                const newValue = "個人宅";
+                setInternalValue(newValue);
+                onValueChange(newValue);
+              }
+            }}
+          >
+            Select Type
+          </button>
+          {children}
+        </div>
+      );
+    },
+    SelectContent: ({ children }: any) => <div>{children}</div>,
+    SelectItem: ({ children, value }: any) => (
+      <div data-value={value}>{children}</div>
+    ),
+    SelectTrigger: ({ children }: any) => <div>{children}</div>,
+    SelectValue: ({ placeholder }: any) => <div>{placeholder}</div>,
+  };
+});
+
+jest.mock("@/components/ui/separator", () => ({
+  Separator: ({ className }: any) => (
+    <hr data-testid="separator" className={className} />
+  ),
+}));
+
+describe("ResidentialPosterMissionForm", () => {
+  it("必須フィールドがすべて表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(screen.getByTestId("select")).toBeInTheDocument();
+    expect(screen.getByLabelText(/貼った日付/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/掲示枚数/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/掲示場所の郵便番号/)).toBeInTheDocument();
+
+    // 必須マーク（*）の確認
+    expect(screen.getAllByText("*")).toHaveLength(4);
+  });
+
+  it("説明テキストが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(
+      screen.getByText("原則ポスター掲示マップ上での報告をお願いします。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "ポスター掲示マップで報告できない場合は以下のフォームに入力してください。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("私有地ポスターマップを開くボタンが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const mapButton = screen.getByRole("button", {
+      name: /私有地ポスターマップを開く/,
+    });
+    expect(mapButton).toBeInTheDocument();
+    expect(mapButton).not.toBeDisabled();
+  });
+
+  it("disabled=trueの場合はすべての入力フィールドが無効化される", () => {
+    render(<ResidentialPosterMissionForm disabled={true} />);
+
+    expect(screen.getByTestId("select")).toHaveAttribute(
+      "data-disabled",
+      "true",
+    );
+    expect(screen.getByLabelText(/貼った日付/)).toBeDisabled();
+    expect(screen.getByLabelText(/掲示枚数/)).toBeDisabled();
+    expect(screen.getByLabelText(/掲示場所の郵便番号/)).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /私有地ポスターマップを開く/ }),
+    ).toBeDisabled();
+  });
+
+  it("disabled=falseの場合はすべての入力フィールドが有効化される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(screen.getByTestId("select")).toHaveAttribute(
+      "data-disabled",
+      "false",
+    );
+    expect(screen.getByLabelText(/貼った日付/)).not.toBeDisabled();
+    expect(screen.getByLabelText(/掲示枚数/)).not.toBeDisabled();
+    expect(screen.getByLabelText(/掲示場所の郵便番号/)).not.toBeDisabled();
+  });
+
+  it("各入力フィールドの属性が正しい", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    // 日付フィールド
+    const dateInput = screen.getByLabelText(/貼った日付/);
+    expect(dateInput).toHaveAttribute("type", "date");
+    expect(dateInput).toHaveAttribute("name", "placedDate");
+    expect(dateInput).toBeRequired();
+
+    // 枚数フィールド
+    const countInput = screen.getByLabelText(/掲示枚数/);
+    expect(countInput).toHaveAttribute("type", "number");
+    expect(countInput).toHaveAttribute("name", "residentialPosterCount");
+    expect(countInput).toHaveAttribute("min", "1");
+    expect(countInput).toBeRequired();
+
+    // 郵便番号フィールド
+    const postalInput = screen.getByLabelText(/掲示場所の郵便番号/);
+    expect(postalInput).toHaveAttribute("type", "text");
+    expect(postalInput).toHaveAttribute("name", "locationText");
+    expect(postalInput).toHaveAttribute("maxLength", "7");
+  });
+
+  it("hidden inputにlocationType名が設定される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const hiddenInput = document.querySelector(
+      'input[name="locationType"][type="hidden"]',
+    );
+    expect(hiddenInput).toBeInTheDocument();
+    expect(hiddenInput).toHaveAttribute("value", "");
+  });
+
+  it("ヘルプテキストが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(
+      screen.getByText("掲示した枚数を入力してください"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("対象エリアの郵便番号をご入力ください"),
+    ).toBeInTheDocument();
+  });
+
+  it("プレースホルダーが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(screen.getByPlaceholderText("例：1")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("例：1540017")).toBeInTheDocument();
+  });
+
+  it("郵便番号が不正な場合にblur後エラーが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const postalInput = screen.getByLabelText(/掲示場所の郵便番号/);
+
+    // 不正な値を入力してblur
+    fireEvent.change(postalInput, { target: { value: "123" } });
+    fireEvent.blur(postalInput);
+
+    expect(
+      screen.getByText("郵便番号はハイフンなし7桁で入力をお願いします"),
+    ).toBeInTheDocument();
+  });
+
+  it("郵便番号が正しい場合はエラーが表示されない", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const postalInput = screen.getByLabelText(/掲示場所の郵便番号/);
+
+    fireEvent.change(postalInput, { target: { value: "1540017" } });
+    fireEvent.blur(postalInput);
+
+    expect(
+      screen.queryByText("郵便番号はハイフンなし7桁で入力をお願いします"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("対象エリアの郵便番号をご入力ください"),
+    ).toBeInTheDocument();
+  });
+
+  it("未入力時はonValidityChangeにfalseが渡される", () => {
+    const onValidityChange = jest.fn();
+
+    render(
+      <ResidentialPosterMissionForm
+        disabled={false}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    expect(onValidityChange).toHaveBeenCalledWith(false);
+  });
+
+  it("全フィールド入力後にonValidityChangeにtrueが渡される", () => {
+    const onValidityChange = jest.fn();
+
+    render(
+      <ResidentialPosterMissionForm
+        disabled={false}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    // 種別を選択
+    fireEvent.click(screen.getByText("Select Type"));
+
+    // 日付を入力
+    fireEvent.change(screen.getByLabelText(/貼った日付/), {
+      target: { value: "2026-04-16" },
+    });
+
+    // 枚数を入力
+    fireEvent.change(screen.getByLabelText(/掲示枚数/), {
+      target: { value: "3" },
+    });
+
+    // 郵便番号を入力
+    fireEvent.change(screen.getByLabelText(/掲示場所の郵便番号/), {
+      target: { value: "1540017" },
+    });
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("枚数が0の場合はonValidityChangeにfalseが渡される", () => {
+    const onValidityChange = jest.fn();
+
+    render(
+      <ResidentialPosterMissionForm
+        disabled={false}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    // 種別を選択
+    fireEvent.click(screen.getByText("Select Type"));
+
+    // 日付を入力
+    fireEvent.change(screen.getByLabelText(/貼った日付/), {
+      target: { value: "2026-04-16" },
+    });
+
+    // 枚数を0に設定
+    fireEvent.change(screen.getByLabelText(/掲示枚数/), {
+      target: { value: "0" },
+    });
+
+    // 郵便番号を入力
+    fireEvent.change(screen.getByLabelText(/掲示場所の郵便番号/), {
+      target: { value: "1540017" },
+    });
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/features/missions/components/residential-poster-form.test.tsx
+++ b/src/features/missions/components/residential-poster-form.test.tsx
@@ -289,4 +289,35 @@ describe("ResidentialPosterMissionForm", () => {
 
     expect(onValidityChange).toHaveBeenLastCalledWith(false);
   });
+
+  it("郵便番号が不正な桁数の場合はonValidityChangeにfalseが渡される", () => {
+    const onValidityChange = jest.fn();
+
+    render(
+      <ResidentialPosterMissionForm
+        disabled={false}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    // 種別を選択
+    fireEvent.click(screen.getByText("Select Type"));
+
+    // 日付を入力
+    fireEvent.change(screen.getByLabelText(/貼った日付/), {
+      target: { value: "2026-04-16" },
+    });
+
+    // 枚数を入力
+    fireEvent.change(screen.getByLabelText(/掲示枚数/), {
+      target: { value: "3" },
+    });
+
+    // 郵便番号を不正な桁数で入力
+    fireEvent.change(screen.getByLabelText(/掲示場所の郵便番号/), {
+      target: { value: "123" },
+    });
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+  });
 });

--- a/src/features/missions/components/residential-poster-form.tsx
+++ b/src/features/missions/components/residential-poster-form.tsx
@@ -1,78 +1,243 @@
 "use client";
 
+import { AlertCircle } from "lucide-react";
+import { useState } from "react";
+import { SubmitButton } from "@/components/common/submit-button";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  LOCATION_TYPES,
+  type LocationTypeValue,
+} from "@/features/map-poster-residential/constants/location-types";
+import { achieveMissionAction } from "@/features/mission-detail/actions/actions";
+import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
+import type { Tables } from "@/lib/types/supabase";
 
 type ResidentialPosterMissionFormProps = {
-  disabled: boolean;
+  mission: Tables<"missions">;
+  buttonLabel: string;
+  isButtonDisabled: boolean;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  onSubmit: (formData: FormData) => Promise<void>;
+  formRef: React.RefObject<HTMLFormElement | null>;
 };
 
+const POSTAL_CODE_REGEX = /^\d{7}$/;
+
 export function ResidentialPosterMissionForm({
-  disabled,
+  mission,
+  buttonLabel,
+  isButtonDisabled,
+  isSubmitting,
+  errorMessage,
+  onSubmit,
+  formRef,
 }: ResidentialPosterMissionFormProps) {
+  const [locationType, setLocationType] = useState<LocationTypeValue | "">("");
+  const [placedDate, setPlacedDate] = useState("");
+  const [posterCount, setPosterCount] = useState("");
+  const [locationText, setLocationText] = useState("");
+  const [postalCodeTouched, setPostalCodeTouched] = useState(false);
+
+  const disabled = isButtonDisabled || isSubmitting;
+
+  const isPostalCodeValid =
+    locationText.length > 0 && POSTAL_CODE_REGEX.test(locationText);
+  const showPostalCodeError =
+    postalCodeTouched && locationText.length > 0 && !isPostalCodeValid;
+
+  const isFormValid =
+    Number(posterCount) >= 1 &&
+    locationType !== "" &&
+    placedDate !== "" &&
+    isPostalCodeValid;
+
   return (
-    <div className="space-y-4">
-      <div>
-        <p>原則ポスター掲示マップ上での報告をお願いします。</p>
-        <p>
-          ポスター掲示マップ上で報告をすることで、自動的にミッションクリアとなります。
-        </p>
-        <Button
-          type="button"
-          size={"lg"}
-          className="w-full my-4"
-          disabled={disabled}
-          onClick={() =>
-            window.open(
-              "/map/poster-residential",
-              "_blank",
-              "noopener,noreferrer",
-            )
-          }
-        >
-          私有地ポスターマップを開く
-        </Button>
+    <form ref={formRef} action={onSubmit} className="flex flex-col gap-4">
+      <input type="hidden" name="missionId" value={mission.id} />
+      <input
+        type="hidden"
+        name="requiredArtifactType"
+        value={ARTIFACT_TYPES.RESIDENTIAL_POSTER.key}
+      />
+      {/* hidden input for Select value (Radix Select doesn't natively submit via FormData) */}
+      <input type="hidden" name="locationType" value={locationType} />
 
-        <Separator className="my-4" />
-        <p>
-          ポスター掲示マップで報告できない場合は以下のフォームに入力してください。
-        </p>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg text-center">
+            ミッション完了を記録しよう
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            ミッションを完了したら、達成を記録しましょう！
+          </p>
+          <p className="text-sm text-muted-foreground">
+            ※ 入力した内容は、外部に公開されることはありません。
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-4">
+            <div>
+              <p>原則ポスター掲示マップ上での報告をお願いします。</p>
+              <p>
+                ポスター掲示マップ上で報告をすることで、自動的にミッションクリアとなります。
+              </p>
+              <Button
+                type="button"
+                size={"lg"}
+                className="w-full my-4"
+                disabled={disabled}
+                onClick={() =>
+                  window.open(
+                    "/map/poster-residential",
+                    "_blank",
+                    "noopener,noreferrer",
+                  )
+                }
+              >
+                私有地ポスターマップを開く
+              </Button>
 
-      {/* 掲示枚数 */}
-      <div className="space-y-2">
-        <Label htmlFor="residentialPosterCount">
-          掲示枚数 <span className="text-red-500">*</span>
-        </Label>
-        <Input
-          type="number"
-          name="residentialPosterCount"
-          id="residentialPosterCount"
-          min="1"
-          required
-          disabled={disabled}
-          placeholder="例：1"
-        />
-        <p className="text-xs text-gray-500">掲示した枚数を入力してください</p>
-      </div>
+              <Separator className="my-4" />
+              <p>
+                ポスター掲示マップで報告できない場合は以下のフォームに入力してください。
+              </p>
+            </div>
 
-      {/* 郵便番号 */}
-      <div className="space-y-2">
-        <Label htmlFor="locationText">掲示場所の郵便番号（ハイフンなし）</Label>
-        <Input
-          type="text"
-          name="locationText"
-          id="locationText"
-          maxLength={100}
-          disabled={disabled}
-          placeholder="例：1540017"
-        />
-        <p className="text-xs text-gray-500">
-          対象エリアの郵便番号をご入力ください
-        </p>
-      </div>
-    </div>
+            {/* 種別 */}
+            <div className="space-y-2">
+              <Label htmlFor="locationType">
+                種別 <span className="text-red-500">*</span>
+              </Label>
+              <Select
+                value={locationType}
+                onValueChange={(v) =>
+                  setLocationType(v as LocationTypeValue | "")
+                }
+                disabled={disabled}
+              >
+                <SelectTrigger id="locationType">
+                  <SelectValue placeholder="種別を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {LOCATION_TYPES.map((type) => (
+                    <SelectItem key={type.value} value={type.value}>
+                      {type.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* 貼った日付 */}
+            <div className="space-y-2">
+              <Label htmlFor="placedDate">
+                貼った日付 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                type="date"
+                name="placedDate"
+                id="placedDate"
+                value={placedDate}
+                onChange={(e) => setPlacedDate(e.target.value)}
+                disabled={disabled}
+                required
+              />
+            </div>
+
+            {/* 掲示枚数 */}
+            <div className="space-y-2">
+              <Label htmlFor="residentialPosterCount">
+                掲示枚数 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                type="number"
+                name="residentialPosterCount"
+                id="residentialPosterCount"
+                min="1"
+                required
+                disabled={disabled}
+                placeholder="例：1"
+                value={posterCount}
+                onChange={(e) => setPosterCount(e.target.value)}
+              />
+              <p className="text-xs text-gray-500">
+                掲示した枚数を入力してください
+              </p>
+            </div>
+
+            {/* 郵便番号 */}
+            <div className="space-y-2">
+              <Label htmlFor="locationText">
+                掲示場所の郵便番号（ハイフンなし）{" "}
+                <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                type="text"
+                name="locationText"
+                id="locationText"
+                maxLength={7}
+                disabled={disabled}
+                placeholder="例：1540017"
+                value={locationText}
+                onChange={(e) => setLocationText(e.target.value)}
+                onBlur={() => setPostalCodeTouched(true)}
+              />
+              {showPostalCodeError ? (
+                <p className="text-xs text-red-600">
+                  郵便番号はハイフンなし7桁で入力をお願いします
+                </p>
+              ) : (
+                <p className="text-xs text-gray-500">
+                  対象エリアの郵便番号をご入力ください
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* 補足説明テキストエリア */}
+          <div className="space-y-2">
+            <Label htmlFor="artifactDescription">補足説明 (任意)</Label>
+            <Textarea
+              name="artifactDescription"
+              id="artifactDescription"
+              placeholder="達成内容に関して補足説明があれば入力してください"
+              rows={3}
+              disabled={disabled}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <SubmitButton
+        pendingText="登録中..."
+        size="lg"
+        disabled={isButtonDisabled || isSubmitting || !isFormValid}
+      >
+        {buttonLabel}
+      </SubmitButton>
+      <p className="text-sm text-muted-foreground">
+        ※
+        成果物の内容が認められない場合、ミッションの達成が取り消される場合があります。正確な内容をご記入ください。
+      </p>
+      {errorMessage && (
+        <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg flex items-center">
+          <AlertCircle className="h-4 w-4 mr-2 shrink-0" />
+          {errorMessage}
+        </div>
+      )}
+    </form>
   );
 }

--- a/src/features/missions/components/residential-poster-form.tsx
+++ b/src/features/missions/components/residential-poster-form.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { AlertCircle } from "lucide-react";
-import { useState } from "react";
-import { SubmitButton } from "@/components/common/submit-button";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -15,43 +12,27 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import { Textarea } from "@/components/ui/textarea";
 import {
   LOCATION_TYPES,
   type LocationTypeValue,
 } from "@/features/map-poster-residential/constants/location-types";
-import { achieveMissionAction } from "@/features/mission-detail/actions/actions";
-import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
-import type { Tables } from "@/lib/types/supabase";
 
 type ResidentialPosterMissionFormProps = {
-  mission: Tables<"missions">;
-  buttonLabel: string;
-  isButtonDisabled: boolean;
-  isSubmitting: boolean;
-  errorMessage: string | null;
-  onSubmit: (formData: FormData) => Promise<void>;
-  formRef: React.RefObject<HTMLFormElement | null>;
+  disabled: boolean;
+  onValidityChange?: (isValid: boolean) => void;
 };
 
 const POSTAL_CODE_REGEX = /^\d{7}$/;
 
 export function ResidentialPosterMissionForm({
-  mission,
-  buttonLabel,
-  isButtonDisabled,
-  isSubmitting,
-  errorMessage,
-  onSubmit,
-  formRef,
+  disabled,
+  onValidityChange,
 }: ResidentialPosterMissionFormProps) {
   const [locationType, setLocationType] = useState<LocationTypeValue | "">("");
   const [placedDate, setPlacedDate] = useState("");
   const [posterCount, setPosterCount] = useState("");
   const [locationText, setLocationText] = useState("");
   const [postalCodeTouched, setPostalCodeTouched] = useState(false);
-
-  const disabled = isButtonDisabled || isSubmitting;
 
   const isPostalCodeValid =
     locationText.length > 0 && POSTAL_CODE_REGEX.test(locationText);
@@ -64,180 +45,127 @@ export function ResidentialPosterMissionForm({
     placedDate !== "" &&
     isPostalCodeValid;
 
+  useEffect(() => {
+    onValidityChange?.(isFormValid);
+  }, [isFormValid, onValidityChange]);
+
   return (
-    <form ref={formRef} action={onSubmit} className="flex flex-col gap-4">
-      <input type="hidden" name="missionId" value={mission.id} />
-      <input
-        type="hidden"
-        name="requiredArtifactType"
-        value={ARTIFACT_TYPES.RESIDENTIAL_POSTER.key}
-      />
+    <div className="space-y-4">
+      <div>
+        <p>原則ポスター掲示マップ上での報告をお願いします。</p>
+        <p>
+          ポスター掲示マップ上で報告をすることで、自動的にミッションクリアとなります。
+        </p>
+        <Button
+          type="button"
+          size={"lg"}
+          className="w-full my-4"
+          disabled={disabled}
+          onClick={() =>
+            window.open(
+              "/map/poster-residential",
+              "_blank",
+              "noopener,noreferrer",
+            )
+          }
+        >
+          私有地ポスターマップを開く
+        </Button>
+
+        <Separator className="my-4" />
+        <p>
+          ポスター掲示マップで報告できない場合は以下のフォームに入力してください。
+        </p>
+      </div>
+
       {/* hidden input for Select value (Radix Select doesn't natively submit via FormData) */}
       <input type="hidden" name="locationType" value={locationType} />
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg text-center">
-            ミッション完了を記録しよう
-          </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            ミッションを完了したら、達成を記録しましょう！
+      {/* 種別 */}
+      <div className="space-y-2">
+        <Label htmlFor="locationType">
+          種別 <span className="text-red-500">*</span>
+        </Label>
+        <Select
+          value={locationType}
+          onValueChange={(v) => setLocationType(v as LocationTypeValue | "")}
+          disabled={disabled}
+        >
+          <SelectTrigger id="locationType">
+            <SelectValue placeholder="種別を選択" />
+          </SelectTrigger>
+          <SelectContent>
+            {LOCATION_TYPES.map((type) => (
+              <SelectItem key={type.value} value={type.value}>
+                {type.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* 貼った日付 */}
+      <div className="space-y-2">
+        <Label htmlFor="placedDate">
+          貼った日付 <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          type="date"
+          name="placedDate"
+          id="placedDate"
+          value={placedDate}
+          onChange={(e) => setPlacedDate(e.target.value)}
+          disabled={disabled}
+          required
+        />
+      </div>
+
+      {/* 掲示枚数 */}
+      <div className="space-y-2">
+        <Label htmlFor="residentialPosterCount">
+          掲示枚数 <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          type="number"
+          name="residentialPosterCount"
+          id="residentialPosterCount"
+          min="1"
+          required
+          disabled={disabled}
+          placeholder="例：1"
+          value={posterCount}
+          onChange={(e) => setPosterCount(e.target.value)}
+        />
+        <p className="text-xs text-gray-500">掲示した枚数を入力してください</p>
+      </div>
+
+      {/* 郵便番号 */}
+      <div className="space-y-2">
+        <Label htmlFor="locationText">
+          掲示場所の郵便番号（ハイフンなし）{" "}
+          <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          type="text"
+          name="locationText"
+          id="locationText"
+          maxLength={7}
+          disabled={disabled}
+          placeholder="例：1540017"
+          value={locationText}
+          onChange={(e) => setLocationText(e.target.value)}
+          onBlur={() => setPostalCodeTouched(true)}
+        />
+        {showPostalCodeError ? (
+          <p className="text-xs text-red-600">
+            郵便番号はハイフンなし7桁で入力をお願いします
           </p>
-          <p className="text-sm text-muted-foreground">
-            ※ 入力した内容は、外部に公開されることはありません。
+        ) : (
+          <p className="text-xs text-gray-500">
+            対象エリアの郵便番号をご入力ください
           </p>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="space-y-4">
-            <div>
-              <p>原則ポスター掲示マップ上での報告をお願いします。</p>
-              <p>
-                ポスター掲示マップ上で報告をすることで、自動的にミッションクリアとなります。
-              </p>
-              <Button
-                type="button"
-                size={"lg"}
-                className="w-full my-4"
-                disabled={disabled}
-                onClick={() =>
-                  window.open(
-                    "/map/poster-residential",
-                    "_blank",
-                    "noopener,noreferrer",
-                  )
-                }
-              >
-                私有地ポスターマップを開く
-              </Button>
-
-              <Separator className="my-4" />
-              <p>
-                ポスター掲示マップで報告できない場合は以下のフォームに入力してください。
-              </p>
-            </div>
-
-            {/* 種別 */}
-            <div className="space-y-2">
-              <Label htmlFor="locationType">
-                種別 <span className="text-red-500">*</span>
-              </Label>
-              <Select
-                value={locationType}
-                onValueChange={(v) =>
-                  setLocationType(v as LocationTypeValue | "")
-                }
-                disabled={disabled}
-              >
-                <SelectTrigger id="locationType">
-                  <SelectValue placeholder="種別を選択" />
-                </SelectTrigger>
-                <SelectContent>
-                  {LOCATION_TYPES.map((type) => (
-                    <SelectItem key={type.value} value={type.value}>
-                      {type.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {/* 貼った日付 */}
-            <div className="space-y-2">
-              <Label htmlFor="placedDate">
-                貼った日付 <span className="text-red-500">*</span>
-              </Label>
-              <Input
-                type="date"
-                name="placedDate"
-                id="placedDate"
-                value={placedDate}
-                onChange={(e) => setPlacedDate(e.target.value)}
-                disabled={disabled}
-                required
-              />
-            </div>
-
-            {/* 掲示枚数 */}
-            <div className="space-y-2">
-              <Label htmlFor="residentialPosterCount">
-                掲示枚数 <span className="text-red-500">*</span>
-              </Label>
-              <Input
-                type="number"
-                name="residentialPosterCount"
-                id="residentialPosterCount"
-                min="1"
-                required
-                disabled={disabled}
-                placeholder="例：1"
-                value={posterCount}
-                onChange={(e) => setPosterCount(e.target.value)}
-              />
-              <p className="text-xs text-gray-500">
-                掲示した枚数を入力してください
-              </p>
-            </div>
-
-            {/* 郵便番号 */}
-            <div className="space-y-2">
-              <Label htmlFor="locationText">
-                掲示場所の郵便番号（ハイフンなし）{" "}
-                <span className="text-red-500">*</span>
-              </Label>
-              <Input
-                type="text"
-                name="locationText"
-                id="locationText"
-                maxLength={7}
-                disabled={disabled}
-                placeholder="例：1540017"
-                value={locationText}
-                onChange={(e) => setLocationText(e.target.value)}
-                onBlur={() => setPostalCodeTouched(true)}
-              />
-              {showPostalCodeError ? (
-                <p className="text-xs text-red-600">
-                  郵便番号はハイフンなし7桁で入力をお願いします
-                </p>
-              ) : (
-                <p className="text-xs text-gray-500">
-                  対象エリアの郵便番号をご入力ください
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* 補足説明テキストエリア */}
-          <div className="space-y-2">
-            <Label htmlFor="artifactDescription">補足説明 (任意)</Label>
-            <Textarea
-              name="artifactDescription"
-              id="artifactDescription"
-              placeholder="達成内容に関して補足説明があれば入力してください"
-              rows={3}
-              disabled={disabled}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      <SubmitButton
-        pendingText="登録中..."
-        size="lg"
-        disabled={isButtonDisabled || isSubmitting || !isFormValid}
-      >
-        {buttonLabel}
-      </SubmitButton>
-      <p className="text-sm text-muted-foreground">
-        ※
-        成果物の内容が認められない場合、ミッションの達成が取り消される場合があります。正確な内容をご記入ください。
-      </p>
-      {errorMessage && (
-        <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg flex items-center">
-          <AlertCircle className="h-4 w-4 mr-2 shrink-0" />
-          {errorMessage}
-        </div>
-      )}
-    </form>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/features/missions/components/residential-poster-form.tsx
+++ b/src/features/missions/components/residential-poster-form.tsx
@@ -113,6 +113,7 @@ export function ResidentialPosterMissionForm({
           type="date"
           name="placedDate"
           id="placedDate"
+          max={new Date().toISOString().split("T")[0]}
           value={placedDate}
           onChange={(e) => setPlacedDate(e.target.value)}
           disabled={disabled}

--- a/supabase/migrations/20260416070000_add_residential_poster_artifact_type.sql
+++ b/supabase/migrations/20260416070000_add_residential_poster_artifact_type.sql
@@ -1,0 +1,104 @@
+-- mission_artifactsのartifact_type制約にRESIDENTIAL_POSTERを追加
+
+-- ==============================================
+-- Part 1: check_artifact_type制約にRESIDENTIAL_POSTERを追加
+-- ==============================================
+
+ALTER TABLE mission_artifacts
+DROP CONSTRAINT IF EXISTS check_artifact_type;
+
+ALTER TABLE mission_artifacts
+ADD CONSTRAINT check_artifact_type
+CHECK (artifact_type IN ('LINK', 'TEXT', 'EMAIL', 'IMAGE', 'IMAGE_WITH_GEOLOCATION', 'REFERRAL', 'POSTING', 'POSTER', 'QUIZ', 'LINK_ACCESS', 'YOUTUBE', 'YOUTUBE_COMMENT', 'RESIDENTIAL_POSTER'));
+
+-- ==============================================
+-- Part 2: ensure_artifact_data制約にRESIDENTIAL_POSTERを追加
+-- RESIDENTIAL_POSTERはPOSTERと同じパターン（text_contentに掲示情報を保存）
+-- ==============================================
+
+ALTER TABLE mission_artifacts
+DROP CONSTRAINT IF EXISTS ensure_artifact_data;
+
+ALTER TABLE mission_artifacts
+ADD CONSTRAINT ensure_artifact_data CHECK (
+  (
+    (
+      (artifact_type = 'LINK'::text)
+      AND (link_url IS NOT NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'TEXT'::text)
+      AND (text_content IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+    )
+    OR (
+      (artifact_type = 'EMAIL'::text)
+      AND (text_content IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+    )
+    OR (
+      (artifact_type = 'IMAGE'::text)
+      AND (image_storage_path IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'IMAGE_WITH_GEOLOCATION'::text)
+      AND (image_storage_path IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'REFERRAL'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NOT NULL)
+    )
+    OR (
+      (artifact_type = 'POSTING'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NOT NULL)
+    )
+    OR (
+      (artifact_type = 'POSTER'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NOT NULL)
+    )
+    OR (
+      (artifact_type = 'QUIZ'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'LINK_ACCESS'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'YOUTUBE'::text)
+      AND (link_url IS NOT NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'YOUTUBE_COMMENT'::text)
+      AND (link_url IS NOT NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'RESIDENTIAL_POSTER'::text)
+      AND (text_content IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+    )
+  )
+);


### PR DESCRIPTION
マップフォームと入力項目を統一し、ミッションページのフォールバックフォームに
種別（Select）と貼った日付（date）を追加。郵便番号を必須化し、7桁数字の
クライアントサイドバリデーション（onBlur時に赤字エラー表示）を実装。
全必須項目が入力されるまで送信ボタンをdisabledにする。

MissionFormWrapperにRESIDENTIAL_POSTER専用分岐を追加し、
自己完結型のステートフルコンポーネントとして独立させることで
他のミッションタイプへの影響を回避。

https://claude.ai/code/session_01CeP9ryqmyqitjUk6h9Jq23

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください
- closes #<issue番号>

# スクリーンショット
- フロントエンドの変更がある場合は、変更前後のスクリーンショットを貼ってください

- [ ] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 民間地ポスター成果物タイプを追加しました。
  * 新しいフォーム入力欄を実装しました: 配置種別、配置日付、住所、郵便番号。
  * リアルタイム形式検証とフォーム状態管理を導入しました。
  * ポスターマップを開くボタンを追加しました。

* **テスト**
  * 民間地ポスターフォームの包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->