### PR TITLE
トップページに「🚩 はじめのミッション」セクションを追加（達成済み非表示・全達成でセクションごと非表示）

### DIFF
--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -107,10 +107,8 @@ export default async function Home({
         <RankingSection />
       </section>
       <div className="w-full md:container md:mx-auto">
-        {/* はじめのミッションセクション */}
-        <section className="py-12 md:py-16 bg-background">
-          <FirstMissions userId={user?.id} showAchievedMissions={true} />
-        </section>
+        {/* はじめのミッションセクション（すべて達成済みならセクションごと非表示） */}
+        <FirstMissions userId={user?.id} />
 
         {/* フューチャードミッションセクション */}
         {showFeatured && (

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -4,6 +4,7 @@ import Hero from "@/components/top/hero";
 import { PrefectureTeamCard } from "@/components/top/prefecture-team-card";
 import { MetricsWithSuspense } from "@/features/metrics/components/metrics-with-suspense";
 import FeaturedMissions from "@/features/missions/components/featured-missions";
+import FirstMissions from "@/features/missions/components/first-missions";
 import MissionsByCategory from "@/features/missions/components/missions-by-category";
 import { hasFeaturedMissions } from "@/features/missions/services/missions";
 import RankingSection from "@/features/ranking/components/ranking-section";
@@ -106,6 +107,11 @@ export default async function Home({
         <RankingSection />
       </section>
       <div className="w-full md:container md:mx-auto">
+        {/* はじめのミッションセクション */}
+        <section className="py-12 md:py-16 bg-background">
+          <FirstMissions userId={user?.id} showAchievedMissions={true} />
+        </section>
+
         {/* フューチャードミッションセクション */}
         {showFeatured && (
           <section className="py-12 md:py-16 bg-background">

--- a/src/features/missions/components/first-missions.test.tsx
+++ b/src/features/missions/components/first-missions.test.tsx
@@ -1,0 +1,52 @@
+import { render } from "@testing-library/react";
+import FirstMissions, { FIRST_MISSION_SLUGS } from "./first-missions";
+
+jest.mock("./mission-list", () => {
+  return function MockMissions(props: any) {
+    return (
+      <div data-testid="missions-component">
+        <div data-testid="filter-slugs">{props.filterSlugs?.join(",")}</div>
+        <div data-testid="title">{props.title}</div>
+        <div data-testid="id">{props.id}</div>
+        <div data-testid="user-id">{props.userId}</div>
+        <div data-testid="show-achieved">
+          {props.showAchievedMissions?.toString()}
+        </div>
+      </div>
+    );
+  };
+});
+
+describe("FirstMissions", () => {
+  it("Missionsコンポーネントに正しいpropsが渡される", () => {
+    const props = {
+      userId: "test-user-id",
+      showAchievedMissions: true,
+    };
+
+    const { getByTestId } = render(<FirstMissions {...props} />);
+
+    expect(getByTestId("title")).toHaveTextContent("🚩 はじめのミッション");
+    expect(getByTestId("id")).toHaveTextContent("first-missions");
+    expect(getByTestId("user-id")).toHaveTextContent("test-user-id");
+    expect(getByTestId("show-achieved")).toHaveTextContent("true");
+  });
+
+  it("指定した3ミッションが指定の並び順で渡される", () => {
+    const { getByTestId } = render(
+      <FirstMissions showAchievedMissions={true} />,
+    );
+
+    expect(getByTestId("filter-slugs")).toHaveTextContent(
+      "add-supporter-line-friend,join-prefecture-openchat,join-slack",
+    );
+  });
+
+  it("FIRST_MISSION_SLUGSの並び順が仕様どおりである", () => {
+    expect([...FIRST_MISSION_SLUGS]).toEqual([
+      "add-supporter-line-friend",
+      "join-prefecture-openchat",
+      "join-slack",
+    ]);
+  });
+});

--- a/src/features/missions/components/first-missions.test.tsx
+++ b/src/features/missions/components/first-missions.test.tsx
@@ -1,5 +1,15 @@
 import { render } from "@testing-library/react";
+import { getMissionsWithFilter } from "@/features/missions/loaders/missions-loaders";
+import { getUserMissionAchievements } from "@/features/user-achievements/loaders/achievements-loaders";
 import FirstMissions, { FIRST_MISSION_SLUGS } from "./first-missions";
+
+jest.mock("@/features/missions/loaders/missions-loaders", () => ({
+  getMissionsWithFilter: jest.fn(),
+}));
+
+jest.mock("@/features/user-achievements/loaders/achievements-loaders", () => ({
+  getUserMissionAchievements: jest.fn(),
+}));
 
 jest.mock("./mission-list", () => {
   return function MockMissions(props: any) {
@@ -17,29 +27,89 @@ jest.mock("./mission-list", () => {
   };
 });
 
-describe("FirstMissions", () => {
-  it("Missionsコンポーネントに正しいpropsが渡される", () => {
-    const props = {
-      userId: "test-user-id",
-      showAchievedMissions: true,
-    };
+const mockGetMissionsWithFilter = getMissionsWithFilter as jest.Mock;
+const mockGetUserMissionAchievements = getUserMissionAchievements as jest.Mock;
 
-    const { getByTestId } = render(<FirstMissions {...props} />);
+const missionOf = (id: string, slug: string) => ({ id, slug });
+
+describe("FirstMissions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserMissionAchievements.mockResolvedValue(new Map());
+    mockGetMissionsWithFilter.mockResolvedValue([
+      missionOf("mission-1", "add-supporter-line-friend"),
+    ]);
+  });
+
+  it("Missionsコンポーネントに正しいpropsが渡される", async () => {
+    const component = await FirstMissions({ userId: "test-user-id" });
+
+    const { getByTestId } = render(component);
 
     expect(getByTestId("title")).toHaveTextContent("🚩 はじめのミッション");
     expect(getByTestId("id")).toHaveTextContent("first-missions");
     expect(getByTestId("user-id")).toHaveTextContent("test-user-id");
-    expect(getByTestId("show-achieved")).toHaveTextContent("true");
   });
 
-  it("指定した3ミッションが指定の並び順で渡される", () => {
-    const { getByTestId } = render(
-      <FirstMissions showAchievedMissions={true} />,
-    );
+  it("指定した3ミッションが指定の並び順で渡される", async () => {
+    const component = await FirstMissions({});
+
+    const { getByTestId } = render(component);
 
     expect(getByTestId("filter-slugs")).toHaveTextContent(
       "add-supporter-line-friend,join-prefecture-openchat,join-slack",
     );
+  });
+
+  it("達成済みのミッションは表示しない（showAchievedMissions=false）", async () => {
+    const component = await FirstMissions({ userId: "test-user-id" });
+
+    const { getByTestId } = render(component);
+
+    expect(getByTestId("show-achieved")).toHaveTextContent("false");
+  });
+
+  it("未達成のミッションが残っていればセクションを描画する", async () => {
+    mockGetUserMissionAchievements.mockResolvedValue(
+      new Map([["mission-1", 1]]),
+    );
+    mockGetMissionsWithFilter.mockResolvedValue([
+      missionOf("mission-2", "join-prefecture-openchat"),
+    ]);
+
+    const component = await FirstMissions({ userId: "test-user-id" });
+
+    expect(component).not.toBeNull();
+    expect(mockGetMissionsWithFilter).toHaveBeenCalledWith({
+      filterSlugs: FIRST_MISSION_SLUGS,
+      excludeMissionIds: ["mission-1"],
+    });
+  });
+
+  it("すべて達成済みならセクションごと描画しない", async () => {
+    mockGetUserMissionAchievements.mockResolvedValue(
+      new Map([
+        ["mission-1", 1],
+        ["mission-2", 1],
+        ["mission-3", 1],
+      ]),
+    );
+    mockGetMissionsWithFilter.mockResolvedValue([]);
+
+    const component = await FirstMissions({ userId: "test-user-id" });
+
+    expect(component).toBeNull();
+  });
+
+  it("未ログイン時は達成済み判定なしで全ミッションを表示する", async () => {
+    const component = await FirstMissions({});
+
+    expect(component).not.toBeNull();
+    expect(mockGetUserMissionAchievements).not.toHaveBeenCalled();
+    expect(mockGetMissionsWithFilter).toHaveBeenCalledWith({
+      filterSlugs: FIRST_MISSION_SLUGS,
+      excludeMissionIds: [],
+    });
   });
 
   it("FIRST_MISSION_SLUGSの並び順が仕様どおりである", () => {

--- a/src/features/missions/components/first-missions.tsx
+++ b/src/features/missions/components/first-missions.tsx
@@ -1,0 +1,22 @@
+import Missions, { type MissionsProps } from "./mission-list";
+
+// はじめのミッションに表示するミッション（この配列の並び順で表示される）
+export const FIRST_MISSION_SLUGS = [
+  "add-supporter-line-friend",
+  "join-prefecture-openchat",
+  "join-slack",
+] as const;
+
+//コードの2重管理回避のためmission-list.tsxを参照する
+export default function FirstMissions(
+  props: Omit<MissionsProps, "filterSlugs">,
+) {
+  return (
+    <Missions
+      {...props}
+      filterSlugs={FIRST_MISSION_SLUGS}
+      title="🚩 はじめのミッション"
+      id="first-missions"
+    />
+  );
+}

--- a/src/features/missions/components/first-missions.tsx
+++ b/src/features/missions/components/first-missions.tsx
@@ -1,4 +1,6 @@
-import Missions, { type MissionsProps } from "./mission-list";
+import { getMissionsWithFilter } from "@/features/missions/loaders/missions-loaders";
+import { getUserMissionAchievements } from "@/features/user-achievements/loaders/achievements-loaders";
+import Missions from "./mission-list";
 
 // はじめのミッションに表示するミッション（この配列の並び順で表示される）
 export const FIRST_MISSION_SLUGS = [
@@ -7,16 +9,35 @@ export const FIRST_MISSION_SLUGS = [
   "join-slack",
 ] as const;
 
+type FirstMissionsProps = {
+  userId?: string;
+};
+
 //コードの2重管理回避のためmission-list.tsxを参照する
-export default function FirstMissions(
-  props: Omit<MissionsProps, "filterSlugs">,
-) {
+export default async function FirstMissions({ userId }: FirstMissionsProps) {
+  // 達成済みは非表示なので、3件すべて達成するとこのセクションは空になる。
+  // 空のセクションだけが余白付きで残らないよう、その場合はセクションごと描画しない
+  const achievedMissionIds = userId
+    ? Array.from((await getUserMissionAchievements(userId)).keys())
+    : [];
+  const unachievedMissions = await getMissionsWithFilter({
+    filterSlugs: FIRST_MISSION_SLUGS,
+    excludeMissionIds: achievedMissionIds,
+  });
+
+  if (unachievedMissions.length === 0) {
+    return null;
+  }
+
   return (
-    <Missions
-      {...props}
-      filterSlugs={FIRST_MISSION_SLUGS}
-      title="🚩 はじめのミッション"
-      id="first-missions"
-    />
+    <section className="py-12 md:py-16 bg-background">
+      <Missions
+        userId={userId}
+        showAchievedMissions={false}
+        filterSlugs={FIRST_MISSION_SLUGS}
+        title="🚩 はじめのミッション"
+        id="first-missions"
+      />
+    </section>
   );
 }

--- a/src/features/missions/components/mission-list.tsx
+++ b/src/features/missions/components/mission-list.tsx
@@ -12,6 +12,7 @@ export type MissionsProps = {
   maxSize?: number;
   showAchievedMissions: boolean;
   filterFeatured?: boolean;
+  filterSlugs?: readonly string[];
   title?: string;
   subTitle?: string;
   id?: string;
@@ -22,6 +23,7 @@ export default async function Missions({
   maxSize,
   showAchievedMissions,
   filterFeatured,
+  filterSlugs,
   title = "📈 ミッション",
   subTitle,
   id,
@@ -40,6 +42,7 @@ export default async function Missions({
   // ミッション一覧を取得
   const missions = await getMissionsWithFilter({
     filterFeatured,
+    filterSlugs,
     excludeMissionIds: showAchievedMissions ? [] : achievedMissionIds,
     maxSize,
   });

--- a/src/features/missions/services/missions.test.ts
+++ b/src/features/missions/services/missions.test.ts
@@ -1,0 +1,176 @@
+import { createAdminClient } from "@/lib/supabase/adminClient";
+import { getMissionsWithFilter } from "./missions";
+
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<
+  typeof createAdminClient
+>;
+
+type SupabaseAdminClient = Awaited<ReturnType<typeof createAdminClient>>;
+type QueryResult = { data: unknown[] | null; error: unknown };
+
+/**
+ * supabase-js のクエリビルダを模したチェーン可能なモック。
+ * await された時点で result を返し、呼ばれたメソッドと引数を calls に記録する
+ */
+function createQueryBuilderMock(result: QueryResult) {
+  const calls: Record<string, unknown[][]> = {};
+  const record =
+    (name: string) =>
+    (...args: unknown[]) => {
+      if (!calls[name]) {
+        calls[name] = [];
+      }
+      calls[name].push(args);
+      return builder;
+    };
+
+  const builder = {
+    select: record("select"),
+    eq: record("eq"),
+    in: record("in"),
+    order: record("order"),
+    not: record("not"),
+    limit: record("limit"),
+    then: (
+      onFulfilled?: (value: QueryResult) => unknown,
+      onRejected?: (reason: unknown) => unknown,
+    ) => Promise.resolve(result).then(onFulfilled, onRejected),
+  };
+
+  return { builder, calls };
+}
+
+function setupAdminClient(result: QueryResult) {
+  const { builder, calls } = createQueryBuilderMock(result);
+  const from = jest.fn(() => builder);
+  mockCreateAdminClient.mockResolvedValue({
+    from,
+  } as unknown as SupabaseAdminClient);
+  return { calls, from };
+}
+
+const missionOf = (slug: string) => ({ id: `id-${slug}`, slug });
+
+const FIRST_SLUGS = [
+  "add-supporter-line-friend",
+  "join-prefecture-openchat",
+  "join-slack",
+];
+
+describe("getMissionsWithFilter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("DB操作には createAdminClient を使う", async () => {
+    const { from } = setupAdminClient({ data: [], error: null });
+
+    await getMissionsWithFilter();
+
+    expect(mockCreateAdminClient).toHaveBeenCalledTimes(1);
+    expect(from).toHaveBeenCalledWith("missions");
+  });
+
+  it("filterSlugs で絞り込み、DBの並び順に関係なく指定した並び順で返す", async () => {
+    // DBからは difficulty / created_at 順（= 指定順とは異なる順）で返ってくる
+    const { calls } = setupAdminClient({
+      data: [
+        missionOf("join-slack"),
+        missionOf("add-supporter-line-friend"),
+        missionOf("join-prefecture-openchat"),
+      ],
+      error: null,
+    });
+
+    const result = await getMissionsWithFilter({ filterSlugs: FIRST_SLUGS });
+
+    expect(calls.in).toEqual([["slug", FIRST_SLUGS]]);
+    expect(result.map((m) => m.slug)).toEqual(FIRST_SLUGS);
+  });
+
+  it("filterSlugs と maxSize の併用時は、指定順に並べ替えた後で maxSize を適用する", async () => {
+    // DB側で limit(2) されると first が落ちて third が残ってしまう並び順を模す
+    const { calls } = setupAdminClient({
+      data: [missionOf("third"), missionOf("second"), missionOf("first")],
+      error: null,
+    });
+
+    const result = await getMissionsWithFilter({
+      filterSlugs: ["first", "second", "third"],
+      maxSize: 2,
+    });
+
+    // 並べ替え前に切り落とさないよう、DB側では limit していない
+    expect(calls.limit).toBeUndefined();
+    expect(result.map((m) => m.slug)).toEqual(["first", "second"]);
+  });
+
+  it("filterSlugs 未指定なら DB 側で limit する", async () => {
+    const { calls } = setupAdminClient({
+      data: [missionOf("a")],
+      error: null,
+    });
+
+    await getMissionsWithFilter({ maxSize: 5 });
+
+    expect(calls.limit).toEqual([[5]]);
+  });
+
+  it("filterSlugs に含まれない slug が混ざっていても末尾に回す", async () => {
+    setupAdminClient({
+      data: [missionOf("unknown"), missionOf("second"), missionOf("first")],
+      error: null,
+    });
+
+    const result = await getMissionsWithFilter({
+      filterSlugs: ["first", "second"],
+    });
+
+    expect(result.map((m) => m.slug)).toEqual(["first", "second", "unknown"]);
+  });
+
+  it("filterSlugs 指定時に該当ミッションが0件なら空配列を返す", async () => {
+    setupAdminClient({ data: [], error: null });
+
+    const result = await getMissionsWithFilter({ filterSlugs: FIRST_SLUGS });
+
+    expect(result).toEqual([]);
+  });
+
+  it("filterFeatured 指定時は is_featured で絞り込む", async () => {
+    const { calls } = setupAdminClient({ data: [], error: null });
+
+    await getMissionsWithFilter({ filterFeatured: true });
+
+    expect(calls.eq).toEqual([
+      ["is_hidden", false],
+      ["is_featured", true],
+    ]);
+  });
+
+  it("excludeMissionIds 指定時は該当IDを除外する", async () => {
+    const { calls } = setupAdminClient({ data: [], error: null });
+
+    await getMissionsWithFilter({ excludeMissionIds: ["m1", "m2"] });
+
+    expect(calls.not).toEqual([["id", "in", '("m1","m2")']]);
+  });
+
+  it("data が null でも空配列を返す", async () => {
+    setupAdminClient({ data: null, error: null });
+
+    await expect(getMissionsWithFilter()).resolves.toEqual([]);
+  });
+
+  it("取得エラー時は throw する", async () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const error = new Error("取得失敗");
+    setupAdminClient({ data: null, error });
+
+    await expect(getMissionsWithFilter()).rejects.toThrow("取得失敗");
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/features/missions/services/missions.ts
+++ b/src/features/missions/services/missions.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { createAdminClient } from "@/lib/supabase/adminClient";
 import { createClient } from "@/lib/supabase/client";
 import type { Tables } from "@/lib/types/supabase";
 
@@ -158,7 +159,7 @@ export async function getMissionsWithFilter(
     maxSize,
   } = options;
 
-  const supabase = createClient();
+  const supabase = await createAdminClient();
 
   let query = supabase.from("missions").select().eq("is_hidden", false);
 
@@ -180,7 +181,9 @@ export async function getMissionsWithFilter(
     query = query.not("id", "in", `("${excludeMissionIds.join('","')}")`);
   }
 
-  if (maxSize) {
+  // filterSlugs 指定時は取得後に指定順へ並べ替えるため、DB側で limit すると
+  // 並べ替え前に上位のミッションが切り落とされてしまう。並べ替えた後に絞り込む
+  if (maxSize && !filterSlugs) {
     query = query.limit(maxSize);
   }
 
@@ -193,11 +196,12 @@ export async function getMissionsWithFilter(
 
   if (filterSlugs) {
     const slugOrder = new Map(filterSlugs.map((slug, index) => [slug, index]));
-    return [...(missions ?? [])].sort(
+    const sorted = [...(missions ?? [])].sort(
       (a, b) =>
         (slugOrder.get(a.slug) ?? Number.MAX_SAFE_INTEGER) -
         (slugOrder.get(b.slug) ?? Number.MAX_SAFE_INTEGER),
     );
+    return maxSize ? sorted.slice(0, maxSize) : sorted;
   }
 
   return missions ?? [];

--- a/src/features/missions/services/missions.ts
+++ b/src/features/missions/services/missions.ts
@@ -139,6 +139,8 @@ export async function getPostingCountsForMissions(
 
 export interface GetMissionsFilterOptions {
   filterFeatured?: boolean;
+  /** 指定した slug のミッションのみを、この配列の並び順で返す */
+  filterSlugs?: readonly string[];
   excludeMissionIds?: string[];
   maxSize?: number;
 }
@@ -149,7 +151,12 @@ export interface GetMissionsFilterOptions {
 export async function getMissionsWithFilter(
   options: GetMissionsFilterOptions = {},
 ): Promise<Tables<"missions">[]> {
-  const { filterFeatured = false, excludeMissionIds = [], maxSize } = options;
+  const {
+    filterFeatured = false,
+    filterSlugs,
+    excludeMissionIds = [],
+    maxSize,
+  } = options;
 
   const supabase = createClient();
 
@@ -159,6 +166,10 @@ export async function getMissionsWithFilter(
     query = query
       .eq("is_featured", true)
       .order("featured_importance", { ascending: false, nullsFirst: false });
+  }
+
+  if (filterSlugs) {
+    query = query.in("slug", [...filterSlugs]);
   }
 
   query = query
@@ -178,6 +189,15 @@ export async function getMissionsWithFilter(
   if (error) {
     console.error("Error fetching missions:", error);
     throw error;
+  }
+
+  if (filterSlugs) {
+    const slugOrder = new Map(filterSlugs.map((slug, index) => [slug, index]));
+    return [...(missions ?? [])].sort(
+      (a, b) =>
+        (slugOrder.get(a.slug) ?? Number.MAX_SAFE_INTEGER) -
+        (slugOrder.get(b.slug) ?? Number.MAX_SAFE_INTEGER),
+    );
   }
 
   return missions ?? [];


### PR DESCRIPTION
## やりたいこと

トップページのミッション表示を **「🚩 はじめのミッション」→「🔥 注目ミッション」→「🎯 ミッション」の 3 段構成**にします。新規サポーターが最初に踏む導線を、注目ミッションより上の最上部に固定で置くのが目的です。

依頼元: 組織活動本部（湯田瑞希さん）

> [!NOTE]
> #2269 の後継PRです。#2269 は fork（`mirai-inu`）からのPRで `maintainerCanModify: false` のため追加コミットを push できず、同じコミット列＋レビュー対応をこのリポジトリのブランチに載せ直しました。#2269 はこちらをマージ後にクローズしてください。

## 仕様

- 「🚩 はじめのミッション」セクションを注目ミッションの**上**に新設
- セクション内には既存の 3 ミッションを、この並び順で表示
  1. サポーター公式LINEに入ろう（`add-supporter-line-friend`）
  2. 都道府県別LINEオープンチャットに入ろう（`join-prefecture-openchat`）
  3. サポーターSlackに入ろう（`join-slack`）
- **クリア済みのミッションは非表示**
- **3件すべてクリアしたらセクションごと非表示**（見出しも余白も残さない）

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `src/features/missions/components/first-missions.tsx` | **新規**。`mission-list.tsx` を再利用する薄いラッパー。表示するミッションを `FIRST_MISSION_SLUGS` で固定し、見出しは「🚩 はじめのミッション」、アンカーは `id="first-missions"`。未達成が0件なら `null` を返す |
| `src/features/missions/components/mission-list.tsx` | `MissionsProps` に `filterSlugs?: readonly string[]` を追加し、取得処理に渡すだけ |
| `src/features/missions/services/missions.ts` | `getMissionsWithFilter` に `filterSlugs` を追加（`.in("slug", ...)` で絞り込み、**渡した配列の並び順**で返す） |
| `src/app/home.tsx` | 注目ミッションセクションの上に `<FirstMissions />` を追加 |
| `src/features/missions/components/first-missions.test.tsx` | **新規**。渡される props・3ミッションの並び順・達成済み非表示・全達成時の非表示を検証 |
| `src/features/missions/services/missions.test.ts` | **新規**。`getMissionsWithFilter` の slug 指定順への並べ替えと `maxSize` の適用順を直接検証（10ケース） |

### 達成済みの出し分けについて

- `showAchievedMissions={false}` は **`FirstMissions` 側の仕様として固定**しています（呼び出し側から `true` にできない）。「はじめのミッション」は新規サポーター向けの導線なので、クリア済みを並べ続ける意味が薄いためです。
- 全達成時は `mission-list.tsx` の「未達成のミッションはありません」プレースホルダーが `py-12 md:py-16` の空セクションとして残ってしまいます。これを避けるため、**`<section>` を `home.tsx` から `FirstMissions` 内に移動**し、`FirstMissions` を async にして未達成0件なら `null` を返す形にしました。`hasFeaturedMissions()` で `showFeatured` を出し分けている既存の注目ミッションと同じ考え方ですが、余白ごと消す必要があるためセクション要素をコンポーネント側に持たせています。
- 未ログイン時は達成済み判定をスキップし、3件すべて表示します。

### 実装方針について（#2269 から変更なし）

- 掲載する 3 件は **コード側の slug 配列で固定**しました（`is_featured` は使わない）。
  - 注目ミッション枠と独立させたかったため。`is_featured` を使うと注目枠と同じ集合になり、**獲得 XP が 2 倍**になる副作用も付いてきます。はじめのミッションは通常の XP のままにしています。
  - 新規カテゴリ（`categories.yaml`）で表現する案もありますが、その場合は「このカテゴリだけ最上部の独立セクションとして描画し、`🎯 ミッション` 側からは除外する」分岐が必要で、変更が広くなるため見送りました。掲載ミッションを YAML から差し替えたいご要望があれば、そちらに寄せる形で作り直せます。
- 既存の「注目ミッション」セクションは**一切変更していません**（名称・掲載ミッション・XP 2 倍の仕様そのまま）。`missions.yaml` も変更なしです。

## レビュー対応（#2269 の CodeRabbit 指摘）

### 1. DB操作は `createAdminClient()` を使う 🟠 Major → 対応済み

`getMissionsWithFilter` の `createClient()` を `await createAdminClient()` に変更しました。`docs/20260206_2220_Supabaseクライアント使い分けガイド.md` の「`supabase.from(...)` は `createAdminClient()`」に合わせています。

なお `services/missions.ts` の他の関数（`getMissionsForRanking` / `hasFeaturedMissions` / `getMissionAchievementCounts` / `getMissionCategoryView`）も同じ規約違反が残っていますが、本PRのスコープ外なので触っていません。別PRでまとめて移行するのが良さそうです。

### 2. `filterSlugs` と `maxSize` 併用時に指定順が保証されない 🟡 Minor → 対応済み

DB側の `limit(maxSize)` は `difficulty` / `created_at` 順に効くため、slug 指定順に並べ替える前に上位のミッションが落ちる可能性がありました。`filterSlugs` がある場合は DB で limit せず、**指定順に並べ替えた後に `slice(0, maxSize)`** するようにしました。

```ts
if (maxSize && !filterSlugs) {
  query = query.limit(maxSize);
}
// ...
if (filterSlugs) {
  const sorted = [...(missions ?? [])].sort(/* 指定順 */);
  return maxSize ? sorted.slice(0, maxSize) : sorted;
}
```

（`FirstMissions` は `maxSize` を渡していないので現状は潜在バグですが、将来の誤用を防ぐために直しています）

### 3. slug順復元と `maxSize` 適用をサービス単位で検証すべき 🟡 Minor → 対応済み

`src/features/missions/services/missions.test.ts` を新規追加し、`getMissionsWithFilter` を直接呼んで検証しています（10ケース）。

- `filterSlugs` 指定時、DBの並び順に関係なく指定順で返ること
- `filterSlugs` + `maxSize` 併用時、**DB側で `limit` していないこと**と、並べ替え後に `slice` が効くこと
  - `["third", "second", "first"]` の順で返ってきたとき `maxSize: 2` で `["first", "second"]` になる = 並べ替え前に切り落としていない
- `filterSlugs` 未指定なら従来どおりDB側で `limit(maxSize)` すること
- `filterSlugs` に無い slug は末尾に回ること / `filterFeatured` / `excludeMissionIds` / `data: null` / エラー時 throw

## 確認したこと（ローカル実行）

- `pnpm run typecheck`（`tsc --noEmit`）… パス
- `pnpm run test:unit`（CIの Unit Tests と同スコープ）… **176 suites / 2113 tests パス**
- `npx biome check` … 変更ファイルに指摘なし
- `services/missions.ts` の行カバレッジ 71.14%（未カバー分は本PRで触っていない他関数）。codecov/patch パス
- e2e は環境が必要なため未実行です。既存の e2e（`tests/e2e/user-mission.spec.ts`）は「注目ミッション」見出しの表示を確認するテストで、その見出しは変わらないため影響しない想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ホーム画面に「はじめのミッション」セクションを追加しました。
  - 初めての方におすすめの3つのミッションを、決められた順番で表示します。
  - ログイン中は達成済みのミッションを自動的に除外します。
  - すべて達成済みの場合は、セクションを表示しません。
  - 未ログイン時もミッションを確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
