### PR TITLE
feat(map-poster): ポスター掲示板マップにテキスト検索機能を追加 (#911)

### DIFF
--- a/src/features/map-poster/components/poster-board-search.tsx
+++ b/src/features/map-poster/components/poster-board-search.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Input } from "@/components/ui/input";
+import type { PosterBoard } from "../types/poster-types";
+import {
+  POSTER_SEARCH_MIN_QUERY_LENGTH,
+  searchPosterBoards,
+} from "../utils/poster-search-logic";
+
+interface PosterBoardSearchProps {
+  boards: PosterBoard[];
+  onSelect: (board: PosterBoard) => void;
+}
+
+/**
+ * ポスター掲示板マップ上のテキスト検索ボックス。
+ * 番号・名前・住所・市区町村・ID で部分一致検索し、結果をドロップダウンで表示する。
+ * 結果を選択すると {@link PosterBoardSearchProps.onSelect} が呼ばれ、
+ * 呼び出し側で該当掲示板へ地図を移動する。
+ */
+export function PosterBoardSearch({
+  boards,
+  onSelect,
+}: PosterBoardSearchProps) {
+  const [query, setQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+
+  const results = useMemo(
+    () => searchPosterBoards(boards, query),
+    [boards, query],
+  );
+
+  const showDropdown =
+    isOpen && query.trim().length >= POSTER_SEARCH_MIN_QUERY_LENGTH;
+
+  const handleSelect = (board: PosterBoard) => {
+    onSelect(board);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="absolute left-4 top-4 z-1000 w-64 max-w-[calc(100%-2rem)]">
+      <div className="relative">
+        <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
+        <Input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+          }}
+          onFocus={() => setIsOpen(true)}
+          placeholder="番号・名前・住所で検索"
+          className="bg-white pl-8 pr-8 shadow-lg"
+          aria-label="掲示板を検索"
+        />
+        {query.length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              setQuery("");
+              setIsOpen(false);
+            }}
+            className="absolute right-2 top-2.5 text-gray-400 hover:text-gray-600"
+            aria-label="検索をクリア"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {showDropdown && (
+        <ul className="mt-1 max-h-72 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+          {results.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-gray-500">
+              該当する掲示板がありません
+            </li>
+          ) : (
+            results.map((board) => (
+              <li key={board.id}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(board)}
+                  className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-gray-100"
+                >
+                  <span className="text-xs font-medium text-gray-900">
+                    {board.number ? `#${board.number} ` : ""}
+                    {board.name}
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    {board.address}
+                    {board.city ? ` (${board.city})` : ""}
+                  </span>
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/features/map-poster/components/poster-board-search.tsx
+++ b/src/features/map-poster/components/poster-board-search.tsx
@@ -70,7 +70,7 @@ export function PosterBoardSearch({
   return (
     <div
       ref={containerRef}
-      className="absolute left-4 top-4 z-1000 w-64 max-w-[calc(100%-2rem)]"
+      className="absolute left-1/2 top-4 z-1000 w-64 max-w-[calc(100%-2rem)] -translate-x-1/2"
     >
       <div className="relative">
         <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />

--- a/src/features/map-poster/components/poster-board-search.tsx
+++ b/src/features/map-poster/components/poster-board-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Search, X } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import type { PosterBoard } from "../types/poster-types";
 import {
@@ -26,6 +26,7 @@ export function PosterBoardSearch({
 }: PosterBoardSearchProps) {
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const results = useMemo(
     () => searchPosterBoards(boards, query),
@@ -35,13 +36,42 @@ export function PosterBoardSearch({
   const showDropdown =
     isOpen && query.trim().length >= POSTER_SEARCH_MIN_QUERY_LENGTH;
 
+  // 外側クリック・Escape キーでドロップダウンを閉じる
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handlePointerDown = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
   const handleSelect = (board: PosterBoard) => {
     onSelect(board);
     setIsOpen(false);
   };
 
   return (
-    <div className="absolute left-4 top-4 z-1000 w-64 max-w-[calc(100%-2rem)]">
+    <div
+      ref={containerRef}
+      className="absolute left-4 top-4 z-1000 w-64 max-w-[calc(100%-2rem)]"
+    >
       <div className="relative">
         <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
         <Input

--- a/src/features/map-poster/components/poster-board-search.tsx
+++ b/src/features/map-poster/components/poster-board-search.tsx
@@ -70,7 +70,7 @@ export function PosterBoardSearch({
   return (
     <div
       ref={containerRef}
-      className="absolute left-1/2 top-4 z-1000 w-64 max-w-[calc(100%-2rem)] -translate-x-1/2"
+      className="absolute left-1/2 top-4 z-[1000] w-64 max-w-[calc(100%-2rem)] -translate-x-1/2"
     >
       <div className="relative">
         <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
@@ -82,7 +82,7 @@ export function PosterBoardSearch({
             setIsOpen(true);
           }}
           onFocus={() => setIsOpen(true)}
-          placeholder="番号・名前・住所で検索"
+          placeholder="番号・名前・住所・市区町村で検索"
           className="bg-white pl-8 pr-8 shadow-lg"
           aria-label="掲示板を検索"
         />

--- a/src/features/map-poster/components/poster-map-with-cluster.tsx
+++ b/src/features/map-poster/components/poster-map-with-cluster.tsx
@@ -23,6 +23,7 @@ import {
   statusColors,
 } from "../utils/marker-icons";
 import { PosterBoardFilter } from "./poster-board-filter";
+import { PosterBoardSearch } from "./poster-board-search";
 
 // Fix Leaflet default marker icon issue with Next.js
 // biome-ignore lint/suspicious/noExplicitAny: Leaflet internal API
@@ -476,6 +477,16 @@ export default function PosterMapWithCluster({
     }
   };
 
+  // 検索結果の掲示板へ地図を移動する
+  const handleSearchSelect = (board: PosterBoard) => {
+    if (board.lat && board.long && mapRef.current) {
+      mapRef.current.flyTo([board.lat, board.long], MAX_ZOOM, {
+        animate: true,
+        duration: 1,
+      });
+    }
+  };
+
   // フルスクリーンモードの切り替え
   const toggleFullscreen = () => {
     setIsFullscreen(!isFullscreen);
@@ -542,6 +553,8 @@ export default function PosterMapWithCluster({
         onDeselectAll={deselectAll}
         activeFilterCount={activeFilterCount}
       />
+
+      <PosterBoardSearch boards={boards} onSelect={handleSearchSelect} />
 
       {/* フルスクリーンボタン */}
       {!isFullscreen && (

--- a/src/features/map-poster/components/poster-map-with-cluster.tsx
+++ b/src/features/map-poster/components/poster-map-with-cluster.tsx
@@ -554,7 +554,10 @@ export default function PosterMapWithCluster({
         activeFilterCount={activeFilterCount}
       />
 
-      <PosterBoardSearch boards={boards} onSelect={handleSearchSelect} />
+      <PosterBoardSearch
+        boards={filteredBoards}
+        onSelect={handleSearchSelect}
+      />
 
       {/* フルスクリーンボタン */}
       {!isFullscreen && (

--- a/src/features/map-poster/utils/poster-search-logic.test.ts
+++ b/src/features/map-poster/utils/poster-search-logic.test.ts
@@ -1,0 +1,103 @@
+import {
+  POSTER_SEARCH_MAX_RESULTS,
+  searchPosterBoards,
+} from "./poster-search-logic";
+
+type TestBoard = {
+  id: string;
+  number: string | number | null;
+  name: string | null;
+  address: string | null;
+  city: string | null;
+};
+
+const makeBoard = (overrides: Partial<TestBoard> = {}): TestBoard => ({
+  id: "id-1",
+  number: "1",
+  name: "中央公園",
+  address: "中央区1-1",
+  city: "中央区",
+  ...overrides,
+});
+
+describe("searchPosterBoards", () => {
+  it("returns empty array when query is shorter than the minimum length", () => {
+    const boards = [makeBoard()];
+    expect(searchPosterBoards(boards, "")).toEqual([]);
+    expect(searchPosterBoards(boards, "中")).toEqual([]);
+  });
+
+  it("returns empty array when query is only whitespace", () => {
+    expect(searchPosterBoards([makeBoard()], "   ")).toEqual([]);
+  });
+
+  it("matches by board number", () => {
+    const boards = [
+      makeBoard({ id: "a", number: "12" }),
+      makeBoard({ id: "b", number: "34" }),
+    ];
+    const result = searchPosterBoards(boards, "12");
+    expect(result.map((b) => b.id)).toEqual(["a"]);
+  });
+
+  it("matches a numeric number field", () => {
+    const boards = [makeBoard({ id: "a", number: 105 })];
+    expect(searchPosterBoards(boards, "10").map((b) => b.id)).toEqual(["a"]);
+  });
+
+  it("matches by name (partial, case-insensitive)", () => {
+    const boards = [
+      makeBoard({ id: "a", name: "Sakura Park" }),
+      makeBoard({ id: "b", name: "中央公園" }),
+    ];
+    expect(searchPosterBoards(boards, "sakura").map((b) => b.id)).toEqual([
+      "a",
+    ]);
+    expect(searchPosterBoards(boards, "公園").map((b) => b.id)).toEqual(["b"]);
+  });
+
+  it("matches by address and city", () => {
+    const boards = [
+      makeBoard({ id: "a", address: "港区六本木6", city: "港区" }),
+      makeBoard({ id: "b", address: "渋谷区道玄坂1", city: "渋谷区" }),
+    ];
+    expect(searchPosterBoards(boards, "六本木").map((b) => b.id)).toEqual([
+      "a",
+    ]);
+    expect(searchPosterBoards(boards, "渋谷").map((b) => b.id)).toEqual(["b"]);
+  });
+
+  it("matches by id", () => {
+    const boards = [makeBoard({ id: "abc-123" }), makeBoard({ id: "xyz-789" })];
+    expect(searchPosterBoards(boards, "xyz").map((b) => b.id)).toEqual([
+      "xyz-789",
+    ]);
+  });
+
+  it("treats null fields as non-matching without throwing", () => {
+    const boards = [
+      makeBoard({
+        id: "a",
+        number: null,
+        name: null,
+        address: null,
+        city: null,
+      }),
+    ];
+    expect(searchPosterBoards(boards, "anything")).toEqual([]);
+  });
+
+  it("returns at most POSTER_SEARCH_MAX_RESULTS results", () => {
+    const boards = Array.from(
+      { length: POSTER_SEARCH_MAX_RESULTS + 5 },
+      (_, i) => makeBoard({ id: `id-${i}`, name: "公園" }),
+    );
+    expect(searchPosterBoards(boards, "公園")).toHaveLength(
+      POSTER_SEARCH_MAX_RESULTS,
+    );
+  });
+
+  it("returns empty array when nothing matches", () => {
+    expect(searchPosterBoards([makeBoard()], "該当なし")).toEqual([]);
+  });
+});

--- a/src/features/map-poster/utils/poster-search-logic.ts
+++ b/src/features/map-poster/utils/poster-search-logic.ts
@@ -1,0 +1,60 @@
+/**
+ * テキスト検索に必要な最小限のボード情報
+ */
+interface SearchableBoard {
+  id: string;
+  number: string | number | null;
+  name: string | null;
+  address: string | null;
+  city: string | null;
+}
+
+/** 検索を開始する最小文字数 */
+export const POSTER_SEARCH_MIN_QUERY_LENGTH = 2;
+
+/** ドロップダウンに表示する検索結果の最大件数 */
+export const POSTER_SEARCH_MAX_RESULTS = 10;
+
+/**
+ * ポスター掲示板を番号・名前・住所・市区町村・ID で部分一致検索する。
+ *
+ * - 大文字小文字を区別しない
+ * - 複数フィールドを OR 検索
+ * - 最小 {@link POSTER_SEARCH_MIN_QUERY_LENGTH} 文字から検索を開始する
+ *   (それ未満のクエリは空配列を返す)
+ * - 入力順を保ったまま最大 {@link POSTER_SEARCH_MAX_RESULTS} 件を返す
+ *
+ * ID を対象に含めるのは、行政からの異常報告が掲示板 ID で行われるため
+ * (issue #911 のコメント要望)。
+ */
+export function searchPosterBoards<T extends SearchableBoard>(
+  boards: T[],
+  query: string,
+): T[] {
+  const normalized = query.trim().toLowerCase();
+  if (normalized.length < POSTER_SEARCH_MIN_QUERY_LENGTH) {
+    return [];
+  }
+
+  const results: T[] = [];
+  for (const board of boards) {
+    const fields: (string | number | null)[] = [
+      board.number,
+      board.name,
+      board.address,
+      board.city,
+      board.id,
+    ];
+    const matched = fields.some(
+      (value) =>
+        value !== null && String(value).toLowerCase().includes(normalized),
+    );
+    if (matched) {
+      results.push(board);
+      if (results.length >= POSTER_SEARCH_MAX_RESULTS) {
+        break;
+      }
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
# 変更の概要

ポスター掲示板マップに、番号・名前・住所・市区町村・ID でのテキスト検索機能を追加します。検索ボックスに文字を入力すると候補がドロップダウン表示され、選択するとその掲示板へ地図が移動（`flyTo`, zoom 18）します。目視やマップの手動移動で掲示板を探す手間を解消します。

# 変更の背景

現在はマップ上の掲示板を探す際、目視で確認するかマップを手動で移動する必要があり、特定の掲示板を素早く見つけて移動できませんでした。

Resolves #911

## 実装内容

- `src/features/map-poster/utils/poster-search-logic.ts`（＋ unit test）: `searchPosterBoards()` — 大文字小文字を区別しない部分一致 OR 検索。2 文字以上で検索開始、最大 10 件。ID も検索対象に含めています（issue コメントの「行政からの異常報告は ID で行われる」というご要望に対応）。
- `src/features/map-poster/components/poster-board-search.tsx`: 検索ボックス＋結果ドロップダウン。既存フィルタパネルと同じオーバーレイ様式。外側クリック / Escape で閉じる、クリアボタン、「該当なし」表示。
- `src/features/map-poster/components/poster-map-with-cluster.tsx`: 検索結果の選択で `flyTo`（zoom 18 / 1 秒）。既存の「現在地」ボタンと同じ map ref・パターンを再利用。検索対象は `filteredBoards`（ステータスフィルタで非表示の掲示板を指さないよう整合）。

## 配置についてのご相談

issue 本文では「統計情報の下に検索ボックスを配置」とありましたが、地図インスタンス（map ref）と掲示板リストが map コンポーネント内にあるため、既存フィルタと同様の地図オーバーレイとして配置しました（zoom コントロール＝左上、フィルタ＝右上 と干渉しないよう上部中央に配置）。「統計情報の下」への移設をご希望でしたら対応します。

# スクリーンショット

**変更前**

![before](https://raw.githubusercontent.com/yasumorishima/action-board/pr-911-screenshots/before.png)

**変更後（検索ボックス設置 / 上部中央）**

![after](https://raw.githubusercontent.com/yasumorishima/action-board/pr-911-screenshots/after.png)

**変更後（「渋谷」で検索 → ドロップダウン表示）**

![after-search](https://raw.githubusercontent.com/yasumorishima/action-board/pr-911-screenshots/after-search.png)

> 注: スクリーンショットは動作確認のためローカルにサンプル掲示板を投入して撮影したものです。

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ポスター掲示板をテキスト検索できるUIを追加しました。
  * 検索結果から掲示板を選ぶと、対象地点へ地図を移動できるようになりました。
* **改善**
  * 入力内容に応じて候補リストを表示し、外側クリックやEscキー、クリア操作で閉じられるようになりました。
  * 検索は名前、番号、住所、市区、IDの部分一致に対応し、結果件数も適切に制御されます。
* **テスト**
  * 検索条件や一致パターンを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->