### PR TITLE
feat: 私有地ポスターに「ポスターの種類」選択項目を追加

### DIFF
--- a/src/features/map-poster-residential/actions/residential-poster-actions.test.ts
+++ b/src/features/map-poster-residential/actions/residential-poster-actions.test.ts
@@ -60,6 +60,7 @@ function buildPlacementInput(
     memo: string | null;
     placed_date: string | null;
     location_type: string | null;
+    poster_type: string | null;
     is_removed: boolean;
   }> = {},
 ) {
@@ -71,6 +72,7 @@ function buildPlacementInput(
     memo: null as string | null,
     placed_date: null as string | null,
     location_type: null as string | null,
+    poster_type: null as string | null,
     is_removed: false,
     ...overrides,
   };
@@ -84,6 +86,7 @@ function buildUpdateInput(
     memo: string | null;
     placed_date: string | null;
     location_type: string | null;
+    poster_type: string | null;
     is_removed: boolean;
   }> = {},
 ) {
@@ -93,6 +96,7 @@ function buildUpdateInput(
     memo: null as string | null,
     placed_date: null as string | null,
     location_type: null as string | null,
+    poster_type: null as string | null,
     is_removed: false,
     ...overrides,
   };
@@ -139,6 +143,7 @@ describe("submitPosterPlacement", () => {
         memo: "テスト",
         placed_date: null,
         location_type: null,
+        poster_type: null,
         is_removed: false,
       }),
     );
@@ -154,6 +159,7 @@ describe("submitPosterPlacement", () => {
         lng: 139.6503,
         placed_date: "2026-04-10",
         location_type: "home",
+        poster_type: "leader_face_a1",
         is_removed: true,
       }),
     );
@@ -163,6 +169,7 @@ describe("submitPosterPlacement", () => {
       expect.objectContaining({
         placed_date: "2026-04-10",
         location_type: "home",
+        poster_type: "leader_face_a1",
         is_removed: true,
       }),
     );
@@ -260,6 +267,7 @@ describe("updatePosterPlacement", () => {
         memo: "メモ更新",
         placed_date: "2026-04-10",
         location_type: "store_office",
+        poster_type: "logo_a2",
       }),
     );
 
@@ -272,6 +280,7 @@ describe("updatePosterPlacement", () => {
         memo: "メモ更新",
         placed_date: "2026-04-10",
         location_type: "store_office",
+        poster_type: "logo_a2",
         is_removed: false,
       },
     );

--- a/src/features/map-poster-residential/actions/residential-poster-actions.test.ts
+++ b/src/features/map-poster-residential/actions/residential-poster-actions.test.ts
@@ -72,7 +72,7 @@ function buildPlacementInput(
     memo: null as string | null,
     placed_date: null as string | null,
     location_type: null as string | null,
-    poster_type: null as string | null,
+    poster_type: "leader_face_a1" as string | null,
     is_removed: false,
     ...overrides,
   };
@@ -96,7 +96,7 @@ function buildUpdateInput(
     memo: null as string | null,
     placed_date: null as string | null,
     location_type: null as string | null,
-    poster_type: null as string | null,
+    poster_type: "leader_face_a1" as string | null,
     is_removed: false,
     ...overrides,
   };
@@ -143,7 +143,7 @@ describe("submitPosterPlacement", () => {
         memo: "テスト",
         placed_date: null,
         location_type: null,
-        poster_type: null,
+        poster_type: "leader_face_a1",
         is_removed: false,
       }),
     );
@@ -193,6 +193,30 @@ describe("submitPosterPlacement", () => {
     const result = await submitPosterPlacement(buildPlacementInput());
 
     expect(result).toEqual({ success: false, error: "認証が必要です" });
+  });
+
+  it("poster_typeがnullなら失敗", async () => {
+    const result = await submitPosterPlacement(
+      buildPlacementInput({ poster_type: null }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "ポスターの種類を選択してください",
+    });
+    expect(mockCreatePosterPlacement).not.toHaveBeenCalled();
+  });
+
+  it("poster_typeが許可値以外なら失敗", async () => {
+    const result = await submitPosterPlacement(
+      buildPlacementInput({ poster_type: "unknown_poster" }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "ポスターの種類を選択してください",
+    });
+    expect(mockCreatePosterPlacement).not.toHaveBeenCalled();
   });
 
   it("ミッション達成失敗でもポスター掲示は成功する", async () => {
@@ -284,6 +308,32 @@ describe("updatePosterPlacement", () => {
         is_removed: false,
       },
     );
+  });
+
+  it("poster_typeがnullなら失敗", async () => {
+    const result = await updatePosterPlacement(
+      "placement-1",
+      buildUpdateInput({ poster_type: null }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "ポスターの種類を選択してください",
+    });
+    expect(mockUpdatePosterPlacementFields).not.toHaveBeenCalled();
+  });
+
+  it("poster_typeが許可値以外なら失敗", async () => {
+    const result = await updatePosterPlacement(
+      "placement-1",
+      buildUpdateInput({ poster_type: "unknown_poster" }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "ポスターの種類を選択してください",
+    });
+    expect(mockUpdatePosterPlacementFields).not.toHaveBeenCalled();
   });
 
   it("他ユーザーのレコードは更新できない", async () => {

--- a/src/features/map-poster-residential/actions/residential-poster-actions.test.ts
+++ b/src/features/map-poster-residential/actions/residential-poster-actions.test.ts
@@ -71,7 +71,7 @@ function buildPlacementInput(
     address: null as string | null,
     memo: null as string | null,
     placed_date: null as string | null,
-    location_type: null as string | null,
+    location_type: "home" as string | null,
     poster_type: "leader_face_a1" as string | null,
     is_removed: false,
     ...overrides,
@@ -95,7 +95,7 @@ function buildUpdateInput(
     address: null as string | null,
     memo: null as string | null,
     placed_date: null as string | null,
-    location_type: null as string | null,
+    location_type: "home" as string | null,
     poster_type: "leader_face_a1" as string | null,
     is_removed: false,
     ...overrides,
@@ -142,7 +142,7 @@ describe("submitPosterPlacement", () => {
         count: 2,
         memo: "テスト",
         placed_date: null,
-        location_type: null,
+        location_type: "home",
         poster_type: "leader_face_a1",
         is_removed: false,
       }),
@@ -215,6 +215,30 @@ describe("submitPosterPlacement", () => {
     expect(result).toEqual({
       success: false,
       error: "ポスターの種類を選択してください",
+    });
+    expect(mockCreatePosterPlacement).not.toHaveBeenCalled();
+  });
+
+  it("location_typeがnullなら失敗", async () => {
+    const result = await submitPosterPlacement(
+      buildPlacementInput({ location_type: null }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "種別を選択してください",
+    });
+    expect(mockCreatePosterPlacement).not.toHaveBeenCalled();
+  });
+
+  it("location_typeが許可値以外なら失敗", async () => {
+    const result = await submitPosterPlacement(
+      buildPlacementInput({ location_type: "unknown_location" }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "種別を選択してください",
     });
     expect(mockCreatePosterPlacement).not.toHaveBeenCalled();
   });
@@ -332,6 +356,32 @@ describe("updatePosterPlacement", () => {
     expect(result).toEqual({
       success: false,
       error: "ポスターの種類を選択してください",
+    });
+    expect(mockUpdatePosterPlacementFields).not.toHaveBeenCalled();
+  });
+
+  it("location_typeがnullなら失敗", async () => {
+    const result = await updatePosterPlacement(
+      "placement-1",
+      buildUpdateInput({ location_type: null }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "種別を選択してください",
+    });
+    expect(mockUpdatePosterPlacementFields).not.toHaveBeenCalled();
+  });
+
+  it("location_typeが許可値以外なら失敗", async () => {
+    const result = await updatePosterPlacement(
+      "placement-1",
+      buildUpdateInput({ location_type: "unknown_location" }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "種別を選択してください",
     });
     expect(mockUpdatePosterPlacementFields).not.toHaveBeenCalled();
   });

--- a/src/features/map-poster-residential/actions/residential-poster-actions.ts
+++ b/src/features/map-poster-residential/actions/residential-poster-actions.ts
@@ -4,6 +4,7 @@ import type { User } from "@supabase/supabase-js";
 import { reverseGeocode } from "@/lib/services/reverse-geocoding";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
+import { LOCATION_TYPES } from "../constants/location-types";
 import { POSTER_TYPES } from "../constants/poster-types";
 import {
   createPosterPlacement,
@@ -17,9 +18,16 @@ import { achievePosterPlacementMission } from "../use-cases/achieve-residential-
 const POSTER_TYPE_VALUES = new Set<string>(
   POSTER_TYPES.map((type) => type.value),
 );
+const LOCATION_TYPE_VALUES = new Set<string>(
+  LOCATION_TYPES.map((type) => type.value),
+);
 
 function isValidPosterType(value: string | null): boolean {
   return value !== null && POSTER_TYPE_VALUES.has(value);
+}
+
+function isValidLocationType(value: string | null): boolean {
+  return value !== null && LOCATION_TYPE_VALUES.has(value);
 }
 
 async function requireAuth(): Promise<User> {
@@ -49,6 +57,9 @@ export async function submitPosterPlacement(params: {
     const user = await requireAuth();
     if (!isValidPosterType(params.poster_type)) {
       return { success: false, error: "ポスターの種類を選択してください" };
+    }
+    if (!isValidLocationType(params.location_type)) {
+      return { success: false, error: "種別を選択してください" };
     }
     const geo = await reverseGeocode(params.lat, params.lng);
     // 1. ポスター掲示レコードを作成（既存処理）
@@ -126,6 +137,9 @@ export async function updatePosterPlacement(
     const user = await requireAuth();
     if (!isValidPosterType(params.poster_type)) {
       return { success: false, error: "ポスターの種類を選択してください" };
+    }
+    if (!isValidLocationType(params.location_type)) {
+      return { success: false, error: "種別を選択してください" };
     }
     const record = await getPosterPlacementById(id);
     if (!record) {

--- a/src/features/map-poster-residential/actions/residential-poster-actions.ts
+++ b/src/features/map-poster-residential/actions/residential-poster-actions.ts
@@ -33,6 +33,7 @@ export async function submitPosterPlacement(params: {
   memo: string | null;
   placed_date: string | null;
   location_type: string | null;
+  poster_type: string | null;
   is_removed: boolean;
 }): Promise<{ success: true; id: string } | { success: false; error: string }> {
   try {
@@ -51,6 +52,7 @@ export async function submitPosterPlacement(params: {
       memo: params.memo,
       placed_date: params.placed_date,
       location_type: params.location_type,
+      poster_type: params.poster_type,
       is_removed: params.is_removed,
     });
 
@@ -104,6 +106,7 @@ export async function updatePosterPlacement(
     memo: string | null;
     placed_date: string | null;
     location_type: string | null;
+    poster_type: string | null;
     is_removed: boolean;
   },
 ): Promise<{ success: true } | { success: false; error: string }> {
@@ -122,6 +125,7 @@ export async function updatePosterPlacement(
       memo: params.memo,
       placed_date: params.placed_date,
       location_type: params.location_type,
+      poster_type: params.poster_type,
       is_removed: params.is_removed,
     });
     return { success: true };

--- a/src/features/map-poster-residential/actions/residential-poster-actions.ts
+++ b/src/features/map-poster-residential/actions/residential-poster-actions.ts
@@ -4,6 +4,7 @@ import type { User } from "@supabase/supabase-js";
 import { reverseGeocode } from "@/lib/services/reverse-geocoding";
 import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
+import { POSTER_TYPES } from "../constants/poster-types";
 import {
   createPosterPlacement,
   deletePosterPlacement,
@@ -12,6 +13,14 @@ import {
   updatePosterPlacementFields,
 } from "../services/residential-posters";
 import { achievePosterPlacementMission } from "../use-cases/achieve-residential-poster-mission";
+
+const POSTER_TYPE_VALUES = new Set<string>(
+  POSTER_TYPES.map((type) => type.value),
+);
+
+function isValidPosterType(value: string | null): boolean {
+  return value !== null && POSTER_TYPE_VALUES.has(value);
+}
 
 async function requireAuth(): Promise<User> {
   const supabase = createClient();
@@ -38,6 +47,9 @@ export async function submitPosterPlacement(params: {
 }): Promise<{ success: true; id: string } | { success: false; error: string }> {
   try {
     const user = await requireAuth();
+    if (!isValidPosterType(params.poster_type)) {
+      return { success: false, error: "ポスターの種類を選択してください" };
+    }
     const geo = await reverseGeocode(params.lat, params.lng);
     // 1. ポスター掲示レコードを作成（既存処理）
     const record = await createPosterPlacement({
@@ -112,6 +124,9 @@ export async function updatePosterPlacement(
 ): Promise<{ success: true } | { success: false; error: string }> {
   try {
     const user = await requireAuth();
+    if (!isValidPosterType(params.poster_type)) {
+      return { success: false, error: "ポスターの種類を選択してください" };
+    }
     const record = await getPosterPlacementById(id);
     if (!record) {
       return { success: false, error: "レコードが見つかりません" };

--- a/src/features/map-poster-residential/components/residential-poster-form.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-form.tsx
@@ -17,6 +17,7 @@ import {
   LOCATION_TYPES,
   type LocationTypeValue,
 } from "../constants/location-types";
+import { POSTER_TYPES, type PosterTypeValue } from "../constants/poster-types";
 
 type PlacementFormProps = {
   lat: number;
@@ -29,6 +30,7 @@ type PlacementFormProps = {
   count: number;
   placedDate: string;
   locationType: LocationTypeValue | "";
+  posterType: PosterTypeValue | "";
   isRemoved: boolean;
   confirmedOrdinance: boolean;
   confirmedLandowner: boolean;
@@ -37,6 +39,7 @@ type PlacementFormProps = {
   onCountChange: (value: number) => void;
   onPlacedDateChange: (value: string) => void;
   onLocationTypeChange: (value: LocationTypeValue | "") => void;
+  onPosterTypeChange: (value: PosterTypeValue | "") => void;
   onIsRemovedChange: (value: boolean) => void;
   onConfirmedOrdinanceChange: (value: boolean) => void;
   onConfirmedLandownerChange: (value: boolean) => void;
@@ -56,6 +59,7 @@ export function PlacementForm({
   count,
   placedDate,
   locationType,
+  posterType,
   isRemoved,
   confirmedOrdinance,
   confirmedLandowner,
@@ -64,6 +68,7 @@ export function PlacementForm({
   onCountChange,
   onPlacedDateChange,
   onLocationTypeChange,
+  onPosterTypeChange,
   onIsRemovedChange,
   onConfirmedOrdinanceChange,
   onConfirmedLandownerChange,
@@ -79,7 +84,7 @@ export function PlacementForm({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setAttempted(true);
-    if (!address || !placedDate || !locationType) return;
+    if (!address || !placedDate || !locationType || !posterType) return;
     if (!canSubmit) return;
     onSubmit();
   };
@@ -181,6 +186,33 @@ export function PlacementForm({
             </SelectContent>
           </Select>
           {attempted && !locationType && (
+            <p className="mt-1 text-red-600 text-xs">必須入力欄です</p>
+          )}
+        </div>
+
+        <div className="mb-4">
+          <Label
+            htmlFor="placement-poster-type"
+            className="mb-1 block font-medium text-sm"
+          >
+            ポスターの種類
+          </Label>
+          <Select
+            value={posterType}
+            onValueChange={(v) => onPosterTypeChange(v as PosterTypeValue | "")}
+          >
+            <SelectTrigger id="placement-poster-type">
+              <SelectValue placeholder="ポスターの種類を選択" />
+            </SelectTrigger>
+            <SelectContent>
+              {POSTER_TYPES.map((type) => (
+                <SelectItem key={type.value} value={type.value}>
+                  {type.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {attempted && !posterType && (
             <p className="mt-1 text-red-600 text-xs">必須入力欄です</p>
           )}
         </div>

--- a/src/features/map-poster-residential/components/residential-poster-page-client.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-page-client.tsx
@@ -58,6 +58,7 @@ export default function PosterPlacementPageClient({
     count,
     placedDate,
     locationType,
+    posterType,
     isRemoved,
     confirmedOrdinance,
     confirmedLandowner,
@@ -68,6 +69,7 @@ export default function PosterPlacementPageClient({
     setCount,
     setPlacedDate,
     setLocationType,
+    setPosterType,
     setIsRemoved,
     setConfirmedOrdinance,
     setConfirmedLandowner,
@@ -134,6 +136,7 @@ export default function PosterPlacementPageClient({
             count={count}
             placedDate={placedDate}
             locationType={locationType}
+            posterType={posterType}
             isRemoved={isRemoved}
             confirmedOrdinance={confirmedOrdinance}
             confirmedLandowner={confirmedLandowner}
@@ -142,6 +145,7 @@ export default function PosterPlacementPageClient({
             onCountChange={setCount}
             onPlacedDateChange={setPlacedDate}
             onLocationTypeChange={setLocationType}
+            onPosterTypeChange={setPosterType}
             onIsRemovedChange={setIsRemoved}
             onConfirmedOrdinanceChange={setConfirmedOrdinance}
             onConfirmedLandownerChange={setConfirmedLandowner}

--- a/src/features/map-poster-residential/constants/poster-types.ts
+++ b/src/features/map-poster-residential/constants/poster-types.ts
@@ -1,0 +1,8 @@
+export const POSTER_TYPES = [
+  { value: "leader_face_a1", label: "党首顔写真（A1サイズ）" },
+  { value: "leader_face_a2", label: "党首顔写真（A2サイズ）" },
+  { value: "logo_a1", label: "ロゴ（A1サイズ）" },
+  { value: "logo_a2", label: "ロゴ（A2サイズ）" },
+] as const;
+
+export type PosterTypeValue = (typeof POSTER_TYPES)[number]["value"];

--- a/src/features/map-poster-residential/hooks/use-residential-poster-map.ts
+++ b/src/features/map-poster-residential/hooks/use-residential-poster-map.ts
@@ -8,6 +8,7 @@ import {
   updatePosterPlacement,
 } from "../actions/residential-poster-actions";
 import type { LocationTypeValue } from "../constants/location-types";
+import type { PosterTypeValue } from "../constants/poster-types";
 import { fetchReverseGeocode } from "../loaders/residential-poster-loaders";
 import type { ResidentialPosterPlacement } from "../types/residential-poster-types";
 
@@ -36,6 +37,7 @@ type UsePosterPlacementMapReturn = {
   count: number;
   placedDate: string;
   locationType: LocationTypeValue | "";
+  posterType: PosterTypeValue | "";
   isRemoved: boolean;
   confirmedOrdinance: boolean;
   confirmedLandowner: boolean;
@@ -46,6 +48,7 @@ type UsePosterPlacementMapReturn = {
   setCount: (value: number) => void;
   setPlacedDate: (value: string) => void;
   setLocationType: (value: LocationTypeValue | "") => void;
+  setPosterType: (value: PosterTypeValue | "") => void;
   setIsRemoved: (value: boolean) => void;
   setConfirmedOrdinance: (value: boolean) => void;
   setConfirmedLandowner: (value: boolean) => void;
@@ -73,6 +76,7 @@ export function usePosterPlacementMap(
   const [count, setCount] = useState(1);
   const [placedDate, setPlacedDate] = useState("");
   const [locationType, setLocationType] = useState<LocationTypeValue | "">("");
+  const [posterType, setPosterType] = useState<PosterTypeValue | "">("");
   const [isRemoved, setIsRemoved] = useState(false);
   const [confirmedOrdinance, setConfirmedOrdinance] = useState(false);
   const [confirmedLandowner, setConfirmedLandowner] = useState(false);
@@ -96,6 +100,7 @@ export function usePosterPlacementMap(
     setCount(1);
     setPlacedDate("");
     setLocationType("");
+    setPosterType("");
     setIsRemoved(false);
     setConfirmedOrdinance(false);
     setConfirmedLandowner(false);
@@ -112,6 +117,7 @@ export function usePosterPlacementMap(
     setCount(1);
     setPlacedDate("");
     setLocationType("");
+    setPosterType("");
     setIsRemoved(false);
     setConfirmedOrdinance(false);
     setConfirmedLandowner(false);
@@ -142,6 +148,7 @@ export function usePosterPlacementMap(
       setCount(placement.count);
       setPlacedDate(placement.placed_date ?? "");
       setLocationType((placement.location_type as LocationTypeValue) ?? "");
+      setPosterType((placement.poster_type as PosterTypeValue) ?? "");
       setIsRemoved(placement.is_removed ?? false);
       setConfirmedOrdinance(true);
       setConfirmedLandowner(true);
@@ -162,6 +169,7 @@ export function usePosterPlacementMap(
           memo: memo || null,
           placed_date: placedDate || null,
           location_type: locationType || null,
+          poster_type: posterType || null,
           is_removed: isRemoved,
         });
         if (result.success) {
@@ -185,6 +193,7 @@ export function usePosterPlacementMap(
           memo: memo || null,
           placed_date: placedDate || null,
           location_type: locationType || null,
+          poster_type: posterType || null,
           is_removed: false,
         });
         if (result.success) {
@@ -210,6 +219,7 @@ export function usePosterPlacementMap(
     memo,
     placedDate,
     locationType,
+    posterType,
     isRemoved,
     confirmedOrdinance,
     confirmedLandowner,
@@ -249,6 +259,7 @@ export function usePosterPlacementMap(
     count,
     placedDate,
     locationType,
+    posterType,
     isRemoved,
     confirmedOrdinance,
     confirmedLandowner,
@@ -259,6 +270,7 @@ export function usePosterPlacementMap(
     setCount,
     setPlacedDate,
     setLocationType,
+    setPosterType,
     setIsRemoved,
     setConfirmedOrdinance,
     setConfirmedLandowner,

--- a/src/features/map-poster-residential/services/residential-posters.ts
+++ b/src/features/map-poster-residential/services/residential-posters.ts
@@ -170,6 +170,7 @@ export async function updatePosterPlacementFields(
     | "memo"
     | "placed_date"
     | "location_type"
+    | "poster_type"
     | "is_removed"
   >,
 ): Promise<void> {

--- a/src/features/mission-detail/actions/actions.test.ts
+++ b/src/features/mission-detail/actions/actions.test.ts
@@ -31,6 +31,7 @@ describe("achieveMissionAction — RESIDENTIAL_POSTER バリデーション", ()
       requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
       residentialPosterCount: "3",
       locationType: "",
+      posterType: "leader_face_a1",
       placedDate: "2026-04-16",
       locationText: "1540017",
     });
@@ -43,12 +44,32 @@ describe("achieveMissionAction — RESIDENTIAL_POSTER バリデーション", ()
     }
   });
 
+  it("posterTypeが空なら『ポスターの種類を選択してください』エラーを返す", async () => {
+    const fd = buildFormData({
+      missionId: "mission-1",
+      requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+      residentialPosterCount: "3",
+      locationType: "home",
+      posterType: "",
+      placedDate: "2026-04-16",
+      locationText: "1540017",
+    });
+
+    const result = await achieveMissionAction(fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("ポスターの種類を選択してください");
+    }
+  });
+
   it("placedDateが空なら『日付を入力してください』エラーを返す", async () => {
     const fd = buildFormData({
       missionId: "mission-1",
       requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
       residentialPosterCount: "3",
       locationType: "home",
+      posterType: "leader_face_a1",
       placedDate: "",
       locationText: "1540017",
     });
@@ -67,6 +88,7 @@ describe("achieveMissionAction — RESIDENTIAL_POSTER バリデーション", ()
       requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
       residentialPosterCount: "3",
       locationType: "home",
+      posterType: "leader_face_a1",
       placedDate: "2026-04-16",
       locationText: "",
     });
@@ -85,6 +107,7 @@ describe("achieveMissionAction — RESIDENTIAL_POSTER バリデーション", ()
       requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
       residentialPosterCount: "3",
       locationType: "home",
+      posterType: "leader_face_a1",
       placedDate: "2026-04-16",
       locationText: "154-0017",
     });
@@ -106,6 +129,7 @@ describe("achieveMissionAction — RESIDENTIAL_POSTER バリデーション", ()
       requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
       residentialPosterCount: "3",
       locationType: "home",
+      posterType: "leader_face_a1",
       placedDate: "2026-04-16",
       locationText: "1540017",
     });

--- a/src/features/mission-detail/actions/actions.test.ts
+++ b/src/features/mission-detail/actions/actions.test.ts
@@ -63,6 +63,44 @@ describe("achieveMissionAction — RESIDENTIAL_POSTER バリデーション", ()
     }
   });
 
+  it("posterTypeが許可値以外なら『有効なポスターの種類を選択してください』エラーを返す", async () => {
+    const fd = buildFormData({
+      missionId: "mission-1",
+      requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+      residentialPosterCount: "3",
+      locationType: "home",
+      posterType: "unknown_poster",
+      placedDate: "2026-04-16",
+      locationText: "1540017",
+    });
+
+    const result = await achieveMissionAction(fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("有効なポスターの種類を選択してください");
+    }
+  });
+
+  it("locationTypeが許可値以外なら『有効な種別を選択してください』エラーを返す", async () => {
+    const fd = buildFormData({
+      missionId: "mission-1",
+      requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
+      residentialPosterCount: "3",
+      locationType: "unknown_location",
+      posterType: "leader_face_a1",
+      placedDate: "2026-04-16",
+      locationText: "1540017",
+    });
+
+    const result = await achieveMissionAction(fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("有効な種別を選択してください");
+    }
+  });
+
   it("placedDateが空なら『日付を入力してください』エラーを返す", async () => {
     const fd = buildFormData({
       missionId: "mission-1",

--- a/src/features/mission-detail/actions/actions.ts
+++ b/src/features/mission-detail/actions/actions.ts
@@ -2,6 +2,8 @@
 
 import { z } from "zod";
 import { VALID_JP_PREFECTURES } from "@/features/map-poster/constants/poster-prefectures";
+import { LOCATION_TYPES } from "@/features/map-poster-residential/constants/location-types";
+import { POSTER_TYPES } from "@/features/map-poster-residential/constants/poster-types";
 import {
   MAX_POSTING_COUNT,
   MAX_RESIDENTIAL_POSTER_COUNT,
@@ -186,10 +188,18 @@ const residentialPosterArtifactSchema = baseMissionFormSchema.extend({
     .max(MAX_RESIDENTIAL_POSTER_COUNT, {
       message: `掲示枚数は${MAX_RESIDENTIAL_POSTER_COUNT}枚以下で入力してください`,
     }),
-  locationType: z.string().nonempty({ message: "種別を選択してください" }),
+  locationType: z
+    .string()
+    .nonempty({ message: "種別を選択してください" })
+    .refine((val) => LOCATION_TYPES.some((type) => type.value === val), {
+      message: "有効な種別を選択してください",
+    }),
   posterType: z
     .string()
-    .nonempty({ message: "ポスターの種類を選択してください" }),
+    .nonempty({ message: "ポスターの種類を選択してください" })
+    .refine((val) => POSTER_TYPES.some((type) => type.value === val), {
+      message: "有効なポスターの種類を選択してください",
+    }),
   placedDate: z.string().nonempty({ message: "日付を入力してください" }),
   locationText: z
     .string()

--- a/src/features/mission-detail/actions/actions.ts
+++ b/src/features/mission-detail/actions/actions.ts
@@ -187,6 +187,9 @@ const residentialPosterArtifactSchema = baseMissionFormSchema.extend({
       message: `掲示枚数は${MAX_RESIDENTIAL_POSTER_COUNT}枚以下で入力してください`,
     }),
   locationType: z.string().nonempty({ message: "種別を選択してください" }),
+  posterType: z
+    .string()
+    .nonempty({ message: "ポスターの種類を選択してください" }),
   placedDate: z.string().nonempty({ message: "日付を入力してください" }),
   locationText: z
     .string()
@@ -272,6 +275,7 @@ export const achieveMissionAction = async (formData: FormData) => {
     .get("residentialPosterCount")
     ?.toString();
   const locationType = formData.get("locationType")?.toString();
+  const posterType = formData.get("posterType")?.toString();
   const placedDate = formData.get("placedDate")?.toString();
   // ポスター用データの取得
   const prefecture = formData.get("prefecture")?.toString();
@@ -300,6 +304,7 @@ export const achieveMissionAction = async (formData: FormData) => {
     locationText,
     residentialPosterCount,
     locationType,
+    posterType,
     placedDate,
     prefecture,
     city,

--- a/src/features/mission-detail/actions/artifact-helpers.test.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.test.ts
@@ -163,11 +163,12 @@ describe("buildArtifactPayload", () => {
       });
     });
 
-    test("RESIDENTIAL_POSTER type → text_contentに「私有地ポスター掲示: X枚 種別 日付 郵便番号」形式の文字列を設定", () => {
+    test("RESIDENTIAL_POSTER type → text_contentに「私有地ポスター掲示: X枚 種別 ポスター種類 日付 郵便番号」形式の文字列を設定", () => {
       const data = baseFormData({
         requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
         residentialPosterCount: 3,
         locationType: "home",
+        posterType: "leader_face_a1",
         placedDate: "2026-04-16",
         locationText: "1540017",
       });
@@ -177,16 +178,18 @@ describe("buildArtifactPayload", () => {
       );
       expect(result).toEqual({
         link_url: null,
-        text_content: "私有地ポスター掲示: 3枚 自宅 2026-04-16 1540017",
+        text_content:
+          "私有地ポスター掲示: 3枚 自宅 党首顔写真（A1サイズ） 2026-04-16 1540017",
         image_storage_path: null,
       });
     });
 
-    test("RESIDENTIAL_POSTER type → 未知のlocationTypeはそのまま文字列として使われる", () => {
+    test("RESIDENTIAL_POSTER type → 未知のlocationType/posterTypeはそのまま文字列として使われる", () => {
       const data = baseFormData({
         requiredArtifactType: ARTIFACT_TYPES.RESIDENTIAL_POSTER.key,
         residentialPosterCount: 1,
         locationType: "unknown_type",
+        posterType: "unknown_poster",
         placedDate: "2026-04-16",
         locationText: "1540017",
       });
@@ -196,7 +199,8 @@ describe("buildArtifactPayload", () => {
       );
       expect(result).toEqual({
         link_url: null,
-        text_content: "私有地ポスター掲示: 1枚 unknown_type 2026-04-16 1540017",
+        text_content:
+          "私有地ポスター掲示: 1枚 unknown_type unknown_poster 2026-04-16 1540017",
         image_storage_path: null,
       });
     });

--- a/src/features/mission-detail/actions/artifact-helpers.ts
+++ b/src/features/mission-detail/actions/artifact-helpers.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { LOCATION_TYPES } from "@/features/map-poster-residential/constants/location-types";
+import { POSTER_TYPES } from "@/features/map-poster-residential/constants/poster-types";
 import {
   buildPosterActivityText,
   buildPostingActivityText,
@@ -107,10 +108,13 @@ const ARTIFACT_PAYLOAD_BUILDERS: Record<
     const locationTypeLabel =
       LOCATION_TYPES.find((t) => t.value === data.locationType)?.label ??
       data.locationType;
+    const posterTypeLabel =
+      POSTER_TYPES.find((t) => t.value === data.posterType)?.label ??
+      data.posterType;
     return {
       link_url: null,
       text_content:
-        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${locationTypeLabel} ${data.placedDate} ${data.locationText}`.trim(),
+        `私有地ポスター掲示: ${data.residentialPosterCount}枚 ${locationTypeLabel} ${posterTypeLabel} ${data.placedDate} ${data.locationText}`.trim(),
       image_storage_path: null,
     };
   },

--- a/src/features/missions/components/residential-poster-form.test.tsx
+++ b/src/features/missions/components/residential-poster-form.test.tsx
@@ -9,7 +9,25 @@ jest.mock("lucide-react", () => ({
 
 // Mock UI components
 jest.mock("@/components/ui/select", () => {
-  const { useState } = require("react");
+  const React = require("react");
+  const { useState } = React;
+
+  const getFirstSelectItemValue = (children: unknown): string => {
+    let value = "";
+    React.Children.forEach(children, (child: unknown) => {
+      if (value || !React.isValidElement(child)) return;
+      const props = (
+        child as { props: { value?: unknown; children?: unknown } }
+      ).props;
+      if (typeof props.value === "string") {
+        value = props.value;
+        return;
+      }
+      value = getFirstSelectItemValue(props.children);
+    });
+    return value;
+  };
+
   return {
     Select: ({ children, value, onValueChange, disabled }: any) => {
       const [internalValue, setInternalValue] = useState(value || "");
@@ -23,7 +41,8 @@ jest.mock("@/components/ui/select", () => {
             type="button"
             onClick={() => {
               if (onValueChange && !disabled) {
-                const newValue = "個人宅";
+                const newValue = getFirstSelectItemValue(children);
+                if (!newValue) return;
                 setInternalValue(newValue);
                 onValueChange(newValue);
               }

--- a/src/features/missions/components/residential-poster-form.test.tsx
+++ b/src/features/missions/components/residential-poster-form.test.tsx
@@ -54,13 +54,14 @@ describe("ResidentialPosterMissionForm", () => {
   it("必須フィールドがすべて表示される", () => {
     render(<ResidentialPosterMissionForm disabled={false} />);
 
-    expect(screen.getByTestId("select")).toBeInTheDocument();
+    // 種別 + ポスターの種類 の 2 つの Select
+    expect(screen.getAllByTestId("select")).toHaveLength(2);
     expect(screen.getByLabelText(/貼った日付/)).toBeInTheDocument();
     expect(screen.getByLabelText(/掲示枚数/)).toBeInTheDocument();
     expect(screen.getByLabelText(/掲示場所の郵便番号/)).toBeInTheDocument();
 
     // 必須マーク（*）の確認
-    expect(screen.getAllByText("*")).toHaveLength(4);
+    expect(screen.getAllByText("*")).toHaveLength(5);
   });
 
   it("説明テキストが表示される", () => {
@@ -110,10 +111,9 @@ describe("ResidentialPosterMissionForm", () => {
   it("disabled=trueの場合はすべての入力フィールドが無効化される", () => {
     render(<ResidentialPosterMissionForm disabled={true} />);
 
-    expect(screen.getByTestId("select")).toHaveAttribute(
-      "data-disabled",
-      "true",
-    );
+    for (const select of screen.getAllByTestId("select")) {
+      expect(select).toHaveAttribute("data-disabled", "true");
+    }
     expect(screen.getByLabelText(/貼った日付/)).toBeDisabled();
     expect(screen.getByLabelText(/掲示枚数/)).toBeDisabled();
     expect(screen.getByLabelText(/掲示場所の郵便番号/)).toBeDisabled();
@@ -125,10 +125,9 @@ describe("ResidentialPosterMissionForm", () => {
   it("disabled=falseの場合はすべての入力フィールドが有効化される", () => {
     render(<ResidentialPosterMissionForm disabled={false} />);
 
-    expect(screen.getByTestId("select")).toHaveAttribute(
-      "data-disabled",
-      "false",
-    );
+    for (const select of screen.getAllByTestId("select")) {
+      expect(select).toHaveAttribute("data-disabled", "false");
+    }
     expect(screen.getByLabelText(/貼った日付/)).not.toBeDisabled();
     expect(screen.getByLabelText(/掲示枚数/)).not.toBeDisabled();
     expect(screen.getByLabelText(/掲示場所の郵便番号/)).not.toBeDisabled();
@@ -157,14 +156,20 @@ describe("ResidentialPosterMissionForm", () => {
     expect(postalInput).toHaveAttribute("maxLength", "7");
   });
 
-  it("hidden inputにlocationType名が設定される", () => {
+  it("hidden inputにlocationType名とposterType名が設定される", () => {
     render(<ResidentialPosterMissionForm disabled={false} />);
 
-    const hiddenInput = document.querySelector(
+    const locationTypeInput = document.querySelector(
       'input[name="locationType"][type="hidden"]',
     );
-    expect(hiddenInput).toBeInTheDocument();
-    expect(hiddenInput).toHaveAttribute("value", "");
+    expect(locationTypeInput).toBeInTheDocument();
+    expect(locationTypeInput).toHaveAttribute("value", "");
+
+    const posterTypeInput = document.querySelector(
+      'input[name="posterType"][type="hidden"]',
+    );
+    expect(posterTypeInput).toBeInTheDocument();
+    expect(posterTypeInput).toHaveAttribute("value", "");
   });
 
   it("ヘルプテキストが表示される", () => {
@@ -238,8 +243,10 @@ describe("ResidentialPosterMissionForm", () => {
       />,
     );
 
-    // 種別を選択
-    fireEvent.click(screen.getByText("Select Type"));
+    // 種別 + ポスターの種類 を選択
+    for (const btn of screen.getAllByText("Select Type")) {
+      fireEvent.click(btn);
+    }
 
     // 日付を入力
     fireEvent.change(screen.getByLabelText(/貼った日付/), {
@@ -269,8 +276,10 @@ describe("ResidentialPosterMissionForm", () => {
       />,
     );
 
-    // 種別を選択
-    fireEvent.click(screen.getByText("Select Type"));
+    // 種別 + ポスターの種類 を選択
+    for (const btn of screen.getAllByText("Select Type")) {
+      fireEvent.click(btn);
+    }
 
     // 日付を入力
     fireEvent.change(screen.getByLabelText(/貼った日付/), {
@@ -300,8 +309,10 @@ describe("ResidentialPosterMissionForm", () => {
       />,
     );
 
-    // 種別を選択
-    fireEvent.click(screen.getByText("Select Type"));
+    // 種別 + ポスターの種類 を選択
+    for (const btn of screen.getAllByText("Select Type")) {
+      fireEvent.click(btn);
+    }
 
     // 日付を入力
     fireEvent.change(screen.getByLabelText(/貼った日付/), {

--- a/src/features/missions/components/residential-poster-form.tsx
+++ b/src/features/missions/components/residential-poster-form.tsx
@@ -16,6 +16,10 @@ import {
   LOCATION_TYPES,
   type LocationTypeValue,
 } from "@/features/map-poster-residential/constants/location-types";
+import {
+  POSTER_TYPES,
+  type PosterTypeValue,
+} from "@/features/map-poster-residential/constants/poster-types";
 
 type ResidentialPosterMissionFormProps = {
   disabled: boolean;
@@ -29,6 +33,7 @@ export function ResidentialPosterMissionForm({
   onValidityChange,
 }: ResidentialPosterMissionFormProps) {
   const [locationType, setLocationType] = useState<LocationTypeValue | "">("");
+  const [posterType, setPosterType] = useState<PosterTypeValue | "">("");
   const [placedDate, setPlacedDate] = useState("");
   const [posterCount, setPosterCount] = useState("");
   const [locationText, setLocationText] = useState("");
@@ -42,6 +47,7 @@ export function ResidentialPosterMissionForm({
   const isFormValid =
     Number(posterCount) >= 1 &&
     locationType !== "" &&
+    posterType !== "" &&
     placedDate !== "" &&
     isPostalCodeValid;
 
@@ -80,6 +86,7 @@ export function ResidentialPosterMissionForm({
 
       {/* hidden input for Select value (Radix Select doesn't natively submit via FormData) */}
       <input type="hidden" name="locationType" value={locationType} />
+      <input type="hidden" name="posterType" value={posterType} />
 
       {/* 種別 */}
       <div className="space-y-2">
@@ -96,6 +103,29 @@ export function ResidentialPosterMissionForm({
           </SelectTrigger>
           <SelectContent>
             {LOCATION_TYPES.map((type) => (
+              <SelectItem key={type.value} value={type.value}>
+                {type.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* ポスターの種類 */}
+      <div className="space-y-2">
+        <Label htmlFor="posterType">
+          ポスターの種類 <span className="text-red-500">*</span>
+        </Label>
+        <Select
+          value={posterType}
+          onValueChange={(v) => setPosterType(v as PosterTypeValue | "")}
+          disabled={disabled}
+        >
+          <SelectTrigger id="posterType">
+            <SelectValue placeholder="ポスターの種類を選択" />
+          </SelectTrigger>
+          <SelectContent>
+            {POSTER_TYPES.map((type) => (
               <SelectItem key={type.value} value={type.value}>
                 {type.label}
               </SelectItem>

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -967,6 +967,7 @@ export type Database = {
           mission_artifact_id: string | null;
           placed_date: string | null;
           postcode: string | null;
+          poster_type: string | null;
           prefecture: string | null;
           updated_at: string;
           user_id: string;
@@ -986,6 +987,7 @@ export type Database = {
           mission_artifact_id?: string | null;
           placed_date?: string | null;
           postcode?: string | null;
+          poster_type?: string | null;
           prefecture?: string | null;
           updated_at?: string;
           user_id: string;
@@ -1005,6 +1007,7 @@ export type Database = {
           mission_artifact_id?: string | null;
           placed_date?: string | null;
           postcode?: string | null;
+          poster_type?: string | null;
           prefecture?: string | null;
           updated_at?: string;
           user_id?: string;

--- a/supabase/migrations/20260423000000_add_poster_type_to_residential_poster_placements.sql
+++ b/supabase/migrations/20260423000000_add_poster_type_to_residential_poster_placements.sql
@@ -1,0 +1,2 @@
+-- Add poster_type to residential_poster_placements
+ALTER TABLE residential_poster_placements ADD COLUMN poster_type TEXT CONSTRAINT residential_poster_placements_poster_type_check CHECK (poster_type IN ('leader_face_a1', 'leader_face_a2', 'logo_a1', 'logo_a2'));


### PR DESCRIPTION
## Summary

私有地ポスターの登録時に「ポスターの種類」を選択できるようにする。

- 新しい選択肢: 党首顔写真（A1サイズ） / 党首顔写真（A2サイズ） / ロゴ（A1サイズ） / ロゴ（A2サイズ）
- 追加箇所:
  - **マップ**: 私有地ポスターマップの登録/編集フォーム（`src/features/map-poster-residential/components/residential-poster-form.tsx`）
  - **ミッション**: 私有地ポスターミッションの提出フォーム（`src/features/missions/components/residential-poster-form.tsx`）
- DB: `residential_poster_placements.poster_type`（`TEXT`, nullable, CHECK 制約付き）を追加
- ミッション提出の `artifact.text_content` に「ポスター種類」のラベルも含めるよう更新

## 変更の内訳

- `src/features/map-poster-residential/constants/poster-types.ts` を新規追加（定数と型）
- map 側: フォーム / ページクライアント / フック / Server Action / サービス を `poster_type` 対応に更新
- mission 側: フォームに hidden input + Select を追加、Zod スキーマと `buildArtifactPayload` を更新
- 型: `src/lib/types/supabase.ts` の `residential_poster_placements` に `poster_type` を追加
- マイグレーション: `supabase/migrations/20260423000000_add_poster_type_to_residential_poster_placements.sql`
- 既存テストの期待値を更新し、空の posterType に対する新規バリデーションテストを追加

## Test plan

- [x] `pnpm run biome:check:write`（pre-existing warnings のみ）
- [x] `pnpm run typecheck`
- [x] `pnpm run test:unit`（2049 passed）
- [x] ブラウザで `/map/poster-residential` を開き、登録フォームの新しい「ポスターの種類」セレクトで全4オプションを選択・保存できることを確認
- [x] 私有地ポスター系ミッション提出フォームで「ポスターの種類」必須バリデーションと送信後の text_content を確認

https://claude.ai/code/session_011Jjr1UhJ9Tib7uUZEwnfAn

---
_Generated by [Claude Code](https://claude.ai/code/session_011Jjr1UhJ9Tib7uUZEwnfAn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 住宅地ポスター掲示フォームに「ポスターの種類」選択（党首顔／ロゴ × A1/A2）を必須項目として追加。選択値は掲示情報とともに保存・更新されます。
* **テスト**
  * 選択必須・無効値の検証を含むユニットテストを追加・更新し、挙動とエラーメッセージを確認。
* **Chores**
  * データベースに poster_type カラムを追加し、許可値を制約で制限。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->