### PR TITLE
Revert: 新規登録フォームのメール登録不具合の注意書きを削除

### DIFF
--- a/src/features/auth/components/email-sign-up-form.tsx
+++ b/src/features/auth/components/email-sign-up-form.tsx
@@ -34,20 +34,11 @@ function EmailSignUpFormContent({
 
   return (
     <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
-      <div className="bg-amber-50 border border-amber-200 rounded-md p-3 mb-2">
-        <p className="text-sm font-medium text-amber-800">
-          ⚠️
-          現在、システムの不具合により、メールアドレスでの新規登録が正常に行えない場合があります。
-        </p>
-        <p className="text-sm text-amber-800 mt-1">
-          お手数ですが、
-          <Link href="/sign-up" className="underline font-medium">
-            LINEでのご登録
-          </Link>
-          をご利用いただけますようお願いいたします。ご不便をおかけし申し訳ございません。
-        </p>
-      </div>
       <Label htmlFor="email">メールアドレス</Label>
+      <p className="text-xs text-muted-foreground mb-2">
+        ※一部のメールアドレスに認証メールが届かない事象が確認されています。Gmail
+        などのメールアドレスをご利用いただくと、より確実にご登録いただけます。
+      </p>
       <Input
         name="email"
         placeholder="you@example.com"

--- a/src/features/auth/components/two-step-sign-up-form.tsx
+++ b/src/features/auth/components/two-step-sign-up-form.tsx
@@ -246,17 +246,6 @@ function LoginSelectionPhase({
         </div>
       )}
 
-      {/* 不具合に関するお知らせ */}
-      <div className="bg-amber-50 border border-amber-200 rounded-md p-3">
-        <p className="text-sm font-medium text-amber-800">
-          ⚠️
-          現在、システムの不具合により、メールアドレスでの新規登録が正常に行えない場合があります。
-        </p>
-        <p className="text-sm text-amber-800 mt-1">
-          お手数ですが、LINEでのご登録をご利用いただけますようお願いいたします。ご不便をおかけし申し訳ございません。
-        </p>
-      </div>
-
       {/* LINEログインボタン */}
       <Button
         type="button"


### PR DESCRIPTION
## 概要

メール送信の不具合が解消し、メールが正常に届くことが確認できたため、PR #2225 で追加した「メール登録不具合の注意書き（案内画面）」を revert します。

## 背景

- PR #2225 で、Mailgun の不具合によりメールアドレス登録が正常に行えない状況を受けて、登録方法選択画面とメール登録フォームに「LINE登録を案内する注意書き（黄色のアラート）」を一時的に追加していました。
- 今回、不具合が解消しメールが届くことが確認できたため、その暫定的な案内表示を削除します。

## 変更内容

`388b1ca`（PR #2225）の revert です。

- `src/features/auth/components/two-step-sign-up-form.tsx` — 登録方法選択画面の不具合アラートを削除
- `src/features/auth/components/email-sign-up-form.tsx` — メール登録フォームの不具合アラート（LINE登録への誘導）を削除し、元々あった控えめな注意書き（「※一部のメールアドレスに認証メールが届かない事象が確認されています。Gmail などのメールアドレスをご利用いただくと…」）を復元

> 注: revert により、PR #2225 以前から存在していた Gmail 推奨の注意書きが元に戻っています。こちらも不要であれば併せて削除しますので、お知らせください。

## 確認済み事項

- `pnpm run biome:check:write` — 変更ファイルはクリーン
- `pnpm run typecheck` — パス
- `pnpm run test:unit` — 2059 テスト全パス

## 参考

Slack スレッド: https://team-mirai-staff.slack.com/archives/C08RX46UHHV/p1781769458390929?thread_ts=1780038273.649199&cid=C08RX46UHHV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsRHXNPos2nn5RSe6uWbq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* メールアドレス登録画面の案内文をシンプル化しました
* ログイン方法選択画面のUIをシンプル化し、ユーザーの利便性を向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->