### PR TITLE
fix: サインアップ失敗時に握りつぶしていたエラーをログ出力

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -114,6 +114,7 @@ export const signUpActionWithState = async (
         formData: currentFormData,
       };
     }
+    console.error("サインアップに失敗しました:", error);
     return {
       error: "ユーザー登録に失敗しました",
       formData: currentFormData,


### PR DESCRIPTION
## 概要

`signUp` のサインアップ処理で、`error` が「already registered / already exists」**以外**のエラーを返した場合に、`error` の中身を捨てて汎用メッセージ（「ユーザー登録に失敗しました」）だけを返していました。これだと想定外のエラーが起きてもログに残らず、原因が追えません（エラーの握りつぶし）。

`src/app/actions.ts` の該当箇所参照: https://github.com/team-mirai-volunteer/action-board/blob/06ca7a683f7a7801aa3ff444e7c4c6d7733042fa/src/app/actions.ts#L105-L121

## 変更内容

想定外のフォールバック分岐で `console.error("サインアップに失敗しました:", error)` を出すようにしました。

- 「already registered / exists」は想定済みの正常分岐なのでログは追加せず、想定外のケースのみログ出力します。
- ログ形式（`console.error("...:", errorObj)`）はこのファイルの既存の慣習に合わせています。

```diff
     }
+    console.error("サインアップに失敗しました:", error);
     return {
       error: "ユーザー登録に失敗しました",
       formData: currentFormData,
     };
   }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * サインアップ処理のエラーハンドリングを強化し、内部ロギング機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->