### PR TITLE
本番デプロイ 7/17 13:20

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -319,7 +319,8 @@ missions:
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1
-    is_featured: false
+    is_featured: true
+    featured_importance: 9999
     is_hidden: false
     artifact_label: あなたのSlackアカウント名
     ogp_image_url: null

--- a/src/app/missions/[slug]/page.tsx
+++ b/src/app/missions/[slug]/page.tsx
@@ -240,7 +240,9 @@ export default async function MissionPage({ params, searchParams }: Props) {
               </CardDescription>
             </CardHeader>
             <CardContent className="text-center">
-              <Link href="/sign-in">
+              <Link
+                href={`/sign-in?returnUrl=${encodeURIComponent(`/missions/${slug}`)}`}
+              >
                 <Button className="w-full sm:w-auto">
                   <LogIn className="mr-2 h-4 w-4" />
                   ログインする
@@ -248,7 +250,10 @@ export default async function MissionPage({ params, searchParams }: Props) {
               </Link>
               <p className="mt-4 text-sm text-muted-foreground">
                 アカウントをお持ちでない方は{" "}
-                <Link href="/sign-up" className="text-primary hover:underline">
+                <Link
+                  href={`/sign-up?returnUrl=${encodeURIComponent(`/missions/${slug}`)}`}
+                  className="text-primary hover:underline"
+                >
                   こちらから登録
                 </Link>
               </p>

--- a/src/app/missions/[slug]/page.tsx
+++ b/src/app/missions/[slug]/page.tsx
@@ -250,10 +250,7 @@ export default async function MissionPage({ params, searchParams }: Props) {
               </Link>
               <p className="mt-4 text-sm text-muted-foreground">
                 アカウントをお持ちでない方は{" "}
-                <Link
-                  href={`/sign-up?returnUrl=${encodeURIComponent(`/missions/${slug}`)}`}
-                  className="text-primary hover:underline"
-                >
+                <Link href="/sign-up" className="text-primary hover:underline">
                   こちらから登録
                 </Link>
               </p>


### PR DESCRIPTION
# 変更の概要
- #2263 企画チームミッションを注目枠の最上位に表示（featured化・ポイント2倍）
- #2262 未ログインでミッションを直接開いた際、ログイン後に元のミッションページへ戻すよう修正

# 変更の背景
- approve済みPRの本番反映