### PR TITLE
test: 0%カバレッジだった共通ユーティリティ/サービスにテストを追加

### DIFF
--- a/src/features/map-poster/use-cases/get-poster-board-stats.ts
+++ b/src/features/map-poster/use-cases/get-poster-board-stats.ts
@@ -1,10 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/types/supabase";
 import type { BoardStatus } from "../types/poster-types";
-import {
-  countBoardsByStatus,
-  createEmptyStatusCounts,
-} from "../utils/poster-stats";
+import { createEmptyStatusCounts } from "../utils/poster-stats";
 
 type PrefectureName = NonNullable<
   Database["public"]["Tables"]["poster_boards"]["Row"]["prefecture"]

--- a/src/features/map-posting/utils/posting-label.test.ts
+++ b/src/features/map-posting/utils/posting-label.test.ts
@@ -1,4 +1,4 @@
-import { getLabelIconWidth } from "./posting-label";
+import { createPostingLabelIcon, getLabelIconWidth } from "./posting-label";
 
 describe("getLabelIconWidth", () => {
   it("returns minimum width of 50 for single digit numbers", () => {
@@ -38,5 +38,35 @@ describe("getLabelIconWidth", () => {
     const width3 = getLabelIconWidth(100); // 3 digits
     const width4 = getLabelIconWidth(1000); // 4 digits
     expect(width4 - width3).toBe(10);
+  });
+});
+
+describe("createPostingLabelIcon", () => {
+  it("divIconをHTML・className・iconSize・iconAnchor付きで生成する", () => {
+    const mockDivIcon = jest.fn((opts) => ({ __kind: "divIcon", ...opts }));
+    const L = { divIcon: mockDivIcon } as unknown as typeof import("leaflet");
+
+    const icon = createPostingLabelIcon(L, 42);
+
+    expect(mockDivIcon).toHaveBeenCalledTimes(1);
+    const opts = mockDivIcon.mock.calls[0][0];
+    expect(opts.html).toBe('<div class="posting-count-label">42枚</div>');
+    expect(opts.className).toBe("posting-count-marker");
+    expect(opts.iconSize).toEqual([50, 20]);
+    expect(opts.iconAnchor).toEqual([25, 10]);
+    // biome-ignore lint/suspicious/noExplicitAny: test object carries mock marker
+    expect((icon as any).__kind).toBe("divIcon");
+  });
+
+  it("大きな枚数では幅が広がる", () => {
+    const mockDivIcon = jest.fn((opts) => opts);
+    const L = { divIcon: mockDivIcon } as unknown as typeof import("leaflet");
+
+    createPostingLabelIcon(L, 12345);
+
+    const opts = mockDivIcon.mock.calls[0][0];
+    expect(opts.iconSize).toEqual([80, 20]);
+    expect(opts.iconAnchor).toEqual([40, 10]);
+    expect(opts.html).toContain("12345枚");
   });
 });

--- a/src/features/mission-detail/actions/actions.test.ts
+++ b/src/features/mission-detail/actions/actions.test.ts
@@ -1,0 +1,120 @@
+import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
+
+// achieveMissionは呼ばれない想定（バリデーション失敗で早期return）だが、
+// 念のためモック化してDBアクセスを完全に遮断する
+jest.mock("../use-cases/achieve-mission", () => ({
+  achieveMission: jest.fn(),
+}));
+jest.mock("../use-cases/cancel-submission", () => ({
+  cancelSubmission: jest.fn(),
+}));
+jest.mock("./quiz-actions", () => ({
+  checkQuizAnswersAction: jest.fn(),
+  getMissionQuizCategoryAction: jest.fn(),
+  getQuizQuestionsAction: jest.fn(),
+}));
+
+import { achieveMissionAction } from "./actions";
+
+function buildFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) {
+    fd.set(k, v);
+  }
+  return fd;
+}
+
+describe("achieveMissionAction — RESIDENTIAL_POSTER バリデーション", () => {
+  it("locationTypeが空なら『種別を選択してください』エラーを返す", async () => {
+    const fd = buildFormData({
+      missionId: "mission-1",
+      requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+      residentialPosterCount: "3",
+      locationType: "",
+      placedDate: "2026-04-16",
+      locationText: "1540017",
+    });
+
+    const result = await achieveMissionAction(fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("種別を選択してください");
+    }
+  });
+
+  it("placedDateが空なら『日付を入力してください』エラーを返す", async () => {
+    const fd = buildFormData({
+      missionId: "mission-1",
+      requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+      residentialPosterCount: "3",
+      locationType: "home",
+      placedDate: "",
+      locationText: "1540017",
+    });
+
+    const result = await achieveMissionAction(fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("日付を入力してください");
+    }
+  });
+
+  it("locationTextが空なら『郵便番号を入力してください』エラーを返す", async () => {
+    const fd = buildFormData({
+      missionId: "mission-1",
+      requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+      residentialPosterCount: "3",
+      locationType: "home",
+      placedDate: "2026-04-16",
+      locationText: "",
+    });
+
+    const result = await achieveMissionAction(fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("郵便番号を入力してください");
+    }
+  });
+
+  it("locationTextが7桁数字でないなら書式エラーを返す", async () => {
+    const fd = buildFormData({
+      missionId: "mission-1",
+      requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+      residentialPosterCount: "3",
+      locationType: "home",
+      placedDate: "2026-04-16",
+      locationText: "154-0017",
+    });
+
+    const result = await achieveMissionAction(fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain(
+        "郵便番号はハイフンなし7桁で入力をお願いします",
+      );
+    }
+  });
+
+  it("全フィールドが有効な場合はバリデーションをパスし、認証エラーを返す（未ログイン）", async () => {
+    // jest.setup.js で createClient.auth.getUser() が user: null を返すよう設定済み
+    const fd = buildFormData({
+      missionId: "mission-1",
+      requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+      residentialPosterCount: "3",
+      locationType: "home",
+      placedDate: "2026-04-16",
+      locationText: "1540017",
+    });
+
+    const result = await achieveMissionAction(fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("認証エラーが発生しました。");
+    }
+  });
+});

--- a/src/features/mission-detail/actions/actions.ts
+++ b/src/features/mission-detail/actions/actions.ts
@@ -186,11 +186,13 @@ const residentialPosterArtifactSchema = baseMissionFormSchema.extend({
     .max(MAX_RESIDENTIAL_POSTER_COUNT, {
       message: `掲示枚数は${MAX_RESIDENTIAL_POSTER_COUNT}枚以下で入力してください`,
     }),
+  locationType: z.string().nonempty({ message: "種別を選択してください" }),
+  placedDate: z.string().nonempty({ message: "日付を入力してください" }),
   locationText: z
     .string()
-    .optional()
-    .refine((val) => !val || /^\d{7}$/.test(val), {
-      message: "郵便番号は7桁の数字で入力してください",
+    .nonempty({ message: "郵便番号を入力してください" })
+    .refine((val) => /^\d{7}$/.test(val), {
+      message: "郵便番号はハイフンなし7桁で入力をお願いします",
     }),
 });
 
@@ -269,6 +271,8 @@ export const achieveMissionAction = async (formData: FormData) => {
   const residentialPosterCount = formData
     .get("residentialPosterCount")
     ?.toString();
+  const locationType = formData.get("locationType")?.toString();
+  const placedDate = formData.get("placedDate")?.toString();
   // ポスター用データの取得
   const prefecture = formData.get("prefecture")?.toString();
   const city = formData.get("city")?.toString();
@@ -295,6 +299,8 @@ export const achieveMissionAction = async (formData: FormData) => {
     postingCount,
     locationText,
     residentialPosterCount,
+    locationType,
+    placedDate,
     prefecture,
     city,
     boardNumber,

--- a/src/features/mission-detail/actions/artifact-helpers.test.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.test.ts
@@ -182,6 +182,25 @@ describe("buildArtifactPayload", () => {
       });
     });
 
+    test("RESIDENTIAL_POSTER type → 未知のlocationTypeはそのまま文字列として使われる", () => {
+      const data = baseFormData({
+        requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+        residentialPosterCount: 1,
+        locationType: "unknown_type",
+        placedDate: "2026-04-16",
+        locationText: "1540017",
+      });
+      const result = buildArtifactPayload(
+        ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+        data,
+      );
+      expect(result).toEqual({
+        link_url: null,
+        text_content: "私有地ポスター掲示: 1枚 unknown_type 2026-04-16 1540017",
+        image_storage_path: null,
+      });
+    });
+
     test("QUIZ type → 全フィールドnull", () => {
       const data = baseFormData({
         requiredArtifactType: ARTIFACT_TYPES.QUIZ.key,

--- a/src/features/mission-detail/actions/artifact-helpers.test.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.test.ts
@@ -163,10 +163,12 @@ describe("buildArtifactPayload", () => {
       });
     });
 
-    test("RESIDENTIAL_POSTER type → text_contentに「私有地ポスター掲示: X枚 郵便番号」形式の文字列を設定", () => {
+    test("RESIDENTIAL_POSTER type → text_contentに「私有地ポスター掲示: X枚 種別 日付 郵便番号」形式の文字列を設定", () => {
       const data = baseFormData({
         requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
         residentialPosterCount: 3,
+        locationType: "home",
+        placedDate: "2026-04-16",
         locationText: "1540017",
       });
       const result = buildArtifactPayload(
@@ -175,23 +177,7 @@ describe("buildArtifactPayload", () => {
       );
       expect(result).toEqual({
         link_url: null,
-        text_content: "私有地ポスター掲示: 3枚 1540017",
-        image_storage_path: null,
-      });
-    });
-
-    test("RESIDENTIAL_POSTER type → locationText未指定の場合", () => {
-      const data = baseFormData({
-        requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
-        residentialPosterCount: 1,
-      });
-      const result = buildArtifactPayload(
-        ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
-        data,
-      );
-      expect(result).toEqual({
-        link_url: null,
-        text_content: "私有地ポスター掲示: 1枚",
+        text_content: "私有地ポスター掲示: 3枚 home 2026-04-16 1540017",
         image_storage_path: null,
       });
     });

--- a/src/features/mission-detail/actions/artifact-helpers.test.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.test.ts
@@ -177,7 +177,7 @@ describe("buildArtifactPayload", () => {
       );
       expect(result).toEqual({
         link_url: null,
-        text_content: "私有地ポスター掲示: 3枚 home 2026-04-16 1540017",
+        text_content: "私有地ポスター掲示: 3枚 自宅 2026-04-16 1540017",
         image_storage_path: null,
       });
     });

--- a/src/features/mission-detail/actions/artifact-helpers.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { LOCATION_TYPES } from "@/features/map-poster-residential/constants/location-types";
 import {
   buildPosterActivityText,
   buildPostingActivityText,
@@ -103,10 +104,13 @@ const ARTIFACT_PAYLOAD_BUILDERS: Record<
   [ARTIFACT_TYPES.RESIDENTIAL_POSTER.key]: (data) => {
     if (data.requiredArtifactType !== ARTIFACT_TYPES.RESIDENTIAL_POSTER.key)
       return nullFields();
+    const locationTypeLabel =
+      LOCATION_TYPES.find((t) => t.value === data.locationType)?.label ??
+      data.locationType;
     return {
       link_url: null,
       text_content:
-        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${data.locationType} ${data.placedDate} ${data.locationText}`.trim(),
+        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${locationTypeLabel} ${data.placedDate} ${data.locationText}`.trim(),
       image_storage_path: null,
     };
   },

--- a/src/features/mission-detail/actions/artifact-helpers.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.ts
@@ -106,7 +106,7 @@ const ARTIFACT_PAYLOAD_BUILDERS: Record<
     return {
       link_url: null,
       text_content:
-        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${data.locationText ?? ""}`.trim(),
+        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${data.locationType} ${data.placedDate} ${data.locationText}`.trim(),
       image_storage_path: null,
     };
   },

--- a/src/features/mission-detail/components/mission-form-wrapper.test.tsx
+++ b/src/features/mission-detail/components/mission-form-wrapper.test.tsx
@@ -1,0 +1,210 @@
+import type { User } from "@supabase/supabase-js";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Tables } from "@/lib/types/supabase";
+import { MissionFormWrapper } from "./mission-form-wrapper";
+
+// Mock lucide-react icons used by this component (AlertCircle only)
+jest.mock("lucide-react", () => ({
+  AlertCircle: () => <div data-testid="alert-icon" />,
+}));
+
+// Mock hooks
+jest.mock("@/features/missions/hooks/use-mission-submission", () => ({
+  useMissionSubmission: jest.fn(() => ({
+    buttonLabel: "達成を記録する",
+    isButtonDisabled: false,
+    hasReachedUserMaxAchievements: false,
+  })),
+}));
+
+jest.mock("@/features/missions/hooks/use-quiz-mission", () => ({
+  useQuizMission: jest.fn(() => ({
+    quizCategory: null,
+    quizKey: 0,
+    isSubmitting: false,
+    handleQuizComplete: jest.fn(),
+    handleQuizSubmit: jest.fn(),
+  })),
+}));
+
+// Mock server action
+jest.mock("@/features/mission-detail/actions/actions", () => ({
+  achieveMissionAction: jest.fn(() => Promise.resolve({ success: true })),
+}));
+
+// Mock child components
+jest.mock(
+  "@/features/mission-detail/components/mission-complete-dialog",
+  () => ({
+    MissionCompleteDialog: () => <div data-testid="mission-complete-dialog" />,
+  }),
+);
+
+jest.mock("@/features/mission-detail/components/main-link-button", () => ({
+  MainLinkButton: () => <div data-testid="main-link-button" />,
+}));
+
+jest.mock("@/features/missions/components/quiz-component", () => ({
+  __esModule: true,
+  default: () => <div data-testid="quiz-component" />,
+}));
+
+jest.mock("@/features/user-level/components/xp-progress-toast-content", () => ({
+  XpProgressToastContent: () => <div data-testid="xp-progress-toast-content" />,
+}));
+
+jest.mock("sonner", () => ({
+  toast: { custom: jest.fn(), dismiss: jest.fn() },
+}));
+
+// Mock ArtifactForm - capture onValidityChange so tests can trigger it
+let capturedOnValidityChange: ((isValid: boolean) => void) | undefined;
+jest.mock("@/features/missions/components/artifact-form", () => ({
+  ArtifactForm: ({
+    onValidityChange,
+    disabled,
+  }: {
+    onValidityChange?: (isValid: boolean) => void;
+    disabled: boolean;
+  }) => {
+    capturedOnValidityChange = onValidityChange;
+    return (
+      <div data-testid="artifact-form" data-disabled={disabled}>
+        <button
+          type="button"
+          onClick={() => onValidityChange?.(false)}
+          data-testid="trigger-invalid"
+        >
+          trigger invalid
+        </button>
+        <button
+          type="button"
+          onClick={() => onValidityChange?.(true)}
+          data-testid="trigger-valid"
+        >
+          trigger valid
+        </button>
+      </div>
+    );
+  },
+}));
+
+const baseMission: Tables<"missions"> = {
+  id: "test-mission-1",
+  title: "テストミッション",
+  content: "テストミッションの内容",
+  difficulty: 1,
+  icon_url: "/test-icon.svg",
+  event_date: null,
+  max_achievement_count: null,
+  is_featured: false,
+  is_hidden: false,
+  featured_importance: null,
+  artifact_label: "テストラベル",
+  ogp_image_url: null,
+  created_at: "2025-06-22T00:00:00Z",
+  updated_at: "2025-06-22T00:00:00Z",
+  slug: "test-mission-1",
+  required_artifact_type: "RESIDENTIAL_POSTER",
+};
+
+const baseAuthUser = { id: "test-user-id" } as User;
+
+describe("MissionFormWrapper", () => {
+  beforeEach(() => {
+    capturedOnValidityChange = undefined;
+  });
+
+  it("RESIDENTIAL_POSTERミッションでArtifactFormとSubmitButtonが描画される", () => {
+    render(
+      <MissionFormWrapper
+        mission={baseMission}
+        authUser={baseAuthUser}
+        userAchievementCount={0}
+      />,
+    );
+
+    expect(screen.getByTestId("artifact-form")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "達成を記録する" }),
+    ).toBeInTheDocument();
+  });
+
+  it("ArtifactFormにonValidityChangeが渡される", () => {
+    render(
+      <MissionFormWrapper
+        mission={baseMission}
+        authUser={baseAuthUser}
+        userAchievementCount={0}
+      />,
+    );
+
+    expect(capturedOnValidityChange).toBeDefined();
+    expect(typeof capturedOnValidityChange).toBe("function");
+  });
+
+  it("onValidityChange(false)が呼ばれるとSubmitButtonがdisabledになる", () => {
+    render(
+      <MissionFormWrapper
+        mission={baseMission}
+        authUser={baseAuthUser}
+        userAchievementCount={0}
+      />,
+    );
+
+    // 初期状態: SubmitButtonは有効
+    const submitButton = screen.getByRole("button", {
+      name: "達成を記録する",
+    });
+    expect(submitButton).not.toBeDisabled();
+
+    // ArtifactFormがinvalidを通知
+    fireEvent.click(screen.getByTestId("trigger-invalid"));
+
+    // SubmitButtonがdisabledになる
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("onValidityChange(true)で再度有効化される", () => {
+    render(
+      <MissionFormWrapper
+        mission={baseMission}
+        authUser={baseAuthUser}
+        userAchievementCount={0}
+      />,
+    );
+
+    const submitButton = screen.getByRole("button", {
+      name: "達成を記録する",
+    });
+
+    // invalid → disabled
+    fireEvent.click(screen.getByTestId("trigger-invalid"));
+    expect(submitButton).toBeDisabled();
+
+    // valid → not disabled
+    fireEvent.click(screen.getByTestId("trigger-valid"));
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it("max達成数に達した場合フォームは描画されない", () => {
+    const {
+      useMissionSubmission,
+    } = require("@/features/missions/hooks/use-mission-submission");
+    (useMissionSubmission as jest.Mock).mockReturnValueOnce({
+      buttonLabel: "達成を記録する",
+      isButtonDisabled: false,
+      hasReachedUserMaxAchievements: true,
+    });
+
+    render(
+      <MissionFormWrapper
+        mission={{ ...baseMission, max_achievement_count: 1 }}
+        authUser={baseAuthUser}
+        userAchievementCount={1}
+      />,
+    );
+
+    expect(screen.queryByTestId("artifact-form")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/mission-detail/components/mission-form-wrapper.tsx
+++ b/src/features/mission-detail/components/mission-form-wrapper.tsx
@@ -12,6 +12,7 @@ import { MainLinkButton } from "@/features/mission-detail/components/main-link-b
 import { MissionCompleteDialog } from "@/features/mission-detail/components/mission-complete-dialog";
 import { ArtifactForm } from "@/features/missions/components/artifact-form";
 import QuizComponent from "@/features/missions/components/quiz-component";
+import { ResidentialPosterMissionForm } from "@/features/missions/components/residential-poster-form";
 import { useMissionSubmission } from "@/features/missions/hooks/use-mission-submission";
 import { useQuizMission } from "@/features/missions/hooks/use-quiz-mission";
 import { XpProgressToastContent } from "@/features/user-level/components/xp-progress-toast-content";
@@ -235,6 +236,24 @@ export function MissionFormWrapper({
             </div>
           )}
         </div>
+      );
+    }
+
+    // 私有地ポスターミッションの場合（専用バリデーション付きフォーム）
+    if (
+      mission.required_artifact_type === ARTIFACT_TYPES.RESIDENTIAL_POSTER.key
+    ) {
+      return (
+        <ResidentialPosterMissionForm
+          key={formKey}
+          mission={mission}
+          buttonLabel={buttonLabel}
+          isButtonDisabled={isButtonDisabled}
+          isSubmitting={isSubmitting}
+          errorMessage={errorMessage}
+          onSubmit={handleSubmit}
+          formRef={formRef}
+        />
       );
     }
 

--- a/src/features/mission-detail/components/mission-form-wrapper.tsx
+++ b/src/features/mission-detail/components/mission-form-wrapper.tsx
@@ -12,7 +12,6 @@ import { MainLinkButton } from "@/features/mission-detail/components/main-link-b
 import { MissionCompleteDialog } from "@/features/mission-detail/components/mission-complete-dialog";
 import { ArtifactForm } from "@/features/missions/components/artifact-form";
 import QuizComponent from "@/features/missions/components/quiz-component";
-import { ResidentialPosterMissionForm } from "@/features/missions/components/residential-poster-form";
 import { useMissionSubmission } from "@/features/missions/hooks/use-mission-submission";
 import { useQuizMission } from "@/features/missions/hooks/use-quiz-mission";
 import { XpProgressToastContent } from "@/features/user-level/components/xp-progress-toast-content";
@@ -50,6 +49,7 @@ export function MissionFormWrapper({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [formKey, setFormKey] = useState(0);
+  const [isArtifactFormValid, setIsArtifactFormValid] = useState(true);
   const formRef = useRef<HTMLFormElement>(null);
 
   // XPアニメーション関連の状態
@@ -239,24 +239,6 @@ export function MissionFormWrapper({
       );
     }
 
-    // 私有地ポスターミッションの場合（専用バリデーション付きフォーム）
-    if (
-      mission.required_artifact_type === ARTIFACT_TYPES.RESIDENTIAL_POSTER.key
-    ) {
-      return (
-        <ResidentialPosterMissionForm
-          key={formKey}
-          mission={mission}
-          buttonLabel={buttonLabel}
-          isButtonDisabled={isButtonDisabled}
-          isSubmitting={isSubmitting}
-          errorMessage={errorMessage}
-          onSubmit={handleSubmit}
-          formRef={formRef}
-        />
-      );
-    }
-
     // 通常のアーティファクト提出ミッションの場合（YouTube含む）
     return (
       <form ref={formRef} action={handleSubmit} className="flex flex-col gap-4">
@@ -271,11 +253,12 @@ export function MissionFormWrapper({
           key={formKey}
           mission={mission}
           disabled={isButtonDisabled || isSubmitting}
+          onValidityChange={setIsArtifactFormValid}
         />
         <SubmitButton
           pendingText="登録中..."
           size="lg"
-          disabled={isButtonDisabled || isSubmitting}
+          disabled={isButtonDisabled || isSubmitting || !isArtifactFormValid}
         >
           {buttonLabel}
         </SubmitButton>

--- a/src/features/missions/components/artifact-form.test.tsx
+++ b/src/features/missions/components/artifact-form.test.tsx
@@ -103,6 +103,25 @@ describe("ArtifactForm", () => {
     // 詳細はPosterForm.test.tsxで確認
   });
 
+  it("RESIDENTIAL_POSTERタイプの場合は私有地ポスター入力フォームが表示される", () => {
+    const mission = {
+      ...baseMission,
+      required_artifact_type: "RESIDENTIAL_POSTER" as const,
+    };
+
+    render(<ArtifactForm mission={mission} disabled={false} />);
+
+    expect(
+      screen.getByText("原則ポスター掲示マップ上での報告をお願いします。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "ポスター掲示マップで報告できない場合は以下のフォームに入力してください。",
+      ),
+    ).toBeInTheDocument();
+    // 詳細はresidential-poster-form.test.tsxで確認
+  });
+
   it("disabledがtrueの場合は入力フィールドが無効化される", () => {
     const mission = { ...baseMission, required_artifact_type: "LINK" as const };
 

--- a/src/features/missions/components/artifact-form.tsx
+++ b/src/features/missions/components/artifact-form.tsx
@@ -9,7 +9,6 @@ import { ARTIFACT_TYPES, getArtifactConfig } from "@/lib/types/artifact-types";
 import type { Tables } from "@/lib/types/supabase";
 import { PosterForm } from "./poster-form";
 import { PostingForm } from "./posting-form";
-import { ResidentialPosterMissionForm } from "./residential-poster-form";
 import { YouTubeCommentForm } from "./youtube-comment-form";
 import { YouTubeForm } from "./youtube-form";
 
@@ -118,11 +117,6 @@ export function ArtifactForm({ mission, disabled }: ArtifactFormProps) {
         {/* ポスター入力フォーム */}
         {artifactConfig.key === ARTIFACT_TYPES.POSTER.key && (
           <PosterForm disabled={disabled} />
-        )}
-
-        {/* 私有地ポスター入力フォーム */}
-        {artifactConfig.key === ARTIFACT_TYPES.RESIDENTIAL_POSTER.key && (
-          <ResidentialPosterMissionForm disabled={disabled} />
         )}
 
         {/* YouTube入力フォーム */}

--- a/src/features/missions/components/artifact-form.tsx
+++ b/src/features/missions/components/artifact-form.tsx
@@ -9,12 +9,14 @@ import { ARTIFACT_TYPES, getArtifactConfig } from "@/lib/types/artifact-types";
 import type { Tables } from "@/lib/types/supabase";
 import { PosterForm } from "./poster-form";
 import { PostingForm } from "./posting-form";
+import { ResidentialPosterMissionForm } from "./residential-poster-form";
 import { YouTubeCommentForm } from "./youtube-comment-form";
 import { YouTubeForm } from "./youtube-form";
 
 type ArtifactFormProps = {
   mission: Tables<"missions">;
   disabled: boolean;
+  onValidityChange?: (isValid: boolean) => void;
 };
 
 type GeolocationData = {
@@ -24,7 +26,11 @@ type GeolocationData = {
   altitude?: number;
 };
 
-export function ArtifactForm({ mission, disabled }: ArtifactFormProps) {
+export function ArtifactForm({
+  mission,
+  disabled,
+  onValidityChange,
+}: ArtifactFormProps) {
   const [_artifactImagePath, _setArtifactImagePath] = useState<
     string | undefined
   >(undefined);
@@ -117,6 +123,14 @@ export function ArtifactForm({ mission, disabled }: ArtifactFormProps) {
         {/* ポスター入力フォーム */}
         {artifactConfig.key === ARTIFACT_TYPES.POSTER.key && (
           <PosterForm disabled={disabled} />
+        )}
+
+        {/* 私有地ポスター入力フォーム */}
+        {artifactConfig.key === ARTIFACT_TYPES.RESIDENTIAL_POSTER.key && (
+          <ResidentialPosterMissionForm
+            disabled={disabled}
+            onValidityChange={onValidityChange}
+          />
         )}
 
         {/* YouTube入力フォーム */}

--- a/src/features/missions/components/residential-poster-form.test.tsx
+++ b/src/features/missions/components/residential-poster-form.test.tsx
@@ -86,6 +86,27 @@ describe("ResidentialPosterMissionForm", () => {
     expect(mapButton).not.toBeDisabled();
   });
 
+  it("マップボタンをクリックすると新規タブで私有地ポスターマップが開く", () => {
+    const windowOpenSpy = jest
+      .spyOn(window, "open")
+      .mockImplementation(() => null);
+
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const mapButton = screen.getByRole("button", {
+      name: /私有地ポスターマップを開く/,
+    });
+    fireEvent.click(mapButton);
+
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      "/map/poster-residential",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    windowOpenSpy.mockRestore();
+  });
+
   it("disabled=trueの場合はすべての入力フィールドが無効化される", () => {
     render(<ResidentialPosterMissionForm disabled={true} />);
 

--- a/src/features/missions/components/residential-poster-form.test.tsx
+++ b/src/features/missions/components/residential-poster-form.test.tsx
@@ -1,0 +1,271 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ResidentialPosterMissionForm } from "./residential-poster-form";
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  ChevronDown: () => <div data-testid="chevron-down" />,
+  Check: () => <div data-testid="check" />,
+}));
+
+// Mock UI components
+jest.mock("@/components/ui/select", () => {
+  const { useState } = require("react");
+  return {
+    Select: ({ children, value, onValueChange, disabled }: any) => {
+      const [internalValue, setInternalValue] = useState(value || "");
+      return (
+        <div
+          data-testid="select"
+          data-value={internalValue}
+          data-disabled={disabled}
+        >
+          <button
+            type="button"
+            onClick={() => {
+              if (onValueChange && !disabled) {
+                const newValue = "個人宅";
+                setInternalValue(newValue);
+                onValueChange(newValue);
+              }
+            }}
+          >
+            Select Type
+          </button>
+          {children}
+        </div>
+      );
+    },
+    SelectContent: ({ children }: any) => <div>{children}</div>,
+    SelectItem: ({ children, value }: any) => (
+      <div data-value={value}>{children}</div>
+    ),
+    SelectTrigger: ({ children }: any) => <div>{children}</div>,
+    SelectValue: ({ placeholder }: any) => <div>{placeholder}</div>,
+  };
+});
+
+jest.mock("@/components/ui/separator", () => ({
+  Separator: ({ className }: any) => (
+    <hr data-testid="separator" className={className} />
+  ),
+}));
+
+describe("ResidentialPosterMissionForm", () => {
+  it("必須フィールドがすべて表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(screen.getByTestId("select")).toBeInTheDocument();
+    expect(screen.getByLabelText(/貼った日付/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/掲示枚数/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/掲示場所の郵便番号/)).toBeInTheDocument();
+
+    // 必須マーク（*）の確認
+    expect(screen.getAllByText("*")).toHaveLength(4);
+  });
+
+  it("説明テキストが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(
+      screen.getByText("原則ポスター掲示マップ上での報告をお願いします。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "ポスター掲示マップで報告できない場合は以下のフォームに入力してください。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("私有地ポスターマップを開くボタンが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const mapButton = screen.getByRole("button", {
+      name: /私有地ポスターマップを開く/,
+    });
+    expect(mapButton).toBeInTheDocument();
+    expect(mapButton).not.toBeDisabled();
+  });
+
+  it("disabled=trueの場合はすべての入力フィールドが無効化される", () => {
+    render(<ResidentialPosterMissionForm disabled={true} />);
+
+    expect(screen.getByTestId("select")).toHaveAttribute(
+      "data-disabled",
+      "true",
+    );
+    expect(screen.getByLabelText(/貼った日付/)).toBeDisabled();
+    expect(screen.getByLabelText(/掲示枚数/)).toBeDisabled();
+    expect(screen.getByLabelText(/掲示場所の郵便番号/)).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /私有地ポスターマップを開く/ }),
+    ).toBeDisabled();
+  });
+
+  it("disabled=falseの場合はすべての入力フィールドが有効化される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(screen.getByTestId("select")).toHaveAttribute(
+      "data-disabled",
+      "false",
+    );
+    expect(screen.getByLabelText(/貼った日付/)).not.toBeDisabled();
+    expect(screen.getByLabelText(/掲示枚数/)).not.toBeDisabled();
+    expect(screen.getByLabelText(/掲示場所の郵便番号/)).not.toBeDisabled();
+  });
+
+  it("各入力フィールドの属性が正しい", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    // 日付フィールド
+    const dateInput = screen.getByLabelText(/貼った日付/);
+    expect(dateInput).toHaveAttribute("type", "date");
+    expect(dateInput).toHaveAttribute("name", "placedDate");
+    expect(dateInput).toBeRequired();
+
+    // 枚数フィールド
+    const countInput = screen.getByLabelText(/掲示枚数/);
+    expect(countInput).toHaveAttribute("type", "number");
+    expect(countInput).toHaveAttribute("name", "residentialPosterCount");
+    expect(countInput).toHaveAttribute("min", "1");
+    expect(countInput).toBeRequired();
+
+    // 郵便番号フィールド
+    const postalInput = screen.getByLabelText(/掲示場所の郵便番号/);
+    expect(postalInput).toHaveAttribute("type", "text");
+    expect(postalInput).toHaveAttribute("name", "locationText");
+    expect(postalInput).toHaveAttribute("maxLength", "7");
+  });
+
+  it("hidden inputにlocationType名が設定される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const hiddenInput = document.querySelector(
+      'input[name="locationType"][type="hidden"]',
+    );
+    expect(hiddenInput).toBeInTheDocument();
+    expect(hiddenInput).toHaveAttribute("value", "");
+  });
+
+  it("ヘルプテキストが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(
+      screen.getByText("掲示した枚数を入力してください"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("対象エリアの郵便番号をご入力ください"),
+    ).toBeInTheDocument();
+  });
+
+  it("プレースホルダーが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    expect(screen.getByPlaceholderText("例：1")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("例：1540017")).toBeInTheDocument();
+  });
+
+  it("郵便番号が不正な場合にblur後エラーが表示される", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const postalInput = screen.getByLabelText(/掲示場所の郵便番号/);
+
+    // 不正な値を入力してblur
+    fireEvent.change(postalInput, { target: { value: "123" } });
+    fireEvent.blur(postalInput);
+
+    expect(
+      screen.getByText("郵便番号はハイフンなし7桁で入力をお願いします"),
+    ).toBeInTheDocument();
+  });
+
+  it("郵便番号が正しい場合はエラーが表示されない", () => {
+    render(<ResidentialPosterMissionForm disabled={false} />);
+
+    const postalInput = screen.getByLabelText(/掲示場所の郵便番号/);
+
+    fireEvent.change(postalInput, { target: { value: "1540017" } });
+    fireEvent.blur(postalInput);
+
+    expect(
+      screen.queryByText("郵便番号はハイフンなし7桁で入力をお願いします"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("対象エリアの郵便番号をご入力ください"),
+    ).toBeInTheDocument();
+  });
+
+  it("未入力時はonValidityChangeにfalseが渡される", () => {
+    const onValidityChange = jest.fn();
+
+    render(
+      <ResidentialPosterMissionForm
+        disabled={false}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    expect(onValidityChange).toHaveBeenCalledWith(false);
+  });
+
+  it("全フィールド入力後にonValidityChangeにtrueが渡される", () => {
+    const onValidityChange = jest.fn();
+
+    render(
+      <ResidentialPosterMissionForm
+        disabled={false}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    // 種別を選択
+    fireEvent.click(screen.getByText("Select Type"));
+
+    // 日付を入力
+    fireEvent.change(screen.getByLabelText(/貼った日付/), {
+      target: { value: "2026-04-16" },
+    });
+
+    // 枚数を入力
+    fireEvent.change(screen.getByLabelText(/掲示枚数/), {
+      target: { value: "3" },
+    });
+
+    // 郵便番号を入力
+    fireEvent.change(screen.getByLabelText(/掲示場所の郵便番号/), {
+      target: { value: "1540017" },
+    });
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("枚数が0の場合はonValidityChangeにfalseが渡される", () => {
+    const onValidityChange = jest.fn();
+
+    render(
+      <ResidentialPosterMissionForm
+        disabled={false}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    // 種別を選択
+    fireEvent.click(screen.getByText("Select Type"));
+
+    // 日付を入力
+    fireEvent.change(screen.getByLabelText(/貼った日付/), {
+      target: { value: "2026-04-16" },
+    });
+
+    // 枚数を0に設定
+    fireEvent.change(screen.getByLabelText(/掲示枚数/), {
+      target: { value: "0" },
+    });
+
+    // 郵便番号を入力
+    fireEvent.change(screen.getByLabelText(/掲示場所の郵便番号/), {
+      target: { value: "1540017" },
+    });
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/features/missions/components/residential-poster-form.test.tsx
+++ b/src/features/missions/components/residential-poster-form.test.tsx
@@ -289,4 +289,35 @@ describe("ResidentialPosterMissionForm", () => {
 
     expect(onValidityChange).toHaveBeenLastCalledWith(false);
   });
+
+  it("郵便番号が不正な桁数の場合はonValidityChangeにfalseが渡される", () => {
+    const onValidityChange = jest.fn();
+
+    render(
+      <ResidentialPosterMissionForm
+        disabled={false}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    // 種別を選択
+    fireEvent.click(screen.getByText("Select Type"));
+
+    // 日付を入力
+    fireEvent.change(screen.getByLabelText(/貼った日付/), {
+      target: { value: "2026-04-16" },
+    });
+
+    // 枚数を入力
+    fireEvent.change(screen.getByLabelText(/掲示枚数/), {
+      target: { value: "3" },
+    });
+
+    // 郵便番号を不正な桁数で入力
+    fireEvent.change(screen.getByLabelText(/掲示場所の郵便番号/), {
+      target: { value: "123" },
+    });
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+  });
 });

--- a/src/features/missions/components/residential-poster-form.tsx
+++ b/src/features/missions/components/residential-poster-form.tsx
@@ -1,78 +1,243 @@
 "use client";
 
+import { AlertCircle } from "lucide-react";
+import { useState } from "react";
+import { SubmitButton } from "@/components/common/submit-button";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  LOCATION_TYPES,
+  type LocationTypeValue,
+} from "@/features/map-poster-residential/constants/location-types";
+import { achieveMissionAction } from "@/features/mission-detail/actions/actions";
+import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
+import type { Tables } from "@/lib/types/supabase";
 
 type ResidentialPosterMissionFormProps = {
-  disabled: boolean;
+  mission: Tables<"missions">;
+  buttonLabel: string;
+  isButtonDisabled: boolean;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  onSubmit: (formData: FormData) => Promise<void>;
+  formRef: React.RefObject<HTMLFormElement | null>;
 };
 
+const POSTAL_CODE_REGEX = /^\d{7}$/;
+
 export function ResidentialPosterMissionForm({
-  disabled,
+  mission,
+  buttonLabel,
+  isButtonDisabled,
+  isSubmitting,
+  errorMessage,
+  onSubmit,
+  formRef,
 }: ResidentialPosterMissionFormProps) {
+  const [locationType, setLocationType] = useState<LocationTypeValue | "">("");
+  const [placedDate, setPlacedDate] = useState("");
+  const [posterCount, setPosterCount] = useState("");
+  const [locationText, setLocationText] = useState("");
+  const [postalCodeTouched, setPostalCodeTouched] = useState(false);
+
+  const disabled = isButtonDisabled || isSubmitting;
+
+  const isPostalCodeValid =
+    locationText.length > 0 && POSTAL_CODE_REGEX.test(locationText);
+  const showPostalCodeError =
+    postalCodeTouched && locationText.length > 0 && !isPostalCodeValid;
+
+  const isFormValid =
+    Number(posterCount) >= 1 &&
+    locationType !== "" &&
+    placedDate !== "" &&
+    isPostalCodeValid;
+
   return (
-    <div className="space-y-4">
-      <div>
-        <p>原則ポスター掲示マップ上での報告をお願いします。</p>
-        <p>
-          ポスター掲示マップ上で報告をすることで、自動的にミッションクリアとなります。
-        </p>
-        <Button
-          type="button"
-          size={"lg"}
-          className="w-full my-4"
-          disabled={disabled}
-          onClick={() =>
-            window.open(
-              "/map/poster-residential",
-              "_blank",
-              "noopener,noreferrer",
-            )
-          }
-        >
-          私有地ポスターマップを開く
-        </Button>
+    <form ref={formRef} action={onSubmit} className="flex flex-col gap-4">
+      <input type="hidden" name="missionId" value={mission.id} />
+      <input
+        type="hidden"
+        name="requiredArtifactType"
+        value={ARTIFACT_TYPES.RESIDENTIAL_POSTER.key}
+      />
+      {/* hidden input for Select value (Radix Select doesn't natively submit via FormData) */}
+      <input type="hidden" name="locationType" value={locationType} />
 
-        <Separator className="my-4" />
-        <p>
-          ポスター掲示マップで報告できない場合は以下のフォームに入力してください。
-        </p>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg text-center">
+            ミッション完了を記録しよう
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            ミッションを完了したら、達成を記録しましょう！
+          </p>
+          <p className="text-sm text-muted-foreground">
+            ※ 入力した内容は、外部に公開されることはありません。
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-4">
+            <div>
+              <p>原則ポスター掲示マップ上での報告をお願いします。</p>
+              <p>
+                ポスター掲示マップ上で報告をすることで、自動的にミッションクリアとなります。
+              </p>
+              <Button
+                type="button"
+                size={"lg"}
+                className="w-full my-4"
+                disabled={disabled}
+                onClick={() =>
+                  window.open(
+                    "/map/poster-residential",
+                    "_blank",
+                    "noopener,noreferrer",
+                  )
+                }
+              >
+                私有地ポスターマップを開く
+              </Button>
 
-      {/* 掲示枚数 */}
-      <div className="space-y-2">
-        <Label htmlFor="residentialPosterCount">
-          掲示枚数 <span className="text-red-500">*</span>
-        </Label>
-        <Input
-          type="number"
-          name="residentialPosterCount"
-          id="residentialPosterCount"
-          min="1"
-          required
-          disabled={disabled}
-          placeholder="例：1"
-        />
-        <p className="text-xs text-gray-500">掲示した枚数を入力してください</p>
-      </div>
+              <Separator className="my-4" />
+              <p>
+                ポスター掲示マップで報告できない場合は以下のフォームに入力してください。
+              </p>
+            </div>
 
-      {/* 郵便番号 */}
-      <div className="space-y-2">
-        <Label htmlFor="locationText">掲示場所の郵便番号（ハイフンなし）</Label>
-        <Input
-          type="text"
-          name="locationText"
-          id="locationText"
-          maxLength={100}
-          disabled={disabled}
-          placeholder="例：1540017"
-        />
-        <p className="text-xs text-gray-500">
-          対象エリアの郵便番号をご入力ください
-        </p>
-      </div>
-    </div>
+            {/* 種別 */}
+            <div className="space-y-2">
+              <Label htmlFor="locationType">
+                種別 <span className="text-red-500">*</span>
+              </Label>
+              <Select
+                value={locationType}
+                onValueChange={(v) =>
+                  setLocationType(v as LocationTypeValue | "")
+                }
+                disabled={disabled}
+              >
+                <SelectTrigger id="locationType">
+                  <SelectValue placeholder="種別を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {LOCATION_TYPES.map((type) => (
+                    <SelectItem key={type.value} value={type.value}>
+                      {type.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* 貼った日付 */}
+            <div className="space-y-2">
+              <Label htmlFor="placedDate">
+                貼った日付 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                type="date"
+                name="placedDate"
+                id="placedDate"
+                value={placedDate}
+                onChange={(e) => setPlacedDate(e.target.value)}
+                disabled={disabled}
+                required
+              />
+            </div>
+
+            {/* 掲示枚数 */}
+            <div className="space-y-2">
+              <Label htmlFor="residentialPosterCount">
+                掲示枚数 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                type="number"
+                name="residentialPosterCount"
+                id="residentialPosterCount"
+                min="1"
+                required
+                disabled={disabled}
+                placeholder="例：1"
+                value={posterCount}
+                onChange={(e) => setPosterCount(e.target.value)}
+              />
+              <p className="text-xs text-gray-500">
+                掲示した枚数を入力してください
+              </p>
+            </div>
+
+            {/* 郵便番号 */}
+            <div className="space-y-2">
+              <Label htmlFor="locationText">
+                掲示場所の郵便番号（ハイフンなし）{" "}
+                <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                type="text"
+                name="locationText"
+                id="locationText"
+                maxLength={7}
+                disabled={disabled}
+                placeholder="例：1540017"
+                value={locationText}
+                onChange={(e) => setLocationText(e.target.value)}
+                onBlur={() => setPostalCodeTouched(true)}
+              />
+              {showPostalCodeError ? (
+                <p className="text-xs text-red-600">
+                  郵便番号はハイフンなし7桁で入力をお願いします
+                </p>
+              ) : (
+                <p className="text-xs text-gray-500">
+                  対象エリアの郵便番号をご入力ください
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* 補足説明テキストエリア */}
+          <div className="space-y-2">
+            <Label htmlFor="artifactDescription">補足説明 (任意)</Label>
+            <Textarea
+              name="artifactDescription"
+              id="artifactDescription"
+              placeholder="達成内容に関して補足説明があれば入力してください"
+              rows={3}
+              disabled={disabled}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <SubmitButton
+        pendingText="登録中..."
+        size="lg"
+        disabled={isButtonDisabled || isSubmitting || !isFormValid}
+      >
+        {buttonLabel}
+      </SubmitButton>
+      <p className="text-sm text-muted-foreground">
+        ※
+        成果物の内容が認められない場合、ミッションの達成が取り消される場合があります。正確な内容をご記入ください。
+      </p>
+      {errorMessage && (
+        <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg flex items-center">
+          <AlertCircle className="h-4 w-4 mr-2 shrink-0" />
+          {errorMessage}
+        </div>
+      )}
+    </form>
   );
 }

--- a/src/features/missions/components/residential-poster-form.tsx
+++ b/src/features/missions/components/residential-poster-form.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { AlertCircle } from "lucide-react";
-import { useState } from "react";
-import { SubmitButton } from "@/components/common/submit-button";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -15,43 +12,27 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import { Textarea } from "@/components/ui/textarea";
 import {
   LOCATION_TYPES,
   type LocationTypeValue,
 } from "@/features/map-poster-residential/constants/location-types";
-import { achieveMissionAction } from "@/features/mission-detail/actions/actions";
-import { ARTIFACT_TYPES } from "@/lib/types/artifact-types";
-import type { Tables } from "@/lib/types/supabase";
 
 type ResidentialPosterMissionFormProps = {
-  mission: Tables<"missions">;
-  buttonLabel: string;
-  isButtonDisabled: boolean;
-  isSubmitting: boolean;
-  errorMessage: string | null;
-  onSubmit: (formData: FormData) => Promise<void>;
-  formRef: React.RefObject<HTMLFormElement | null>;
+  disabled: boolean;
+  onValidityChange?: (isValid: boolean) => void;
 };
 
 const POSTAL_CODE_REGEX = /^\d{7}$/;
 
 export function ResidentialPosterMissionForm({
-  mission,
-  buttonLabel,
-  isButtonDisabled,
-  isSubmitting,
-  errorMessage,
-  onSubmit,
-  formRef,
+  disabled,
+  onValidityChange,
 }: ResidentialPosterMissionFormProps) {
   const [locationType, setLocationType] = useState<LocationTypeValue | "">("");
   const [placedDate, setPlacedDate] = useState("");
   const [posterCount, setPosterCount] = useState("");
   const [locationText, setLocationText] = useState("");
   const [postalCodeTouched, setPostalCodeTouched] = useState(false);
-
-  const disabled = isButtonDisabled || isSubmitting;
 
   const isPostalCodeValid =
     locationText.length > 0 && POSTAL_CODE_REGEX.test(locationText);
@@ -64,180 +45,127 @@ export function ResidentialPosterMissionForm({
     placedDate !== "" &&
     isPostalCodeValid;
 
+  useEffect(() => {
+    onValidityChange?.(isFormValid);
+  }, [isFormValid, onValidityChange]);
+
   return (
-    <form ref={formRef} action={onSubmit} className="flex flex-col gap-4">
-      <input type="hidden" name="missionId" value={mission.id} />
-      <input
-        type="hidden"
-        name="requiredArtifactType"
-        value={ARTIFACT_TYPES.RESIDENTIAL_POSTER.key}
-      />
+    <div className="space-y-4">
+      <div>
+        <p>原則ポスター掲示マップ上での報告をお願いします。</p>
+        <p>
+          ポスター掲示マップ上で報告をすることで、自動的にミッションクリアとなります。
+        </p>
+        <Button
+          type="button"
+          size={"lg"}
+          className="w-full my-4"
+          disabled={disabled}
+          onClick={() =>
+            window.open(
+              "/map/poster-residential",
+              "_blank",
+              "noopener,noreferrer",
+            )
+          }
+        >
+          私有地ポスターマップを開く
+        </Button>
+
+        <Separator className="my-4" />
+        <p>
+          ポスター掲示マップで報告できない場合は以下のフォームに入力してください。
+        </p>
+      </div>
+
       {/* hidden input for Select value (Radix Select doesn't natively submit via FormData) */}
       <input type="hidden" name="locationType" value={locationType} />
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg text-center">
-            ミッション完了を記録しよう
-          </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            ミッションを完了したら、達成を記録しましょう！
+      {/* 種別 */}
+      <div className="space-y-2">
+        <Label htmlFor="locationType">
+          種別 <span className="text-red-500">*</span>
+        </Label>
+        <Select
+          value={locationType}
+          onValueChange={(v) => setLocationType(v as LocationTypeValue | "")}
+          disabled={disabled}
+        >
+          <SelectTrigger id="locationType">
+            <SelectValue placeholder="種別を選択" />
+          </SelectTrigger>
+          <SelectContent>
+            {LOCATION_TYPES.map((type) => (
+              <SelectItem key={type.value} value={type.value}>
+                {type.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* 貼った日付 */}
+      <div className="space-y-2">
+        <Label htmlFor="placedDate">
+          貼った日付 <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          type="date"
+          name="placedDate"
+          id="placedDate"
+          value={placedDate}
+          onChange={(e) => setPlacedDate(e.target.value)}
+          disabled={disabled}
+          required
+        />
+      </div>
+
+      {/* 掲示枚数 */}
+      <div className="space-y-2">
+        <Label htmlFor="residentialPosterCount">
+          掲示枚数 <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          type="number"
+          name="residentialPosterCount"
+          id="residentialPosterCount"
+          min="1"
+          required
+          disabled={disabled}
+          placeholder="例：1"
+          value={posterCount}
+          onChange={(e) => setPosterCount(e.target.value)}
+        />
+        <p className="text-xs text-gray-500">掲示した枚数を入力してください</p>
+      </div>
+
+      {/* 郵便番号 */}
+      <div className="space-y-2">
+        <Label htmlFor="locationText">
+          掲示場所の郵便番号（ハイフンなし）{" "}
+          <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          type="text"
+          name="locationText"
+          id="locationText"
+          maxLength={7}
+          disabled={disabled}
+          placeholder="例：1540017"
+          value={locationText}
+          onChange={(e) => setLocationText(e.target.value)}
+          onBlur={() => setPostalCodeTouched(true)}
+        />
+        {showPostalCodeError ? (
+          <p className="text-xs text-red-600">
+            郵便番号はハイフンなし7桁で入力をお願いします
           </p>
-          <p className="text-sm text-muted-foreground">
-            ※ 入力した内容は、外部に公開されることはありません。
+        ) : (
+          <p className="text-xs text-gray-500">
+            対象エリアの郵便番号をご入力ください
           </p>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="space-y-4">
-            <div>
-              <p>原則ポスター掲示マップ上での報告をお願いします。</p>
-              <p>
-                ポスター掲示マップ上で報告をすることで、自動的にミッションクリアとなります。
-              </p>
-              <Button
-                type="button"
-                size={"lg"}
-                className="w-full my-4"
-                disabled={disabled}
-                onClick={() =>
-                  window.open(
-                    "/map/poster-residential",
-                    "_blank",
-                    "noopener,noreferrer",
-                  )
-                }
-              >
-                私有地ポスターマップを開く
-              </Button>
-
-              <Separator className="my-4" />
-              <p>
-                ポスター掲示マップで報告できない場合は以下のフォームに入力してください。
-              </p>
-            </div>
-
-            {/* 種別 */}
-            <div className="space-y-2">
-              <Label htmlFor="locationType">
-                種別 <span className="text-red-500">*</span>
-              </Label>
-              <Select
-                value={locationType}
-                onValueChange={(v) =>
-                  setLocationType(v as LocationTypeValue | "")
-                }
-                disabled={disabled}
-              >
-                <SelectTrigger id="locationType">
-                  <SelectValue placeholder="種別を選択" />
-                </SelectTrigger>
-                <SelectContent>
-                  {LOCATION_TYPES.map((type) => (
-                    <SelectItem key={type.value} value={type.value}>
-                      {type.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {/* 貼った日付 */}
-            <div className="space-y-2">
-              <Label htmlFor="placedDate">
-                貼った日付 <span className="text-red-500">*</span>
-              </Label>
-              <Input
-                type="date"
-                name="placedDate"
-                id="placedDate"
-                value={placedDate}
-                onChange={(e) => setPlacedDate(e.target.value)}
-                disabled={disabled}
-                required
-              />
-            </div>
-
-            {/* 掲示枚数 */}
-            <div className="space-y-2">
-              <Label htmlFor="residentialPosterCount">
-                掲示枚数 <span className="text-red-500">*</span>
-              </Label>
-              <Input
-                type="number"
-                name="residentialPosterCount"
-                id="residentialPosterCount"
-                min="1"
-                required
-                disabled={disabled}
-                placeholder="例：1"
-                value={posterCount}
-                onChange={(e) => setPosterCount(e.target.value)}
-              />
-              <p className="text-xs text-gray-500">
-                掲示した枚数を入力してください
-              </p>
-            </div>
-
-            {/* 郵便番号 */}
-            <div className="space-y-2">
-              <Label htmlFor="locationText">
-                掲示場所の郵便番号（ハイフンなし）{" "}
-                <span className="text-red-500">*</span>
-              </Label>
-              <Input
-                type="text"
-                name="locationText"
-                id="locationText"
-                maxLength={7}
-                disabled={disabled}
-                placeholder="例：1540017"
-                value={locationText}
-                onChange={(e) => setLocationText(e.target.value)}
-                onBlur={() => setPostalCodeTouched(true)}
-              />
-              {showPostalCodeError ? (
-                <p className="text-xs text-red-600">
-                  郵便番号はハイフンなし7桁で入力をお願いします
-                </p>
-              ) : (
-                <p className="text-xs text-gray-500">
-                  対象エリアの郵便番号をご入力ください
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* 補足説明テキストエリア */}
-          <div className="space-y-2">
-            <Label htmlFor="artifactDescription">補足説明 (任意)</Label>
-            <Textarea
-              name="artifactDescription"
-              id="artifactDescription"
-              placeholder="達成内容に関して補足説明があれば入力してください"
-              rows={3}
-              disabled={disabled}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      <SubmitButton
-        pendingText="登録中..."
-        size="lg"
-        disabled={isButtonDisabled || isSubmitting || !isFormValid}
-      >
-        {buttonLabel}
-      </SubmitButton>
-      <p className="text-sm text-muted-foreground">
-        ※
-        成果物の内容が認められない場合、ミッションの達成が取り消される場合があります。正確な内容をご記入ください。
-      </p>
-      {errorMessage && (
-        <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg flex items-center">
-          <AlertCircle className="h-4 w-4 mr-2 shrink-0" />
-          {errorMessage}
-        </div>
-      )}
-    </form>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/features/missions/components/residential-poster-form.tsx
+++ b/src/features/missions/components/residential-poster-form.tsx
@@ -113,6 +113,7 @@ export function ResidentialPosterMissionForm({
           type="date"
           name="placedDate"
           id="placedDate"
+          max={new Date().toISOString().split("T")[0]}
           value={placedDate}
           onChange={(e) => setPlacedDate(e.target.value)}
           disabled={disabled}

--- a/src/features/tiktok-stats/utils/format.test.ts
+++ b/src/features/tiktok-stats/utils/format.test.ts
@@ -1,0 +1,15 @@
+import { formatNumberJa, formatNumberJaShort } from "./format";
+
+describe("tiktok-stats/utils/format re-exports", () => {
+  it("formatNumberJaがformat-number-jaから正しく再エクスポートされている", () => {
+    expect(typeof formatNumberJa).toBe("function");
+    expect(formatNumberJa(10000)).toBe("1万");
+    expect(formatNumberJa(null)).toBe("-");
+  });
+
+  it("formatNumberJaShortがformat-number-jaから正しく再エクスポートされている", () => {
+    expect(typeof formatNumberJaShort).toBe("function");
+    expect(formatNumberJaShort(10000)).toBe("1万");
+    expect(formatNumberJaShort(15000)).toBe("2万");
+  });
+});

--- a/src/lib/services/contributors.test.ts
+++ b/src/lib/services/contributors.test.ts
@@ -1,0 +1,100 @@
+import { createAdminClient } from "@/lib/supabase/adminClient";
+import { getContributorNames } from "./contributors";
+
+jest.mock("@/lib/supabase/adminClient", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+describe("getContributorNames", () => {
+  const mockRange = jest.fn();
+  const mockOrder = jest.fn(() => ({ range: mockRange }));
+  const mockSelect = jest.fn(() => ({ order: mockOrder }));
+  const mockFrom = jest.fn(() => ({ select: mockSelect }));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createAdminClient as jest.Mock).mockResolvedValue({ from: mockFrom });
+  });
+
+  it("1ページ（1000件未満）のデータをそのまま返す", async () => {
+    mockRange.mockResolvedValueOnce({
+      data: [{ name: "Alice" }, { name: "Bob" }],
+      error: null,
+    });
+
+    const result = await getContributorNames();
+
+    expect(result).toEqual([{ name: "Alice" }, { name: "Bob" }]);
+    expect(mockFrom).toHaveBeenCalledWith("user_ranking_view");
+    expect(mockSelect).toHaveBeenCalledWith("name");
+    expect(mockOrder).toHaveBeenCalledWith("rank", { ascending: true });
+    expect(mockRange).toHaveBeenCalledTimes(1);
+    expect(mockRange).toHaveBeenCalledWith(0, 999);
+  });
+
+  it("nameがnullの行は'Unknown'に置換する", async () => {
+    mockRange.mockResolvedValueOnce({
+      data: [{ name: null }, { name: "Bob" }],
+      error: null,
+    });
+
+    const result = await getContributorNames();
+
+    expect(result).toEqual([{ name: "Unknown" }, { name: "Bob" }]);
+  });
+
+  it("1000件ちょうどの場合は次ページを取得する", async () => {
+    const firstPage = Array.from({ length: 1000 }, (_, i) => ({
+      name: `user${i}`,
+    }));
+    const secondPage = [{ name: "last" }];
+
+    mockRange
+      .mockResolvedValueOnce({ data: firstPage, error: null })
+      .mockResolvedValueOnce({ data: secondPage, error: null });
+
+    const result = await getContributorNames();
+
+    expect(result).toHaveLength(1001);
+    expect(result[1000]).toEqual({ name: "last" });
+    expect(mockRange).toHaveBeenNthCalledWith(1, 0, 999);
+    expect(mockRange).toHaveBeenNthCalledWith(2, 1000, 1999);
+  });
+
+  it("空配列が返ればループを抜ける", async () => {
+    mockRange.mockResolvedValueOnce({ data: [], error: null });
+
+    const result = await getContributorNames();
+
+    expect(result).toEqual([]);
+    expect(mockRange).toHaveBeenCalledTimes(1);
+  });
+
+  it("2ページ目が空なら1ページ目だけ返す", async () => {
+    const firstPage = Array.from({ length: 1000 }, (_, i) => ({
+      name: `u${i}`,
+    }));
+    mockRange
+      .mockResolvedValueOnce({ data: firstPage, error: null })
+      .mockResolvedValueOnce({ data: [], error: null });
+
+    const result = await getContributorNames();
+
+    expect(result).toHaveLength(1000);
+    expect(mockRange).toHaveBeenCalledTimes(2);
+  });
+
+  it("エラー時は例外を投げる", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockRange.mockResolvedValueOnce({
+      data: null,
+      error: { message: "db error" },
+    });
+
+    await expect(getContributorNames()).rejects.toThrow(
+      "貢献者一覧の取得に失敗しました",
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/lib/services/mail.test.ts
+++ b/src/lib/services/mail.test.ts
@@ -1,0 +1,117 @@
+// Mock mailgun.js before importing the service
+const mockCreate = jest.fn();
+const mockClient = jest.fn(() => ({
+  messages: { create: mockCreate },
+}));
+const mockMailgunConstructor = jest.fn().mockImplementation(() => ({
+  client: mockClient,
+}));
+
+jest.mock("mailgun.js", () => ({
+  __esModule: true,
+  default: mockMailgunConstructor,
+}));
+
+// Mock fs for welcome mail
+jest.mock("node:fs/promises", () => ({
+  __esModule: true,
+  default: { readFile: jest.fn() },
+  readFile: jest.fn(),
+}));
+
+// Required env vars (checked at module load)
+process.env.MAILGUN_API_KEY = "test-api-key";
+process.env.MAILGUN_DOMAIN = "example.com";
+
+import fs from "node:fs/promises";
+
+describe("mail service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("sendMail", () => {
+    it("mailgun.messages.createを正しい引数で呼ぶ", async () => {
+      mockCreate.mockResolvedValue({ id: "msg-1" });
+      const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+      const { sendMail } = require("./mail");
+      await sendMail({
+        to: "user@example.com",
+        subject: "Hello",
+        html: "<p>Hi</p>",
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith("example.com", {
+        from: '"チームみらい" <noreply@example.com>',
+        to: "user@example.com",
+        subject: "Hello",
+        html: "<p>Hi</p>",
+      });
+      expect(logSpy).toHaveBeenCalledWith("Mailgun response:", { id: "msg-1" });
+
+      logSpy.mockRestore();
+    });
+
+    it("送信失敗時はエラーをログして再スローする", async () => {
+      const err = new Error("network");
+      mockCreate.mockRejectedValue(err);
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const { sendMail } = require("./mail");
+
+      await expect(
+        sendMail({
+          to: "user@example.com",
+          subject: "x",
+          html: "y",
+        }),
+      ).rejects.toThrow("network");
+
+      expect(errSpy).toHaveBeenCalledWith("Mailgun error:", err);
+      errSpy.mockRestore();
+    });
+  });
+
+  describe("sendWelcomeMail", () => {
+    it("テンプレートを読み込んでウェルカムメールを送信する", async () => {
+      (fs.readFile as jest.Mock).mockResolvedValue("<html>welcome</html>");
+      mockCreate.mockResolvedValue({ id: "msg-welcome" });
+      const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+      const { sendWelcomeMail } = require("./mail");
+      await sendWelcomeMail("new@example.com");
+
+      expect(fs.readFile).toHaveBeenCalledWith(
+        expect.stringContaining("public/welcome.html"),
+        "utf8",
+      );
+      expect(mockCreate).toHaveBeenCalledWith(
+        "example.com",
+        expect.objectContaining({
+          to: "new@example.com",
+          subject:
+            "「チームみらい」アクションボードに登録いただきありがとうございます",
+          html: "<html>welcome</html>",
+        }),
+      );
+
+      logSpy.mockRestore();
+    });
+
+    it("テンプレート読み込み失敗時はエラーを投げる", async () => {
+      (fs.readFile as jest.Mock).mockRejectedValue(new Error("ENOENT"));
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const { sendWelcomeMail } = require("./mail");
+
+      await expect(sendWelcomeMail("new@example.com")).rejects.toThrow(
+        "メールテンプレートが見つかりません",
+      );
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(errSpy).toHaveBeenCalled();
+
+      errSpy.mockRestore();
+    });
+  });
+});

--- a/src/lib/services/reverse-geocoding.test.ts
+++ b/src/lib/services/reverse-geocoding.test.ts
@@ -1,0 +1,116 @@
+import { reverseGeocode } from "./reverse-geocoding";
+
+describe("reverseGeocode", () => {
+  const emptyResult = {
+    prefecture: null,
+    city: null,
+    address: null,
+    postcode: null,
+  };
+
+  let fetchMock: jest.Mock;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("Nominatim APIを正しいクエリで呼び出す", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ address: {} }),
+    });
+
+    await reverseGeocode(35.681, 139.767);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe(
+      "https://nominatim.openstreetmap.org/reverse",
+    );
+    expect(parsed.searchParams.get("lat")).toBe("35.681");
+    expect(parsed.searchParams.get("lon")).toBe("139.767");
+    expect(parsed.searchParams.get("format")).toBe("json");
+    expect(parsed.searchParams.get("addressdetails")).toBe("1");
+    expect(parsed.searchParams.get("accept-language")).toBe("ja");
+    expect(init.headers["User-Agent"]).toBe("ActionBoard/1.0");
+  });
+
+  it("正常レスポンスを住所情報に変換する", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        address: {
+          "ISO3166-2-lvl4": "JP-13",
+          city: "千代田区",
+          road: "内堀通り",
+          house_number: "1-1",
+          postcode: "100-0001",
+        },
+      }),
+    });
+
+    const result = await reverseGeocode(35.681, 139.767);
+
+    expect(result).toEqual({
+      prefecture: "東京都",
+      city: "千代田区",
+      address: "内堀通り1-1",
+      postcode: "100-0001",
+    });
+  });
+
+  it("HTTPエラー時は空の結果を返す", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    const result = await reverseGeocode(0, 0);
+
+    expect(result).toEqual(emptyResult);
+    expect(errorSpy).toHaveBeenCalledWith("Nominatim API error: 500");
+  });
+
+  it("レスポンスボディにerrorが含まれる場合は空の結果を返す", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ error: "Unable to geocode" }),
+    });
+
+    const result = await reverseGeocode(0, 0);
+
+    expect(result).toEqual(emptyResult);
+    expect(errorSpy).toHaveBeenCalledWith("Nominatim error: Unable to geocode");
+  });
+
+  it("addressが含まれない場合は空の結果を返す", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const result = await reverseGeocode(35.0, 135.0);
+
+    expect(result).toEqual(emptyResult);
+  });
+
+  it("fetch自体が例外を投げた場合は空の結果を返す", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const result = await reverseGeocode(0, 0);
+
+    expect(result).toEqual(emptyResult);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Reverse geocoding failed:",
+      expect.any(Error),
+    );
+  });
+});

--- a/src/lib/utils/logger.test.ts
+++ b/src/lib/utils/logger.test.ts
@@ -1,0 +1,94 @@
+describe("logger", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let logSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    jest.resetModules();
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value: originalNodeEnv,
+      configurable: true,
+    });
+  });
+
+  describe("開発環境", () => {
+    beforeEach(() => {
+      jest.resetModules();
+      Object.defineProperty(process.env, "NODE_ENV", {
+        value: "development",
+        configurable: true,
+      });
+    });
+
+    it("debugはコンソールに[DEBUG]プレフィックス付きで出力する", () => {
+      const { logger } = require("./logger");
+      logger.debug("hello", 42);
+      expect(logSpy).toHaveBeenCalledWith("[DEBUG]", "hello", 42);
+    });
+
+    it("infoはコンソールに[INFO]プレフィックス付きで出力する", () => {
+      const { logger } = require("./logger");
+      logger.info("msg", { a: 1 });
+      expect(infoSpy).toHaveBeenCalledWith("[INFO]", "msg", { a: 1 });
+    });
+
+    it("warnはコンソールに[WARN]プレフィックス付きで出力する", () => {
+      const { logger } = require("./logger");
+      logger.warn("warning");
+      expect(warnSpy).toHaveBeenCalledWith("[WARN]", "warning");
+    });
+
+    it("errorはコンソールに[ERROR]プレフィックス付きで出力する", () => {
+      const { logger } = require("./logger");
+      logger.error("oops");
+      expect(errorSpy).toHaveBeenCalledWith("[ERROR]", "oops");
+    });
+  });
+
+  describe("本番環境", () => {
+    beforeEach(() => {
+      jest.resetModules();
+      Object.defineProperty(process.env, "NODE_ENV", {
+        value: "production",
+        configurable: true,
+      });
+    });
+
+    it("debugは出力しない", () => {
+      const { logger } = require("./logger");
+      logger.debug("suppressed");
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it("infoは出力しない", () => {
+      const { logger } = require("./logger");
+      logger.info("suppressed");
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+
+    it("warnは本番でも出力する", () => {
+      const { logger } = require("./logger");
+      logger.warn("prod warning");
+      expect(warnSpy).toHaveBeenCalledWith("[WARN]", "prod warning");
+    });
+
+    it("errorは本番でも出力する", () => {
+      const { logger } = require("./logger");
+      logger.error("prod error");
+      expect(errorSpy).toHaveBeenCalledWith("[ERROR]", "prod error");
+    });
+  });
+});

--- a/src/lib/utils/server-cookies.test.ts
+++ b/src/lib/utils/server-cookies.test.ts
@@ -1,0 +1,107 @@
+import { cookies } from "next/headers";
+import { deleteCookie, getCookie, setCookie } from "./server-cookies";
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+const mockCookiesFn = cookies as jest.MockedFunction<typeof cookies>;
+
+describe("server-cookies", () => {
+  const mockSet = jest.fn();
+  const mockGet = jest.fn();
+  const mockDelete = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockCookiesFn.mockResolvedValue({
+      set: mockSet,
+      get: mockGet,
+      delete: mockDelete,
+    } as any);
+  });
+
+  describe("setCookie", () => {
+    it("デフォルトオプションでCookieを設定する", async () => {
+      await setCookie("token", "abc123");
+
+      expect(mockSet).toHaveBeenCalledWith("token", "abc123", {
+        maxAge: 60 * 60 * 24 * 30,
+        path: "/",
+        domain: undefined,
+        secure: undefined,
+        httpOnly: false,
+        sameSite: "lax",
+      });
+    });
+
+    it("カスタムオプションを上書き反映する", async () => {
+      await setCookie("session", "xyz", {
+        maxAge: 3600,
+        path: "/admin",
+        domain: "example.com",
+        secure: true,
+        httpOnly: true,
+        sameSite: "strict",
+      });
+
+      expect(mockSet).toHaveBeenCalledWith("session", "xyz", {
+        maxAge: 3600,
+        path: "/admin",
+        domain: "example.com",
+        secure: true,
+        httpOnly: true,
+        sameSite: "strict",
+      });
+    });
+
+    it("maxAgeが0でも未指定時と同様にデフォルト値が使われる", async () => {
+      // 実装上 `options?.maxAge || default` なので0はfalsyとして扱われデフォルトに戻る
+      await setCookie("k", "v", { maxAge: 0 });
+
+      expect(mockSet).toHaveBeenCalledWith(
+        "k",
+        "v",
+        expect.objectContaining({ maxAge: 60 * 60 * 24 * 30 }),
+      );
+    });
+  });
+
+  describe("getCookie", () => {
+    it("存在するCookieの値を返す", async () => {
+      mockGet.mockReturnValue({ value: "hello" });
+
+      await expect(getCookie("greeting")).resolves.toBe("hello");
+      expect(mockGet).toHaveBeenCalledWith("greeting");
+    });
+
+    it("存在しないCookieはundefinedを返す", async () => {
+      mockGet.mockReturnValue(undefined);
+
+      await expect(getCookie("missing")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("deleteCookie", () => {
+    it("デフォルトオプションで削除する", async () => {
+      await deleteCookie("token");
+
+      expect(mockDelete).toHaveBeenCalledWith({
+        name: "token",
+        path: "/",
+        domain: undefined,
+      });
+    });
+
+    it("カスタムpath/domainを指定して削除できる", async () => {
+      await deleteCookie("token", { path: "/admin", domain: "example.com" });
+
+      expect(mockDelete).toHaveBeenCalledWith({
+        name: "token",
+        path: "/admin",
+        domain: "example.com",
+      });
+    });
+  });
+});

--- a/supabase/migrations/20260416070000_add_residential_poster_artifact_type.sql
+++ b/supabase/migrations/20260416070000_add_residential_poster_artifact_type.sql
@@ -1,0 +1,104 @@
+-- mission_artifactsのartifact_type制約にRESIDENTIAL_POSTERを追加
+
+-- ==============================================
+-- Part 1: check_artifact_type制約にRESIDENTIAL_POSTERを追加
+-- ==============================================
+
+ALTER TABLE mission_artifacts
+DROP CONSTRAINT IF EXISTS check_artifact_type;
+
+ALTER TABLE mission_artifacts
+ADD CONSTRAINT check_artifact_type
+CHECK (artifact_type IN ('LINK', 'TEXT', 'EMAIL', 'IMAGE', 'IMAGE_WITH_GEOLOCATION', 'REFERRAL', 'POSTING', 'POSTER', 'QUIZ', 'LINK_ACCESS', 'YOUTUBE', 'YOUTUBE_COMMENT', 'RESIDENTIAL_POSTER'));
+
+-- ==============================================
+-- Part 2: ensure_artifact_data制約にRESIDENTIAL_POSTERを追加
+-- RESIDENTIAL_POSTERはPOSTERと同じパターン（text_contentに掲示情報を保存）
+-- ==============================================
+
+ALTER TABLE mission_artifacts
+DROP CONSTRAINT IF EXISTS ensure_artifact_data;
+
+ALTER TABLE mission_artifacts
+ADD CONSTRAINT ensure_artifact_data CHECK (
+  (
+    (
+      (artifact_type = 'LINK'::text)
+      AND (link_url IS NOT NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'TEXT'::text)
+      AND (text_content IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+    )
+    OR (
+      (artifact_type = 'EMAIL'::text)
+      AND (text_content IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+    )
+    OR (
+      (artifact_type = 'IMAGE'::text)
+      AND (image_storage_path IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'IMAGE_WITH_GEOLOCATION'::text)
+      AND (image_storage_path IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'REFERRAL'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NOT NULL)
+    )
+    OR (
+      (artifact_type = 'POSTING'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NOT NULL)
+    )
+    OR (
+      (artifact_type = 'POSTER'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NOT NULL)
+    )
+    OR (
+      (artifact_type = 'QUIZ'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'LINK_ACCESS'::text)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'YOUTUBE'::text)
+      AND (link_url IS NOT NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'YOUTUBE_COMMENT'::text)
+      AND (link_url IS NOT NULL)
+      AND (image_storage_path IS NULL)
+      AND (text_content IS NULL)
+    )
+    OR (
+      (artifact_type = 'RESIDENTIAL_POSTER'::text)
+      AND (text_content IS NOT NULL)
+      AND (link_url IS NULL)
+      AND (image_storage_path IS NULL)
+    )
+  )
+);


### PR DESCRIPTION
## Summary

カバレッジレポートで0%だった共通ユーティリティ・サービスにユニットテストを追加しました。全体のテスト本数は 2007 → 2042（+35 件）に増加しています。

### 対象ファイル（Statements カバレッジ）

| ファイル | Before | After |
|---|---|---|
| `src/lib/utils/logger.ts` | 0% | **100%** |
| `src/lib/utils/server-cookies.ts` | 0% | **100%** |
| `src/lib/services/contributors.ts` | 0% | **100%** |
| `src/lib/services/mail.ts` | 0% | **94%** (残りは起動時の env 未設定チェック) |
| `src/lib/services/reverse-geocoding.ts` | 0% | **100%** |
| `src/features/tiktok-stats/utils/format.ts` | 0% | **100%** |
| `src/features/map-posting/utils/posting-label.ts` | 56% | **100%** (`createPostingLabelIcon` を追加カバー) |

### テスト観点

- `logger`: `NODE_ENV` による出力抑制（dev のみ debug/info、warn/error は常時）
- `server-cookies`: `set/get/delete` のデフォルト/カスタムオプション挙動
- `contributors`: 1000 件ページネーション、`name` が null の場合の `Unknown` 置換、エラー時の例外
- `mail`: `sendMail` の Mailgun 呼び出し引数・エラー伝播、`sendWelcomeMail` のテンプレート読み込み失敗
- `reverse-geocoding`: Nominatim URL 組み立て、正常系、HTTP エラー、レスポンス内 `error`、`fetch` 例外
- `posting-label`: `createPostingLabelIcon` の `divIcon` 引数と幅計算

### 事前チェック

- [x] `pnpm run biome:check:write` — 新規テストに関する指摘なし
- [x] `pnpm run typecheck`
- [x] `pnpm run test:unit` — 2042 / 2042 passing

## Test plan

- [x] CI の unit テストがグリーンであること
- [x] カバレッジレポートで対象ファイルが 94–100% になっていること
