### PR TITLE
feat: 私有地ポスター登録フォームの種別にポスターデザイン種類を追加

### DIFF
--- a/src/features/map-poster-residential/constants/location-types.ts
+++ b/src/features/map-poster-residential/constants/location-types.ts
@@ -2,6 +2,10 @@ export const LOCATION_TYPES = [
   { value: "home", label: "自宅" },
   { value: "store_office", label: "店舗事務所" },
   { value: "public_facility", label: "公共施設" },
+  { value: "leader_photo_a1", label: "党首顔写真（A1サイズ）" },
+  { value: "leader_photo_a2", label: "党首顔写真（A2サイズ）" },
+  { value: "logo_a1", label: "ロゴ（A1サイズ）" },
+  { value: "logo_a2", label: "ロゴ（A2サイズ）" },
   { value: "other", label: "その他" },
 ] as const;
 

--- a/supabase/migrations/20260422040421_extend_residential_location_type_check.sql
+++ b/supabase/migrations/20260422040421_extend_residential_location_type_check.sql
@@ -1,0 +1,20 @@
+-- Extend residential_poster_placements.location_type CHECK constraint to allow
+-- poster design types (leader_photo_a1/a2, logo_a1/a2) in addition to existing
+-- location types (home, store_office, public_facility, other).
+ALTER TABLE residential_poster_placements
+  DROP CONSTRAINT IF EXISTS residential_poster_placements_location_type_check;
+
+ALTER TABLE residential_poster_placements
+  ADD CONSTRAINT residential_poster_placements_location_type_check
+  CHECK (
+    location_type IN (
+      'home',
+      'store_office',
+      'public_facility',
+      'leader_photo_a1',
+      'leader_photo_a2',
+      'logo_a1',
+      'logo_a2',
+      'other'
+    )
+  );


### PR DESCRIPTION
## Summary

私有地ポスターの登録フォーム「種別」ドロップダウンに、ポスターデザイン種別の選択肢を追加しました。何を貼ったかを把握したいという運用上の要望への対応です。

追加した選択肢:
- 党首顔写真（A1サイズ） (`leader_photo_a1`)
- 党首顔写真（A2サイズ） (`leader_photo_a2`)
- ロゴ（A1サイズ） (`logo_a1`)
- ロゴ（A2サイズ） (`logo_a2`)

## 変更内容

- `src/features/map-poster-residential/constants/location-types.ts` に4つの選択肢を追加
- DBカラム `residential_poster_placements.location_type` は `string | null` のため、マイグレーション不要
- `LocationTypeValue` 型は `typeof LOCATION_TYPES` から派生しており、型定義・フォーム・hookに自動伝播

## Test plan

- [x] `pnpm run biome:check:write` 通過
- [x] `pnpm run typecheck` 通過
- [x] `pnpm run test:unit` 通過（1986 tests）
- [ ] 動作確認: ポスター登録フォームで新しい種別が選択でき、保存・編集できること

## 備考

既存の `LOCATION_TYPES` は本来「貼った場所の種別」(自宅/店舗事務所/公共施設/その他) を表す軸でしたが、今回の追加分は「ポスターデザインの種類」という別軸です。運用上は同じ「種別」ドロップダウンに混在しますが、フロント要件に合わせて最小改修としました。将来的にデザイン軸を分離する場合は別カラム化を検討してください。

https://claude.ai/code/session_011WqhN9V43P7jUTzy7zjqgK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
  * 党首顔写真とロゴのA1・A2サイズに対応した新しいロケーションタイプを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->