### PR TITLE
fix: 私有地ポスターマップの掲示枚数フィールドを編集可能に修正

### DIFF
--- a/src/features/map-poster-residential/components/residential-poster-form.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-form.tsx
@@ -86,9 +86,20 @@ export function PlacementForm({
   const canSubmit =
     mode === "edit" || (confirmedOrdinance && confirmedLandowner);
 
+  const normalizeCount = () => {
+    const num = Number(countInput);
+    if (Number.isNaN(num) || num < 1) {
+      setCountInput("1");
+      onCountChange(1);
+    } else {
+      onCountChange(num);
+    }
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setAttempted(true);
+    normalizeCount();
     if (!address || !placedDate || !locationType || !posterType) return;
     if (!canSubmit) return;
     onSubmit();
@@ -151,13 +162,7 @@ export function PlacementForm({
                 onCountChange(num);
               }
             }}
-            onBlur={() => {
-              const num = Number(countInput);
-              if (Number.isNaN(num) || num < 1) {
-                setCountInput("1");
-                onCountChange(1);
-              }
-            }}
+            onBlur={normalizeCount}
           />
         </div>
 

--- a/src/features/map-poster-residential/components/residential-poster-form.tsx
+++ b/src/features/map-poster-residential/components/residential-poster-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -77,6 +77,11 @@ export function PlacementForm({
   onDelete,
 }: PlacementFormProps) {
   const [attempted, setAttempted] = useState(false);
+  const [countInput, setCountInput] = useState(count > 0 ? String(count) : "");
+
+  useEffect(() => {
+    setCountInput(count > 0 ? String(count) : "");
+  }, [count]);
 
   const canSubmit =
     mode === "edit" || (confirmedOrdinance && confirmedLandowner);
@@ -138,8 +143,21 @@ export function PlacementForm({
             id="placement-count"
             type="number"
             min={1}
-            value={count}
-            onChange={(e) => onCountChange(Number(e.target.value) || 1)}
+            value={countInput}
+            onChange={(e) => {
+              setCountInput(e.target.value);
+              const num = Number(e.target.value);
+              if (!Number.isNaN(num) && num >= 1) {
+                onCountChange(num);
+              }
+            }}
+            onBlur={() => {
+              const num = Number(countInput);
+              if (Number.isNaN(num) || num < 1) {
+                setCountInput("1");
+                onCountChange(1);
+              }
+            }}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- 私有地ポスターマップの「掲示枚数」入力フィールドで、数値を削除しても即座に1に戻ってしまい、別の数字を入力できなかった問題を修正
- 入力中は文字列状態として別管理し、blur時にバリデーションを行う方式に変更

## 原因
`onChange={(e) => onCountChange(Number(e.target.value) || 1)}` により、空文字入力時に `Number("") || 1` が `1` に戻してしまっていた

## 修正内容
- フォームコンポーネント内でローカルの入力状態 (`countInput`) を追加
- 有効な数値の場合のみ親コンポーネントの状態を更新
- blur時に無効な値（空や0以下）なら1にリセット

## Test plan
- [ ] 私有地ポスターマップ (`/map/poster-residential`) でポスター登録フォームを開く
- [ ] 掲示枚数フィールドで「1」を削除し、別の数字（例: 5）を入力できることを確認
- [ ] フィールドから離れた時、空のままなら「1」に戻ることを確認
- [ ] 登録が正常に行われることを確認

---
Slack thread: https://team-mirai-staff.slack.com/archives/C0AELM9AEKX/p1778124474919269?thread_ts=1778122715.883049&cid=C0AELM9AEKX

https://claude.ai/code/session_019dxhfa4jj9EaCJgBVKSthY

---
_Generated by [Claude Code](https://claude.ai/code/session_019dxhfa4jj9EaCJgBVKSthY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 住宅ポスター配置フォームのポスター数入力フィールドの入力検証と正規化機能が改善されました。無効な値や空欄が入力された場合、フォーカスを外すと自動的に「1」に修正され、正しい値が保存されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->