### PR TITLE
Revert: 新規登録フォームのメール登録不具合の注意書きを削除

### DIFF
--- a/src/features/auth/components/email-sign-up-form.tsx
+++ b/src/features/auth/components/email-sign-up-form.tsx
@@ -34,20 +34,11 @@ function EmailSignUpFormContent({
 
   return (
     <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
-      <div className="bg-amber-50 border border-amber-200 rounded-md p-3 mb-2">
-        <p className="text-sm font-medium text-amber-800">
-          ⚠️
-          現在、システムの不具合により、メールアドレスでの新規登録が正常に行えない場合があります。
-        </p>
-        <p className="text-sm text-amber-800 mt-1">
-          お手数ですが、
-          <Link href="/sign-up" className="underline font-medium">
-            LINEでのご登録
-          </Link>
-          をご利用いただけますようお願いいたします。ご不便をおかけし申し訳ございません。
-        </p>
-      </div>
       <Label htmlFor="email">メールアドレス</Label>
+      <p className="text-xs text-muted-foreground mb-2">
+        ※一部のメールアドレスに認証メールが届かない事象が確認されています。Gmail
+        などのメールアドレスをご利用いただくと、より確実にご登録いただけます。
+      </p>
       <Input
         name="email"
         placeholder="you@example.com"

--- a/src/features/auth/components/two-step-sign-up-form.tsx
+++ b/src/features/auth/components/two-step-sign-up-form.tsx
@@ -246,17 +246,6 @@ function LoginSelectionPhase({
         </div>
       )}
 
-      {/* 不具合に関するお知らせ */}
-      <div className="bg-amber-50 border border-amber-200 rounded-md p-3">
-        <p className="text-sm font-medium text-amber-800">
-          ⚠️
-          現在、システムの不具合により、メールアドレスでの新規登録が正常に行えない場合があります。
-        </p>
-        <p className="text-sm text-amber-800 mt-1">
-          お手数ですが、LINEでのご登録をご利用いただけますようお願いいたします。ご不便をおかけし申し訳ございません。
-        </p>
-      </div>
-
       {/* LINEログインボタン */}
       <Button
         type="button"


### PR DESCRIPTION
## 概要

メール送信の不具合が解消し、認証メールが正常に届くことが確認できたため、新規登録フローに暫定的に表示していた不具合の注意書き（案内画面）を削除します。

これはコミット `388b1ca`（"feat(auth): 新規登録フォームにメール登録不具合の注意書きを追加"）を `git revert` したものです。

## 変更内容

- **登録方法選択画面** (`two-step-sign-up-form.tsx`): メール不具合を知らせる黄色のアラートを削除
- **メール登録フォーム** (`email-sign-up-form.tsx`): 黄色の不具合アラートを削除し、コミット前にあった「Gmail推奨」の控えめな注意書きを復元（純粋な revert のため）

## 確認済み事項

- `pnpm run typecheck` パス
- `pnpm run biome:check:write`（編集ファイルに変更なし）
- `pnpm run test:unit` 全2059テストパス

## 経緯

Slackスレッド: https://team-mirai-staff.slack.com/archives/C08RX46UHHV/p1781769458390929?thread_ts=1780038273.649199&cid=C08RX46UHHV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1RybUrBuBRHDe1wruRTep)_