### PR TITLE
test: fix flaky createTestUser by making default email unique

### DIFF
--- a/tests/supabase/utils.ts
+++ b/tests/supabase/utils.ts
@@ -33,7 +33,10 @@ export type TestUser = {
  * テストユーザーを作成し、認証情報を持つクライアントを返す
  */
 export async function createTestUser(
-  email = `test-${Date.now()}@example.com`,
+  // Date.now() だけだと、Jest が複数ワーカーでテストファイルを並列実行した際に
+  // 同一ミリ秒で衝突してメールが重複し、GoTrue が "Database error creating new user"
+  // を返してフレーキーになる。crypto.randomUUID() を付与して一意性を担保する。
+  email = `test-${Date.now()}-${crypto.randomUUID()}@example.com`,
   password = "password123",
 ): Promise<{
   user: TestUser;


### PR DESCRIPTION
## 問題

`Supabase & Integration Tests` ジョブが断続的に失敗していた（例: [PR #2230 のCI](https://github.com/team-mirai-volunteer/action-board/pull/2230)）。

```
FAIL tests/integration/achieve-mission.test.ts
  ● achieveMission ユースケース › POSTERタイプでミッション達成 - poster_activities にレコードが作成される
    テストユーザーの作成に失敗しました: Database error creating new user
      at createTestUser (tests/supabase/utils.ts:58:11)
```

## 原因

`createTestUser()` の既定メールは `test-${Date.now()}@example.com` で、ミリ秒精度のタイムスタンプのみに依存していた。Jest はテストファイルを複数ワーカーで**並列実行**するため、異なるテストファイルの `createTestUser()` 呼び出しが**同一ミリ秒**に重なるとメールアドレスが衝突し、GoTrue が重複ユーザーを汎用エラー `Database error creating new user` として返していた。スケジューリング次第で発生するため、典型的なフレーキー挙動になっていた。

`tests/supabase/**`（RLS・db_function）のテストは全て `${crypto.randomUUID()}@example.com` を明示的に渡して衝突を回避済みで、これらは安定して成功している。一方で `tests/integration/**` のテストは引数なしの `createTestUser()` を使い既定値に依存していたため、こちらだけがフレーキーになっていた。

## 修正

既定メールに `crypto.randomUUID()` を付与し、並列ワーカー間・時間に依存しない一意性を担保する（`tests/supabase` 配下の既存テストと同じ方式）。呼び出し側の変更は不要で、修正をユーティリティに集約している。

```ts
email = `test-${Date.now()}-${crypto.randomUUID()}@example.com`,
```

## 検証

- `pnpm run biome:check:write` — 編集ファイルはクリーン（既存の警告は別ファイル）
- `pnpm run typecheck` — パス
- `pnpm run test:unit` — 2059 件すべてパス

統合テストはローカルSupabaseが必要なため、CIの `Supabase & Integration Tests` ジョブで最終確認する。

https://claude.ai/code/session_01DZFHXvXPrTafiprWadFGdY

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZFHXvXPrTafiprWadFGdY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

この変更は内部テストインフラストラクチャの改善のため、エンドユーザーに影響する機能変更はありません。

* **Tests**
  * テスト用のメール生成ロジックを改善し、並行実行時の一意性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->