### PR TITLE
feat: 活動報告ポスティングミッションのポイントを50ptに引き下げ

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -383,7 +383,7 @@ missions:
     difficulty: 2
     required_artifact_type: POSTING
     max_achievement_count: null
-    is_featured: true
+    is_featured: false
     is_hidden: false
     artifact_label: ポスティング情報
     ogp_image_url: null


### PR DESCRIPTION
## Summary
- 「チームみらいの活動報告をポスティングしよう」ミッションの `is_featured` を `false` に変更
- これにより獲得ポイントが100pt（50pt×2倍）から50ptに引き下がる
- 注目ミッションから外れる

## 背景
元々サポーターさんには4月末までと伝えていたため、5月以降は獲得ポイントを通常に戻す対応。

## Test plan
- [ ] デプロイ後、ミッション詳細ページで1枚あたり50ptと表示されることを確認
- [ ] トップページの「注目ミッション」欄に表示されないことを確認

Slackスレッド: https://team-mirai-staff.slack.com/archives/C0AELM9AEKX/p1777599204203359

https://claude.ai/code/session_01WVs5WAFCyKriiER1KLgaVf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVs5WAFCyKriiER1KLgaVf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 「投稿アクティビティマガジン」ミッションがフィーチャーから外れました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->