### PR TITLE
fix: street-flyer ミッションのタイトルから末尾の感嘆符を削除

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -410,7 +410,7 @@ missions:
     artifact_label: ポスティング情報
     ogp_image_url: null
   - slug: street-flyer
-    title: 街頭でチームみらいのチラシを配布しよう！
+    title: 街頭でチームみらいのチラシを配布しよう
     icon_url: /img/mission-icons/actionboard_icon_work_20260616_ol_street-flyer.png
     content: |-
       街頭でチームみらいのチラシを配布しよう！配布した枚数と場所を報告してください。配布1枚につき50ポイントを獲得できます。


### PR DESCRIPTION
## 概要

`street-flyer` ミッションのタイトル末尾の感嘆符「！」を削除します。

- 変更前: `街頭でチームみらいのチラシを配布しよう！`
- 変更後: `街頭でチームみらいのチラシを配布しよう`

PR #2233 でこのミッションを追加した際、タイトル修正コミットがマージに含まれなかったため、本PRで対応します。

## 変更ファイル

- `mission_data/missions.yaml` — `street-flyer` の `title` を変更

## 検証方法

- `mission_data/missions.yaml` のYAML構文が有効であることを確認済み
- CI/CDデプロイ時に `npm run mission:sync` でDBに反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UatRNFr11ofpja8BicXrd

---
_Generated by [Claude Code](https://claude.ai/code/session_013UatRNFr11ofpja8BicXrd)_