### PR TITLE
「注目ミッション」→「🌱 はじめのミッション」に改名 + 掲載ミッションの入れ替え

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -97,7 +97,8 @@ missions:
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1
-    is_featured: false
+    is_featured: true
+    featured_importance: 300
     is_hidden: false
     artifact_label: あなたのLINEアカウント名
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//7_add_official_line.png
@@ -257,7 +258,8 @@ missions:
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1
-    is_featured: false
+    is_featured: true
+    featured_importance: 200
     is_hidden: false
     artifact_label: 参加したオープンチャット名とあなたのLINEアカウント名
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//2_join_prefecture_openchat.png
@@ -308,7 +310,8 @@ missions:
     difficulty: 1
     required_artifact_type: EMAIL
     max_achievement_count: 1
-    is_featured: false
+    is_featured: true
+    featured_importance: 100
     is_hidden: false
     artifact_label: 登録したメールアドレス
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//16_slack_join.png

--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -319,7 +319,7 @@ missions:
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1
-    is_featured: true
+    is_featured: false
     featured_importance: 9999
     is_hidden: false
     artifact_label: あなたのSlackアカウント名

--- a/src/features/missions/components/featured-missions.test.tsx
+++ b/src/features/missions/components/featured-missions.test.tsx
@@ -31,7 +31,7 @@ describe("FeaturedMissions", () => {
     const { getByTestId } = render(<FeaturedMissions {...props} />);
 
     expect(getByTestId("filter-featured")).toHaveTextContent("true");
-    expect(getByTestId("title")).toHaveTextContent("🔥 注目ミッション");
+    expect(getByTestId("title")).toHaveTextContent("🔥 はじめのミッション");
     expect(getByTestId("id")).toHaveTextContent("featured-missions");
     expect(getByTestId("user-id")).toHaveTextContent("test-user-id");
     expect(getByTestId("max-size")).toHaveTextContent("5");
@@ -55,7 +55,7 @@ describe("FeaturedMissions", () => {
 
     const { getByTestId } = render(<FeaturedMissions {...props} />);
 
-    expect(getByTestId("title")).toHaveTextContent("🔥 注目ミッション");
+    expect(getByTestId("title")).toHaveTextContent("🔥 はじめのミッション");
     expect(getByTestId("id")).toHaveTextContent("featured-missions");
   });
 

--- a/src/features/missions/components/featured-missions.test.tsx
+++ b/src/features/missions/components/featured-missions.test.tsx
@@ -31,7 +31,7 @@ describe("FeaturedMissions", () => {
     const { getByTestId } = render(<FeaturedMissions {...props} />);
 
     expect(getByTestId("filter-featured")).toHaveTextContent("true");
-    expect(getByTestId("title")).toHaveTextContent("🔥 はじめのミッション");
+    expect(getByTestId("title")).toHaveTextContent("🌱 はじめのミッション");
     expect(getByTestId("id")).toHaveTextContent("featured-missions");
     expect(getByTestId("user-id")).toHaveTextContent("test-user-id");
     expect(getByTestId("max-size")).toHaveTextContent("5");
@@ -55,7 +55,7 @@ describe("FeaturedMissions", () => {
 
     const { getByTestId } = render(<FeaturedMissions {...props} />);
 
-    expect(getByTestId("title")).toHaveTextContent("🔥 はじめのミッション");
+    expect(getByTestId("title")).toHaveTextContent("🌱 はじめのミッション");
     expect(getByTestId("id")).toHaveTextContent("featured-missions");
   });
 

--- a/src/features/missions/components/featured-missions.tsx
+++ b/src/features/missions/components/featured-missions.tsx
@@ -8,8 +8,8 @@ export default function FeaturedMissions(
     <Missions
       {...props}
       filterFeatured={true}
-      title="🔥 注目ミッション"
-      subTitle="注目ミッションは獲得ポイントが2倍となります"
+      title="🔥 はじめのミッション"
+      subTitle="はじめのミッションは獲得ポイントが2倍となります"
       id="featured-missions"
     />
   );

--- a/src/features/missions/components/featured-missions.tsx
+++ b/src/features/missions/components/featured-missions.tsx
@@ -8,7 +8,7 @@ export default function FeaturedMissions(
     <Missions
       {...props}
       filterFeatured={true}
-      title="🔥 はじめのミッション"
+      title="🌱 はじめのミッション"
       subTitle="はじめのミッションは獲得ポイントが2倍となります"
       id="featured-missions"
     />

--- a/tests/e2e/user-mission.spec.ts
+++ b/tests/e2e/user-mission.spec.ts
@@ -1,7 +1,7 @@
 import { assertAuthState, expect, test } from "../e2e-test-helpers";
 
 test.describe("アクションボード（Web版）のe2eテスト", () => {
-  test("ログイン済み状態からトップページ確認", async ({ signedInPage }) => {
+  test("ログイン済み状態からトップヘージ確認", async ({ signedInPage }) => {
     await assertAuthState(signedInPage, true);
 
     // 自身のステータス表示を確認
@@ -24,9 +24,9 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
     ).toBeVisible();
     await expect(signedInPage.getByText("サポーター数")).toBeVisible();
 
-    // 注目ミッションの表示を確認
+    // はじめのミッションの表示を確認
     await expect(
-      signedInPage.getByRole("heading", { name: /注目ミッション/ }),
+      signedInPage.getByRole("heading", { name: /はじめのミッション/ }),
     ).toBeVisible();
 
     // 活動タイムラインの表示を確認
@@ -34,7 +34,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       signedInPage.getByRole("heading", { name: /活動タイムライン/ }),
     ).toBeVisible();
 
-    // 問い合わせフォームの表示を確認
+    // 問い合るせフォームの表示を確認
     await expect(
       signedInPage.getByRole("heading", { name: "ご意見箱" }),
     ).toBeVisible();
@@ -64,17 +64,17 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
     ).toBeVisible();
   });
 
-  test("アカウントページ遷移が正常に動作する", async ({ signedInPage }) => {
+  test("アカウントヘージ遷移が正常に動作する", async ({ signedInPage }) => {
     await assertAuthState(signedInPage, true);
 
-    // アカウントページに遷移
+    // アカウントヘージに遷移
     await signedInPage.getByTestId("usermenubutton").click();
     await signedInPage.getByRole("menuitem", { name: "アカウント" }).click();
     await expect(signedInPage).toHaveURL(/\/settings\/profile/, {
       timeout: 10000,
     });
 
-    // アカウントページの表示内容を確認
+    // アカウントヘージの表示内容を確認
     await expect(signedInPage.getByText("プロフィール設定")).toBeVisible();
     await expect(signedInPage.getByText("ニックネーム")).toBeVisible();
     // 生年月日
@@ -113,10 +113,10 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
     ).toBeVisible();
   });
 
-  test("ユーザーページ遷移が正常に動作する", async ({ signedInPage }) => {
+  test("ユーザーヘージ遷移が正常に動作する", async ({ signedInPage }) => {
     await assertAuthState(signedInPage, true);
 
-    // 自身のユーザーページに遷移
+    // 自身のユーザーヘージに遷移
     await signedInPage
       .getByRole("link", { name: "テストユーザーさんのプロフィールへ" })
       .click();
@@ -124,14 +124,14 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       timeout: 10000,
     });
 
-    // 自身のユーザーページの表示内容を確認
+    // 自身のユーザーヘージの表示内容を確認
     await expect(signedInPage.getByText("テストユーザー")).toBeVisible();
   });
 
-  test("任意のユーザーページ遷移が正常に動作する", async ({ signedInPage }) => {
+  test("任意のユーザーヘージ遷移が正常に動作する", async ({ signedInPage }) => {
     await assertAuthState(signedInPage, true);
 
-    // 任意のユーザーページに遷移（ランキングから佐藤太郎のページへ）
+    // 任意のユーザーヘージに遷移（ランキングから佐藤太郎のヘージへ）
     await signedInPage
       .getByRole("link")
       .filter({ hasText: "佐藤太郎" })
@@ -141,16 +141,16 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       timeout: 10000,
     });
 
-    // 任意のユーザーページの表示内容を確認
+    // 任意のユーザーヘージの表示内容を確認
     await expect(signedInPage.getByText("佐藤太郎").first()).toBeVisible();
   });
 
-  test("ミッションページ遷移 → ミッション完了 → ミッション取消が正常に動作する", async ({
+  test("ミッションヘージ遷移 → ミッション完了 → ミッション取消が正常に動作する", async ({
     signedInPage,
   }) => {
     await assertAuthState(signedInPage, true);
 
-    // ミッションページに遷移（ゴミ拾いミッションをクリック）
+    // ミッションヘージに遷移（ゴミ拾いミッションをクリック）
     await signedInPage
       .getByRole("article")
       .filter({ hasText: "(seed) ゴミ拾いをしよう (成果物不要)" })
@@ -160,7 +160,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       timeout: 10000,
     });
 
-    // ミッションページの表示内容を確認
+    // ミッションヘージの表示内容を確認
     await expect(
       signedInPage.getByRole("button", { name: "ミッション完了を記録する" }),
     ).toBeVisible();
@@ -170,11 +170,11 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       ),
     ).toBeVisible();
 
-    // ミッション完了ページに遷移
+    // ミッション完了ヘージに遷移
     await signedInPage
       .getByRole("button", { name: "ミッション完了を記録する" })
       .click();
-    await expect(signedInPage.getByText("おめでとうございます！")).toBeVisible({
+    await expect(signedInPage.getByText("おめでとうごごいます！")).toBeVisible({
       timeout: 10000,
     });
     await signedInPage.getByRole("button", { name: "このまま閉じる" }).click();
@@ -250,7 +250,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
   }) => {
     await assertAuthState(signedInPage, true);
 
-    // ランキングページに遷移
+    // ランキングヘージに遷移
     await signedInPage.getByRole("link", { name: "トップ100を見る" }).click();
     await expect(signedInPage).toHaveURL("/ranking", { timeout: 10000 });
 

--- a/tests/e2e/user-mission.spec.ts
+++ b/tests/e2e/user-mission.spec.ts
@@ -1,7 +1,7 @@
 import { assertAuthState, expect, test } from "../e2e-test-helpers";
 
 test.describe("アクションボード（Web版）のe2eテスト", () => {
-  test("ログイン済み状態からトップヘージ確認", async ({ signedInPage }) => {
+  test("ログイン済み状態からトップページ確認", async ({ signedInPage }) => {
     await assertAuthState(signedInPage, true);
 
     // 自身のステータス表示を確認
@@ -34,7 +34,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       signedInPage.getByRole("heading", { name: /活動タイムライン/ }),
     ).toBeVisible();
 
-    // 問い合るせフォームの表示を確認
+    // 問い合わせフォームの表示を確認
     await expect(
       signedInPage.getByRole("heading", { name: "ご意見箱" }),
     ).toBeVisible();
@@ -64,17 +64,17 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
     ).toBeVisible();
   });
 
-  test("アカウントヘージ遷移が正常に動作する", async ({ signedInPage }) => {
+  test("アカウントページ遷移が正常に動作する", async ({ signedInPage }) => {
     await assertAuthState(signedInPage, true);
 
-    // アカウントヘージに遷移
+    // アカウントページに遷移
     await signedInPage.getByTestId("usermenubutton").click();
     await signedInPage.getByRole("menuitem", { name: "アカウント" }).click();
     await expect(signedInPage).toHaveURL(/\/settings\/profile/, {
       timeout: 10000,
     });
 
-    // アカウントヘージの表示内容を確認
+    // アカウントページの表示内容を確認
     await expect(signedInPage.getByText("プロフィール設定")).toBeVisible();
     await expect(signedInPage.getByText("ニックネーム")).toBeVisible();
     // 生年月日
@@ -113,10 +113,10 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
     ).toBeVisible();
   });
 
-  test("ユーザーヘージ遷移が正常に動作する", async ({ signedInPage }) => {
+  test("ユーザーページ遷移が正常に動作する", async ({ signedInPage }) => {
     await assertAuthState(signedInPage, true);
 
-    // 自身のユーザーヘージに遷移
+    // 自身のユーザーページに遷移
     await signedInPage
       .getByRole("link", { name: "テストユーザーさんのプロフィールへ" })
       .click();
@@ -124,14 +124,14 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       timeout: 10000,
     });
 
-    // 自身のユーザーヘージの表示内容を確認
+    // 自身のユーザーページの表示内容を確認
     await expect(signedInPage.getByText("テストユーザー")).toBeVisible();
   });
 
-  test("任意のユーザーヘージ遷移が正常に動作する", async ({ signedInPage }) => {
+  test("任意のユーザーページ遷移が正常に動作する", async ({ signedInPage }) => {
     await assertAuthState(signedInPage, true);
 
-    // 任意のユーザーヘージに遷移（ランキングから佐藤太郎のヘージへ）
+    // 任意のユーザーページに遷移（ランキングから佐藤太郎のページへ）
     await signedInPage
       .getByRole("link")
       .filter({ hasText: "佐藤太郎" })
@@ -141,16 +141,16 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       timeout: 10000,
     });
 
-    // 任意のユーザーヘージの表示内容を確認
+    // 任意のユーザーページの表示内容を確認
     await expect(signedInPage.getByText("佐藤太郎").first()).toBeVisible();
   });
 
-  test("ミッションヘージ遷移 → ミッション完了 → ミッション取消が正常に動作する", async ({
+  test("ミッションページ遷移 → ミッション完了 → ミッション取消が正常に動作する", async ({
     signedInPage,
   }) => {
     await assertAuthState(signedInPage, true);
 
-    // ミッションヘージに遷移（ゴミ拾いミッションをクリック）
+    // ミッションページに遷移（ゴミ拾いミッションをクリック）
     await signedInPage
       .getByRole("article")
       .filter({ hasText: "(seed) ゴミ拾いをしよう (成果物不要)" })
@@ -160,7 +160,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       timeout: 10000,
     });
 
-    // ミッションヘージの表示内容を確認
+    // ミッションページの表示内容を確認
     await expect(
       signedInPage.getByRole("button", { name: "ミッション完了を記録する" }),
     ).toBeVisible();
@@ -170,11 +170,11 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
       ),
     ).toBeVisible();
 
-    // ミッション完了ヘージに遷移
+    // ミッション完了ページに遷移
     await signedInPage
       .getByRole("button", { name: "ミッション完了を記録する" })
       .click();
-    await expect(signedInPage.getByText("おめでとうごごいます！")).toBeVisible({
+    await expect(signedInPage.getByText("おめでとうございます！")).toBeVisible({
       timeout: 10000,
     });
     await signedInPage.getByRole("button", { name: "このまま閉じる" }).click();
@@ -250,7 +250,7 @@ test.describe("アクションボード（Web版）のe2eテスト", () => {
   }) => {
     await assertAuthState(signedInPage, true);
 
-    // ランキングヘージに遷移
+    // ランキングページに遷移
     await signedInPage.getByRole("link", { name: "トップ100を見る" }).click();
     await expect(signedInPage).toHaveURL("/ranking", { timeout: 10000 });
 


### PR DESCRIPTION
## 変更内容

トップページの「注目ミッション」セクションについて、(1) 表示名の変更 と (2) 掲載ミッションの入れ替え を行います。

### 1. セクション名の変更（`featured-missions.tsx`）

| 箇所 | 変更前 | 変更後 |
| --- | --- | --- |
| 見出し | 🔥 注目ミッション | 🌱 **はじめのミッション** |
| 副題 | 注目ミッションは獲得ポイントが2倍となります | **はじめのミッション**は獲得ポイントが2倍となります |

絵文字も「はじめの一歩」が伝わる 🌱 に変更しています（依頼者の指定）。あわせて文言をアサーションしているテストも更新しました（`featured-missions.test.tsx` のユニットテスト、`tests/e2e/user-mission.spec.ts` の見出しアサーション）。

### 2. 掲載ミッションの入れ替え（`missions.yaml`）

| ミッション | slug | 変更 |
| --- | --- | --- |
| 企画チームのメンバーになろう | `join-planning-team` | `is_featured: true → false`（枠から外す） |
| サポーター公式LINEに入ろう | `add-supporter-line-friend` | `is_featured: false → true` / `featured_importance: 300` |
| 都道府県別LINEオープンチャットに入ろう | `join-prefecture-openchat` | `is_featured: false → true` / `featured_importance: 200` |
| サポーターSlackに入ろう | `join-slack` | `is_featured: false → true` / `featured_importance: 100` |

表示順は `featured_importance` 降順なので **サポーター公式LINE → 都道府県別LINEオープンチャット → サポーターSlack** の順に並びます。

## 背景 / 依頼

組織活動本部（湯田瑞希さん）からの依頼です。

1. 7/18 の党大会に合わせて注目枠に出していた「企画チームのメンバーになろう」の役目が済んだので、一般ミッションに下げる。
2. 枠自体は残し、代わりにコミュニティ導線の 3 ミッションを掲載する。
3. セクション名を、新規サポーターが最初に取り組む導線であることが伝わる「🌱 はじめのミッション」に変更する。

## 影響 / 補足

- 枠に入るミッションは引き続き **獲得 XP が 2 倍**（`calculateMissionXp(difficulty, is_featured)`、カードに「x 2」バッジ）です。今回掲載する 3 件はいずれも難易度 1 / `max_achievement_count: 1` の 1 回きりミッションです。
- 内部の識別子（`is_featured` / `featured_importance` カラム、セクションの `id="featured-missions"`、`FeaturedMissions` コンポーネント名）は変更していません。表示文言のみの変更で、DB マイグレーションは不要です。
- `is_featured` の意味を説明しているコード内コメント（`level.ts` など）や過去のマイグレーションのカラムコメントは、この PR のスコープ外として触っていません。
- `join-planning-team` は公開のまま（`is_hidden: false`）で、カテゴリ「コミュニティに参加しよう」の先頭（`sort_no: 50`）に掲載されます。URL `/missions/join-planning-team` も変わらないので、配布済みのリンク・QR はそのまま使えます。
- ミッションデータの反映は `npm run mission:sync`（CI/CD デプロイ時に自動実行）経由です。

## 確認したこと

- `yaml.safe_load` でパース確認済み（missions 71 件、`is_featured: true` は 3 件で表示順は上記のとおり）。掲載 3 件はいずれも `is_hidden: false`（注目枠のクエリは `is_hidden=false` かつ `is_featured=true` が対象）。
- 文言をアサーションしている箇所をリポジトリ全体で洗い出し、ユニットテストと e2e の両方を更新済み（`grep` で UI / テスト側に旧文言の残りが無いことを確認）。
- 各コミット後に GitHub 上のファイルを取得し直し、意図した差分以外がバイト単位で変わっていないことを検証しています。途中のコミットで e2e ファイルに文字化けを混入させてしまいましたが、後続コミットで修正済みです（現在の差分は 4 ファイル・各 2〜11 行のみ）。

<!-- mirai-inu-session: sesn_01CoQXVUibYdwn5vDuNA2sRV -->
