### PR TITLE
feat: 私有地ポスターマップにガイドラインリンクを追加

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -849,7 +849,7 @@ missions:
     content: |-
       ポスターを掲示して、掲示マップから報告しましょう。
       掲示した場所と枚数を地図上のピンで報告するとXPが獲得できます。
-      メニューの「私有地ポスターマップ」から報告できます。
+      メニューの「私有地ポスターマップ」から報告できます。<br><a href="https://docs.google.com/document/d/1Wru0CkA_c3YDhYV3S8pXZnl0EnBZ16smpc60ulSPi9E/edit?tab=t.0" target="_blank" rel="noopener noreferrer">ガイドラインはこちら</a>
     difficulty: 2
     required_artifact_type: RESIDENTIAL_POSTER
     max_achievement_count: null

--- a/src/features/map-poster-residential/components/residential-poster-page-client.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-page-client.tsx
@@ -80,75 +80,77 @@ export default function PosterPlacementPageClient({
   } = usePosterPlacementMap({ onSubmitSuccess: refreshData });
 
   return (
-    <div className="relative w-full" style={{ height: CONTENT_HEIGHT }}>
-      {/* フローティングトグル - sticky でスクロール追従、マップ領域内に制約 */}
-      <div
-        className="sticky z-20 pointer-events-none"
-        style={{ top: `${HEADER_HEIGHT}px`, height: 0 }}
-      >
-        <div className="flex justify-between items-start gap-2 px-4 pt-4">
-          <div className="pointer-events-auto rounded-lg bg-white px-3 py-2 shadow-lg">
-            <div className="font-bold text-sm">私有地ポスターマップ</div>
-            <a
-              href="https://docs.google.com/document/d/1Wru0CkA_c3YDhYV3S8pXZnl0EnBZ16smpc60ulSPi9E/edit?tab=t.0"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-blue-600 underline"
-            >
-              ガイドラインはこちら
-            </a>
-          </div>
-          <label
-            htmlFor="show-my-pins"
-            className="pointer-events-auto flex items-center gap-2 rounded-lg bg-white px-3 py-2 shadow-lg text-sm cursor-pointer"
-          >
-            <Checkbox
-              id="show-my-pins"
-              checked={showMyPins}
-              onCheckedChange={(checked) => setShowMyPins(checked === true)}
-            />
-            自分のピンを表示
-          </label>
-        </div>
+    <div className="w-full">
+      <div className="space-y-1 px-4 pt-4 pb-2">
+        <h1 className="text-2xl font-bold">私有地ポスターマップ</h1>
+        <a
+          href="https://docs.google.com/document/d/1Wru0CkA_c3YDhYV3S8pXZnl0EnBZ16smpc60ulSPi9E/edit?tab=t.0"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-blue-600 underline"
+        >
+          ガイドラインはこちら
+        </a>
       </div>
+      <div className="relative w-full" style={{ height: CONTENT_HEIGHT }}>
+        {/* フローティングトグル - sticky でスクロール追従、マップ領域内に制約 */}
+        <div
+          className="sticky z-20 pointer-events-none"
+          style={{ top: `${HEADER_HEIGHT}px`, height: 0 }}
+        >
+          <div className="flex justify-end pr-4 pt-4">
+            <label
+              htmlFor="show-my-pins"
+              className="pointer-events-auto flex items-center gap-2 rounded-lg bg-white px-3 py-2 shadow-lg text-sm cursor-pointer"
+            >
+              <Checkbox
+                id="show-my-pins"
+                checked={showMyPins}
+                onCheckedChange={(checked) => setShowMyPins(checked === true)}
+              />
+              自分のピンを表示
+            </label>
+          </div>
+        </div>
 
-      <PosterPlacementMap
-        onPinPlaced={handlePinPlaced}
-        onPlacementClick={handlePlacementClick}
-        pinPosition={selectedPosition}
-        cityStats={cityStats}
-        myPlacements={myPlacements}
-        showMyPins={showMyPins}
-      />
-
-      {isFormOpen && selectedPosition && (
-        <PlacementForm
-          lat={selectedPosition.lat}
-          lng={selectedPosition.lng}
-          mode={mode}
-          isSubmitting={isSubmitting}
-          isLoadingAddress={isLoadingAddress}
-          address={address}
-          memo={memo}
-          count={count}
-          placedDate={placedDate}
-          locationType={locationType}
-          isRemoved={isRemoved}
-          confirmedOrdinance={confirmedOrdinance}
-          confirmedLandowner={confirmedLandowner}
-          onAddressChange={setAddress}
-          onMemoChange={setMemo}
-          onCountChange={setCount}
-          onPlacedDateChange={setPlacedDate}
-          onLocationTypeChange={setLocationType}
-          onIsRemovedChange={setIsRemoved}
-          onConfirmedOrdinanceChange={setConfirmedOrdinance}
-          onConfirmedLandownerChange={setConfirmedLandowner}
-          onSubmit={handleSubmit}
-          onCancel={handleCancel}
-          onDelete={mode === "edit" ? handleDelete : undefined}
+        <PosterPlacementMap
+          onPinPlaced={handlePinPlaced}
+          onPlacementClick={handlePlacementClick}
+          pinPosition={selectedPosition}
+          cityStats={cityStats}
+          myPlacements={myPlacements}
+          showMyPins={showMyPins}
         />
-      )}
+
+        {isFormOpen && selectedPosition && (
+          <PlacementForm
+            lat={selectedPosition.lat}
+            lng={selectedPosition.lng}
+            mode={mode}
+            isSubmitting={isSubmitting}
+            isLoadingAddress={isLoadingAddress}
+            address={address}
+            memo={memo}
+            count={count}
+            placedDate={placedDate}
+            locationType={locationType}
+            isRemoved={isRemoved}
+            confirmedOrdinance={confirmedOrdinance}
+            confirmedLandowner={confirmedLandowner}
+            onAddressChange={setAddress}
+            onMemoChange={setMemo}
+            onCountChange={setCount}
+            onPlacedDateChange={setPlacedDate}
+            onLocationTypeChange={setLocationType}
+            onIsRemovedChange={setIsRemoved}
+            onConfirmedOrdinanceChange={setConfirmedOrdinance}
+            onConfirmedLandownerChange={setConfirmedLandowner}
+            onSubmit={handleSubmit}
+            onCancel={handleCancel}
+            onDelete={mode === "edit" ? handleDelete : undefined}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/map-poster-residential/components/residential-poster-page-client.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-page-client.tsx
@@ -86,7 +86,18 @@ export default function PosterPlacementPageClient({
         className="sticky z-20 pointer-events-none"
         style={{ top: `${HEADER_HEIGHT}px`, height: 0 }}
       >
-        <div className="flex justify-end pr-4 pt-4">
+        <div className="flex justify-between items-start gap-2 px-4 pt-4">
+          <div className="pointer-events-auto rounded-lg bg-white px-3 py-2 shadow-lg">
+            <div className="font-bold text-sm">私有地ポスターマップ</div>
+            <a
+              href="https://docs.google.com/document/d/1Wru0CkA_c3YDhYV3S8pXZnl0EnBZ16smpc60ulSPi9E/edit?tab=t.0"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-blue-600 underline"
+            >
+              ガイドラインはこちら
+            </a>
+          </div>
           <label
             htmlFor="show-my-pins"
             className="pointer-events-auto flex items-center gap-2 rounded-lg bg-white px-3 py-2 shadow-lg text-sm cursor-pointer"


### PR DESCRIPTION
## Summary

私有地ポスターマップに関するガイドラインドキュメントへのリンクを2箇所に追加します。

- **マップ画面**: 画面上部にフローティングのタイトル「私有地ポスターマップ」と小さな文字で「ガイドラインはこちら」のリンクを追加
- **ミッション説明文**: `residential-poster` ミッションの content に同じ「ガイドラインはこちら」リンクを追加

リンク先: https://docs.google.com/document/d/1Wru0CkA_c3YDhYV3S8pXZnl0EnBZ16smpc60ulSPi9E/edit?tab=t.0

## 変更ファイル

- `src/features/map-poster-residential/components/residential-poster-page-client.tsx` - マップ左上にタイトル＋ガイドラインリンクのフローティングパネルを追加
- `mission_data/missions.yaml` - `residential-poster` ミッションの content にガイドラインリンクを追加

<img width="437" height="279" alt="image" src="https://github.com/user-attachments/assets/4f6c91a7-b501-4614-bbd5-9ab3ab1cf328" />

## Test plan

- [ ] `/map/poster-residential` を開き、マップ左上にタイトルとガイドラインリンクが表示されることを確認
- [ ] 「ガイドラインはこちら」を押下すると別タブでGoogle Docsが開くことを確認
- [ ] 私有地ポスターミッションの詳細ページにガイドラインリンクが表示されることを確認
- [ ] `pnpm run typecheck` / `pnpm run test:unit` がパスすることを確認（ローカルで確認済み）

https://claude.ai/code/session_0157UssVRCEMWM5vXtXdr99c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 住宅地ポスターマップにガイドラインドキュメントへのリンクを追加しました。

* **Style**
  * マップページのヘッダーUIレイアウトを改善し、ページタイトルと操作パネルをバランス良く配置できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->