### PR TITLE
「🚩 はじめのミッション」の見出し下に説明文を追加

### DIFF
--- a/src/features/missions/components/first-missions.test.tsx
+++ b/src/features/missions/components/first-missions.test.tsx
@@ -17,6 +17,7 @@ jest.mock("./mission-list", () => {
       <div data-testid="missions-component">
         <div data-testid="filter-slugs">{props.filterSlugs?.join(",")}</div>
         <div data-testid="title">{props.title}</div>
+        <div data-testid="sub-title">{props.subTitle}</div>
         <div data-testid="id">{props.id}</div>
         <div data-testid="user-id">{props.userId}</div>
         <div data-testid="show-achieved">
@@ -47,6 +48,9 @@ describe("FirstMissions", () => {
     const { getByTestId } = render(component);
 
     expect(getByTestId("title")).toHaveTextContent("🚩 はじめのミッション");
+    expect(getByTestId("sub-title")).toHaveTextContent(
+      "まずはここから。チームみらいの活動に参加するための最初のステップです",
+    );
     expect(getByTestId("id")).toHaveTextContent("first-missions");
     expect(getByTestId("user-id")).toHaveTextContent("test-user-id");
   });

--- a/src/features/missions/components/first-missions.tsx
+++ b/src/features/missions/components/first-missions.tsx
@@ -36,6 +36,7 @@ export default async function FirstMissions({ userId }: FirstMissionsProps) {
         showAchievedMissions={false}
         filterSlugs={FIRST_MISSION_SLUGS}
         title="🚩 はじめのミッション"
+        subTitle="まずはここから。チームみらいの活動に参加するための最初のステップです"
         id="first-missions"
       />
     </section>


### PR DESCRIPTION
## やりたいこと

#2270 で追加した「🚩 はじめのミッション」セクションが**見出しだけ**で、なぜこの3つを最初にやるのかが伝わらないため、見出しの下に一言添えます。

隣の「🔥 注目ミッション」は `subTitle="注目ミッションは獲得ポイントが2倍となります"` を持っているので、見た目としても揃います。

## 変更内容

`mission-list.tsx` が既に持っている `subTitle` prop を使うだけで、新しい実装は足していません。

```diff
       <Missions
         userId={userId}
         showAchievedMissions={false}
         filterSlugs={FIRST_MISSION_SLUGS}
         title="🚩 はじめのミッション"
+        subTitle="まずはここから。チームみらいの活動に参加するための最初のステップです"
         id="first-missions"
       />
```

| ファイル | 変更 |
| --- | --- |
| `src/features/missions/components/first-missions.tsx` | `subTitle` を追加（+1行） |
| `src/features/missions/components/first-missions.test.tsx` | props検証テストに `subTitle` のアサーションを追加 |

`subTitle` は `mission-list.tsx` 側で `<p className="text-sm text-gray-600 mt-2">` として描画されます（注目ミッションと同じ扱い）。

## 文言について

掲載する3ミッション（LINE公式 / 都道府県オープンチャット / Slack）は **達成すると1件ずつ消えていく**ので、「この3つを〜」のように**件数に依存する文言は避けています**。

文言はご意見あれば差し替えます。候補として考えたもの:

- **採用**: まずはここから。チームみらいの活動に参加するための最初のステップです
- はじめてのかたはここから。まずはチームみらいの仲間とつながりましょう
- チームみらいの活動に参加するための最初のステップです（「まずはここから」なし）

依頼元の組織活動本部（湯田瑞希さん）に好みがあればそちらに寄せます。

## 確認したこと（ローカル実行）

- `pnpm run typecheck`（`tsc --noEmit`）… パス
- `pnpm run test:unit`（CIの Unit Tests と同スコープ）… **176 suites / 2113 tests パス**
- `npx biome check`（変更2ファイル）… 指摘なし
- e2e は環境が必要なため未実行。既存 e2e（`tests/e2e/user-mission.spec.ts`）は「注目ミッション」見出しを見るテストで、今回は見出しを変えていないため影響しない想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)