### PR TITLE
claude/fix-metrics-background-p4tEL

### DIFF
--- a/src/features/metrics/components/metrics-error-boundary.tsx
+++ b/src/features/metrics/components/metrics-error-boundary.tsx
@@ -30,8 +30,8 @@ export class MetricsErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       return (
-        <section className="bg-gradient-hero flex justify-center py-6 px-4">
-          <div className="w-full max-w-xl bg-white rounded-md shadow-custom p-6">
+        <section className="flex justify-center py-10 px-4">
+          <div className="w-full max-w-lg bg-white rounded-md shadow-custom p-6 py-8">
             <div className="text-center">
               <h2 className="text-xl font-bold text-black mb-2">
                 チームみらいの活動状況🚀

--- a/src/features/metrics/components/metrics-with-suspense.tsx
+++ b/src/features/metrics/components/metrics-with-suspense.tsx
@@ -5,8 +5,8 @@ import { Metrics } from "./metrics-index";
 
 function MetricsSkeleton() {
   return (
-    <section className="bg-gradient-hero flex justify-center py-6">
-      <div className="w-full max-w-xl bg-white rounded-md shadow-custom p-6">
+    <section className="flex justify-center py-10 px-4">
+      <div className="w-full max-w-lg bg-white rounded-md shadow-custom p-6 py-8">
         <div className="text-center mb-6">
           <h2 className="text-2xl font-bold text-black mb-1">
             チームみらいの活動状況🚀
@@ -17,7 +17,7 @@ function MetricsSkeleton() {
           </output>
         </div>
         <div className="space-y-6">
-          <div className="p-4 text-center bg-gray-50 rounded">
+          <div className="p-4 text-center bg-muted rounded">
             <Skeleton className="h-4 w-24 mx-auto mb-2" />
             <Skeleton className="h-8 w-32 mx-auto mb-1" />
             <Skeleton className="h-4 w-20 mx-auto" />


### PR DESCRIPTION
スケルトンとエラー境界で bg-gradient-hero（緑グラデーション）が使われていたが、
実際のMetricsLayoutは背景色なし。他セクションと同様のベージュ/グレー背景に統一。
- bg-gradient-hero を削除し、MetricsLayoutと同じレイアウトに合わせる
- bg-gray-50 → bg-muted に変更（デザインシステムの色に統一）
- max-w-xl → max-w-lg, py-6 → py-10 でMetricsLayoutと一致させる

https://claude.ai/code/session_014RshfXFM3UvqA8orQxPPXc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * エラー表示時のコンテナレイアウトを改善し、背景グラデーションを削除して上下のスペーシングを最適化しました。カードのサイズと垂直パディングも調整しています。
  * ローディング状態のスケルトン表示のデザインを更新しました。カード幅、パディング設定、プレースホルダーの背景色を改善してUIの一貫性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->