### PR TITLE
トップページに「🚩 はじめのミッション」セクションを追加（はじめの > 注目 > ミッションの3段構成）

### DIFF
--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -4,6 +4,7 @@ import Hero from "@/components/top/hero";
 import { PrefectureTeamCard } from "@/components/top/prefecture-team-card";
 import { MetricsWithSuspense } from "@/features/metrics/components/metrics-with-suspense";
 import FeaturedMissions from "@/features/missions/components/featured-missions";
+import FirstMissions from "@/features/missions/components/first-missions";
 import MissionsByCategory from "@/features/missions/components/missions-by-category";
 import { hasFeaturedMissions } from "@/features/missions/services/missions";
 import RankingSection from "@/features/ranking/components/ranking-section";
@@ -106,6 +107,11 @@ export default async function Home({
         <RankingSection />
       </section>
       <div className="w-full md:container md:mx-auto">
+        {/* はじめのミッションセクション */}
+        <section className="py-12 md:py-16 bg-background">
+          <FirstMissions userId={user?.id} showAchievedMissions={true} />
+        </section>
+
         {/* フューチャードミッションセクション */}
         {showFeatured && (
           <section className="py-12 md:py-16 bg-background">

--- a/src/features/missions/components/first-missions.test.tsx
+++ b/src/features/missions/components/first-missions.test.tsx
@@ -1,0 +1,52 @@
+import { render } from "@testing-library/react";
+import FirstMissions, { FIRST_MISSION_SLUGS } from "./first-missions";
+
+jest.mock("./mission-list", () => {
+  return function MockMissions(props: any) {
+    return (
+      <div data-testid="missions-component">
+        <div data-testid="filter-slugs">{props.filterSlugs?.join(",")}</div>
+        <div data-testid="title">{props.title}</div>
+        <div data-testid="id">{props.id}</div>
+        <div data-testid="user-id">{props.userId}</div>
+        <div data-testid="show-achieved">
+          {props.showAchievedMissions?.toString()}
+        </div>
+      </div>
+    );
+  };
+});
+
+describe("FirstMissions", () => {
+  it("Missionsコンポーネントに正しいpropsが渡される", () => {
+    const props = {
+      userId: "test-user-id",
+      showAchievedMissions: true,
+    };
+
+    const { getByTestId } = render(<FirstMissions {...props} />);
+
+    expect(getByTestId("title")).toHaveTextContent("🚩 はじめのミッション");
+    expect(getByTestId("id")).toHaveTextContent("first-missions");
+    expect(getByTestId("user-id")).toHaveTextContent("test-user-id");
+    expect(getByTestId("show-achieved")).toHaveTextContent("true");
+  });
+
+  it("指定した3ミッションが指定の並び順で渡される", () => {
+    const { getByTestId } = render(
+      <FirstMissions showAchievedMissions={true} />,
+    );
+
+    expect(getByTestId("filter-slugs")).toHaveTextContent(
+      "add-supporter-line-friend,join-prefecture-openchat,join-slack",
+    );
+  });
+
+  it("FIRST_MISSION_SLUGSの並び順が仕様どおりである", () => {
+    expect([...FIRST_MISSION_SLUGS]).toEqual([
+      "add-supporter-line-friend",
+      "join-prefecture-openchat",
+      "join-slack",
+    ]);
+  });
+});

--- a/src/features/missions/components/first-missions.tsx
+++ b/src/features/missions/components/first-missions.tsx
@@ -1,0 +1,22 @@
+import Missions, { type MissionsProps } from "./mission-list";
+
+// はじめのミッションに表示するミッション（この配列の並び順で表示される）
+export const FIRST_MISSION_SLUGS = [
+  "add-supporter-line-friend",
+  "join-prefecture-openchat",
+  "join-slack",
+] as const;
+
+//コードの2重管理回避のためmission-list.tsxを参照する
+export default function FirstMissions(
+  props: Omit<MissionsProps, "filterSlugs">,
+) {
+  return (
+    <Missions
+      {...props}
+      filterSlugs={FIRST_MISSION_SLUGS}
+      title="🚩 はじめのミッション"
+      id="first-missions"
+    />
+  );
+}

--- a/src/features/missions/components/mission-list.tsx
+++ b/src/features/missions/components/mission-list.tsx
@@ -12,6 +12,7 @@ export type MissionsProps = {
   maxSize?: number;
   showAchievedMissions: boolean;
   filterFeatured?: boolean;
+  filterSlugs?: readonly string[];
   title?: string;
   subTitle?: string;
   id?: string;
@@ -22,6 +23,7 @@ export default async function Missions({
   maxSize,
   showAchievedMissions,
   filterFeatured,
+  filterSlugs,
   title = "📈 ミッション",
   subTitle,
   id,
@@ -40,6 +42,7 @@ export default async function Missions({
   // ミッション一覧を取得
   const missions = await getMissionsWithFilter({
     filterFeatured,
+    filterSlugs,
     excludeMissionIds: showAchievedMissions ? [] : achievedMissionIds,
     maxSize,
   });

--- a/src/features/missions/services/missions.ts
+++ b/src/features/missions/services/missions.ts
@@ -139,6 +139,8 @@ export async function getPostingCountsForMissions(
 
 export interface GetMissionsFilterOptions {
   filterFeatured?: boolean;
+  /** 指定した slug のミッションのみを、この配列の並び順で返す */
+  filterSlugs?: readonly string[];
   excludeMissionIds?: string[];
   maxSize?: number;
 }
@@ -149,7 +151,12 @@ export interface GetMissionsFilterOptions {
 export async function getMissionsWithFilter(
   options: GetMissionsFilterOptions = {},
 ): Promise<Tables<"missions">[]> {
-  const { filterFeatured = false, excludeMissionIds = [], maxSize } = options;
+  const {
+    filterFeatured = false,
+    filterSlugs,
+    excludeMissionIds = [],
+    maxSize,
+  } = options;
 
   const supabase = createClient();
 
@@ -159,6 +166,10 @@ export async function getMissionsWithFilter(
     query = query
       .eq("is_featured", true)
       .order("featured_importance", { ascending: false, nullsFirst: false });
+  }
+
+  if (filterSlugs) {
+    query = query.in("slug", [...filterSlugs]);
   }
 
   query = query
@@ -178,6 +189,15 @@ export async function getMissionsWithFilter(
   if (error) {
     console.error("Error fetching missions:", error);
     throw error;
+  }
+
+  if (filterSlugs) {
+    const slugOrder = new Map(filterSlugs.map((slug, index) => [slug, index]));
+    return [...(missions ?? [])].sort(
+      (a, b) =>
+        (slugOrder.get(a.slug) ?? Number.MAX_SAFE_INTEGER) -
+        (slugOrder.get(b.slug) ?? Number.MAX_SAFE_INTEGER),
+    );
   }
 
   return missions ?? [];


### PR DESCRIPTION
## やりたいこと

トップページのミッション表示を **「🚩 はじめのミッション」→「🔥 注目ミッション」→「🎯 ミッション」の 3 段構成**にします。新規サポーターが最初に踏む導線を、注目ミッションより上の最上部に固定で置くのが目的です。

## 仕様

- 「🚩 はじめのミッション」セクションを注目ミッションの**上**に新設
- セクション内には既存の 3 ミッションを、この並び順で表示
  1. サポーター公式LINEに入ろう（`add-supporter-line-friend`）
  2. 都道府県別LINEオープンチャットに入ろう（`join-prefecture-openchat`）
  3. サポーターSlackに入ろう（`join-slack`）

依頼元: 組織活動本部（湯田瑞希さん）

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `src/features/missions/components/first-missions.tsx` | **新規**。既存の `FeaturedMissions` と同じく `mission-list.tsx` を再利用する薄いラッパー。表示するミッションを `FIRST_MISSION_SLUGS` で固定し、見出しは「🚩 はじめのミッション」、アンカーは `id="first-missions"` |
| `src/features/missions/components/mission-list.tsx` | `MissionsProps` に `filterSlugs?: readonly string[]` を追加し、取得処理に渡すだけ |
| `src/features/missions/services/missions.ts` | `getMissionsWithFilter` に `filterSlugs` を追加（`.in("slug", ...)` で絞り込み、**渡した配列の並び順**で返す） |
| `src/app/home.tsx` | 注目ミッションセクションの上に「はじめのミッション」セクションを追加 |
| `src/features/missions/components/first-missions.test.tsx` | **新規**。渡される props と 3 ミッションの並び順を検証 |

### 実装方針について

- 掲載する 3 件は **コード側の slug 配列で固定**しました（`is_featured` は使わない）。
  - 注目ミッション枠と独立させたかったため。`is_featured` を使うと注目枠と同じ集合になり、**獲得 XP が 2 倍**になる副作用も付いてきます。はじめのミッションは通常の XP のままにしています。
  - 新規カテゴリ（`categories.yaml`）で表現する案もありますが、その場合は「このカテゴリだけ最上部の独立セクションとして描画し、`🎯 ミッション` 側からは除外する」分岐が必要で、変更が広くなるため見送りました。掲載ミッションを YAML から差し替えたいご要望があれば、そちらに寄せる形で作り直せます。
- 既存の「注目ミッション」セクションは**一切変更していません**（名称・掲載ミッション・XP 2 倍の仕様そのまま）。`missions.yaml` も変更なしです。
- セクションは達成済みでも表示され続けます（`showAchievedMissions={true}`。注目ミッションと同じ挙動）。

## 確認したこと（ローカル実行）

- `pnpm run typecheck`（`tsc --noEmit`）… パス
- `pnpm run biome:check:write` … 変更ファイルに差分・指摘なし
- `npx jest src/features/missions` … **14 suites / 117 tests パス**（新規テストを含む）
- e2e は環境が必要なため未実行です。既存の e2e（`tests/e2e/user-mission.spec.ts`）は「注目ミッション」見出しの表示を確認するテストで、その見出しは変わらないため影響しない想定です。

<!-- mirai-inu-session: sesn_01CoQXVUibYdwn5vDuNA2sRV -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ホーム画面に「はじめのミッション」セクションを追加しました。
  - サポート用LINE公式アカウントの追加、都道府県別オープンチャットへの参加、Slackへの参加を、指定順で表示します。
  - ミッションを指定した条件で絞り込み、設定された順序で表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->