### PR TITLE
ci(deploy): supabase db/config push に --yes を付与

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Apply migrations
         run: |
-          supabase db push --include-all
-          supabase config push
+          supabase db push --include-all --yes
+          supabase config push --yes
 
       - uses: pnpm/action-setup@v4
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,8 +6,8 @@ steps:
       - |
         npx supabase link --project-ref ${_SUPABASE_PROJECT_ID} -p $$SUPABASE_DB_PASSWORD
 
-        npx supabase db push --include-all
-        npx supabase config push
+        npx supabase db push --include-all --yes
+        npx supabase config push --yes
     env:
       - 'CI=true'
       - 'SMTP_ENABLED=true'

--- a/docs/20260115_1500_GCP_to_Vercel_migration_plan.md
+++ b/docs/20260115_1500_GCP_to_Vercel_migration_plan.md
@@ -143,8 +143,8 @@ Your understanding is correct. The action-board codebase is **completely cloud-a
 
          - name: Apply migrations
            run: |
-             supabase db push --include-all
-             supabase config push
+             supabase db push --include-all --yes
+             supabase config push --yes
            env:
              SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 


### PR DESCRIPTION
## 概要

CIのデプロイパイプライン（cloudbuild.yaml / GitHub Actions deploy.yml）の `supabase db push` / `supabase config push` に `--yes` を付与する。

## 背景・理由

`supabase config push` はローカルの `config.toml` とリモートの差分を表示し、**確認プロンプトを出す**コマンド。CI は非インタラクティブ環境のため、実際に config 差分が発生したタイミングで以下のリスクがある:

- プロンプトのデフォルト挙動次第で **config が黙って push されない**（失敗せずスルーされ、気付きにくい）
- stdin 待ちでハング、もしくはエラーでビルド失敗

現状動いているのは、これまで config に差分が無く確認プロンプトが発火していなかっただけの可能性が高い。

加えて、cloudbuild は `npx supabase`、deploy.yml は `version: latest` で**常に最新CLIを取得**するため、将来バージョンでプロンプト挙動が変わるリスクもある。`--yes`（"Answer yes to all prompts"）を明示することでこの曖昧さを排除する。

破壊的変更を伴う `db push --include-all` にも同様に `--yes` を付与し、CI で明示的に承認する。

## 変更内容

- `cloudbuild.yaml`: `db push --include-all --yes` / `config push --yes`
- `.github/workflows/deploy.yml`: 同上

## 検証方法

- YAML のみの変更でアプリコードへの影響なし
- マージ後の develop デプロイで `supabase db push` / `config push` ステップがプロンプト待ちにならず正常完了することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * デプロイ時の移行手順で、Supabase CLI の「Apply migrations」実行を自動承認（対話なし）に変更し、デプロイプロセスをよりスムーズにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->