### PR TITLE
「🚩 はじめのミッション」の説明文をスマホで1行に収める

### DIFF
--- a/src/features/missions/components/first-missions.test.tsx
+++ b/src/features/missions/components/first-missions.test.tsx
@@ -1,7 +1,11 @@
 import { render } from "@testing-library/react";
 import { getMissionsWithFilter } from "@/features/missions/loaders/missions-loaders";
 import { getUserMissionAchievements } from "@/features/user-achievements/loaders/achievements-loaders";
-import FirstMissions, { FIRST_MISSION_SLUGS } from "./first-missions";
+import FirstMissions, {
+  FIRST_MISSION_SLUGS,
+  FIRST_MISSIONS_SUB_TITLE,
+  FIRST_MISSIONS_SUB_TITLE_MAX_LENGTH,
+} from "./first-missions";
 
 jest.mock("@/features/missions/loaders/missions-loaders", () => ({
   getMissionsWithFilter: jest.fn(),
@@ -49,7 +53,7 @@ describe("FirstMissions", () => {
 
     expect(getByTestId("title")).toHaveTextContent("🚩 はじめのミッション");
     expect(getByTestId("sub-title")).toHaveTextContent(
-      "まずはここから。チームみらいの活動に参加するための最初のステップです",
+      FIRST_MISSIONS_SUB_TITLE,
     );
     expect(getByTestId("id")).toHaveTextContent("first-missions");
     expect(getByTestId("user-id")).toHaveTextContent("test-user-id");
@@ -114,6 +118,14 @@ describe("FirstMissions", () => {
       filterSlugs: FIRST_MISSION_SLUGS,
       excludeMissionIds: [],
     });
+  });
+
+  // スマホで折り返すと見出しとカードの間が詰まって窮屈になるため、
+  // 文言を編集したときに1行に収まらなくなったことを気づけるようにしている
+  it("説明文はスマホで1行に収まる長さである", () => {
+    expect(Array.from(FIRST_MISSIONS_SUB_TITLE).length).toBeLessThanOrEqual(
+      FIRST_MISSIONS_SUB_TITLE_MAX_LENGTH,
+    );
   });
 
   it("FIRST_MISSION_SLUGSの並び順が仕様どおりである", () => {

--- a/src/features/missions/components/first-missions.tsx
+++ b/src/features/missions/components/first-missions.tsx
@@ -9,6 +9,13 @@ export const FIRST_MISSION_SLUGS = [
   "join-slack",
 ] as const;
 
+// 見出し下の説明文。スマホで折り返さず1行に収めるため 20 文字以内に保つ
+// （text-sm = 14px の全角 1 文字 ≒ 14px、コンテナ幅は viewport - 32px の
+//  `px-4` 分なので、320px 端末で 288px / 20文字が上限）
+export const FIRST_MISSIONS_SUB_TITLE =
+  "まずはここから。仲間とつながる第一歩です";
+export const FIRST_MISSIONS_SUB_TITLE_MAX_LENGTH = 20;
+
 type FirstMissionsProps = {
   userId?: string;
 };
@@ -36,7 +43,7 @@ export default async function FirstMissions({ userId }: FirstMissionsProps) {
         showAchievedMissions={false}
         filterSlugs={FIRST_MISSION_SLUGS}
         title="🚩 はじめのミッション"
-        subTitle="まずはここから。チームみらいの活動に参加するための最初のステップです"
+        subTitle={FIRST_MISSIONS_SUB_TITLE}
         id="first-missions"
       />
     </section>

--- a/src/features/missions/components/first-missions.tsx
+++ b/src/features/missions/components/first-missions.tsx
@@ -12,8 +12,7 @@ export const FIRST_MISSION_SLUGS = [
 // 見出し下の説明文。スマホで折り返さず1行に収めるため 20 文字以内に保つ
 // （text-sm = 14px の全角 1 文字 ≒ 14px、コンテナ幅は viewport - 32px の
 //  `px-4` 分なので、320px 端末で 288px / 20文字が上限）
-export const FIRST_MISSIONS_SUB_TITLE =
-  "まずはここから。仲間とつながる第一歩です";
+export const FIRST_MISSIONS_SUB_TITLE = "まずはここから始めてみましょう";
 export const FIRST_MISSIONS_SUB_TITLE_MAX_LENGTH = 20;
 
 type FirstMissionsProps = {


### PR DESCRIPTION
## やりたいこと

#2271 で追加した説明文が **34文字あってスマホで2行に折り返す**ため、見出しとカードの間が窮屈でした。1行に収まる長さに詰めます。

| | 文言 | 文字数 | 実測幅 |
| --- | --- | --- | --- |
| Before | まずはここから。チームみらいの活動に参加するための最初のステップです | 34 | 476px（**2行**） |
| **After** | **まずはここから始めてみましょう** | **15** | **210px（1行）** |

## 20文字を上限にした根拠

実機フォント（`Noto Sans JP` / `text-sm` = 14px）で `canvas.measureText` で実測しました。**全角1文字 = ちょうど14px**です（半角英数はより狭い）。

コンテナ幅は `mission-list.tsx` の `px-4` により `viewport - 32px` なので、端末ごとの上限文字数は:

| 端末幅 | コンテナ幅 | 上限 |
| --- | --- | --- |
| 320px | 288px | 20文字 |
| 375px（iPhone SE 2/3） | 343px | 24文字 |
| 393px（Pixel 5 = e2eのmobile設定） | 361px | 25文字 |

e2e の mobile は Pixel 5（393px）ですが、**320px でも折り返さない20文字**を上限に設定しました。フォントフォールバックが効いた端末や、OS側の文字サイズ拡大設定で幅が膨らむ余地を残したいためです。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `src/features/missions/components/first-missions.tsx` | 文言を `FIRST_MISSIONS_SUB_TITLE` として定数化し、上限を `FIRST_MISSIONS_SUB_TITLE_MAX_LENGTH = 20` で明示。算出根拠をコメントに残した |
| `src/features/missions/components/first-missions.test.tsx` | 文字数が上限以内であることを検証するテストを追加（+1ケース） |

文言をハードコードのままにすると次に編集した人が同じ罠を踏むので、**定数＋長さのテスト**にしてCIで気づけるようにしています。

## 文言について

当初 `まずはここから。仲間とつながる第一歩です`（20文字）を案にしていましたが、**新規サポーター向けの導線としては「仲間とつながる」が重い**というレビューを受けて、情緒的な重さのない言い回しに変えました。

掲載3件は達成すると1件ずつ消えるので、**件数に依存する文言は避けています**（「この3つを」等）。

検討した他の候補（いずれも320px端末で1行に収まることを実測済み）:

| 文言 | 文字数 | 幅 |
| --- | --- | --- |
| **まずはここから始めてみましょう（採用）** | **15** | **210px** |
| まずはここから。気軽にのぞいてみて | 17 | 238px |
| まずはここから。お知らせを受け取ろう | 18 | 252px |
| まずはここから。LINEとSlackに入るだけ | 23 | 261px |

## 確認したこと（ローカル実行）

- `pnpm run typecheck`（`tsc --noEmit`）… パス
- `pnpm run test:unit`（CIの Unit Tests と同スコープ）… **176 suites / 2114 tests パス**
- `npx biome check`（変更2ファイル）… 指摘なし
- 折り返しは `mcp__chrome-devtools__emulate` で**実寸375pxのモバイルviewport**を作り、`Range.getClientRects().length === 1` と目視の両方で確認（Before は2行）。320px〜414pxのコンテナ幅すべてで1行になることも実測

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 初回ミッションの説明文を見直し、スマートフォン画面でも1行に収まりやすい表示に調整しました。
  * 説明文の文字数上限を設け、表示内容の一貫性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->