### PR TITLE
キャンペーン別（?cv=）登録数の集計をMCPツールとして追加

### DIFF
--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -1,8 +1,17 @@
 import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
+import {
+  getCampaignAttributionStats,
+  JST_DATE_REGEX,
+} from "@/features/campaign-attribution/services/campaign-attribution-stats";
+import {
+  buildCampaignStatsResponse,
+  DEFAULT_CAMPAIGN_STATS_LIMIT,
+} from "@/features/campaign-attribution/utils/campaign-stats-response";
 import { getPartyMembershipByEmail } from "@/features/party-membership/services/memberships";
 import { buildMembershipLookupResponse } from "@/features/party-membership/utils/membership-lookup";
 import { verifyBearerToken } from "@/lib/utils/bearer-token";
+import { isValidCampaignCodeFormat } from "@/lib/validation/campaign-attribution";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
 
@@ -28,6 +37,62 @@ const handler = createMcpHandler(
       async ({ email }) => {
         const lookup = await getPartyMembershipByEmail(email);
         const response = buildMembershipLookupResponse(lookup, SITE_URL);
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+        };
+      },
+    );
+
+    server.tool(
+      "get_campaign_attribution_stats",
+      "キャンペーンコード（?cv=）別のアクションボード新規登録数を集計する。全国キャラバンの会場別登録数など、イベント/キャンペーン起因の成果測定（アトリビューション計測）に使う。返すのは集計値のみで個人は特定できない。",
+      {
+        campaignCodePrefix: z
+          .string()
+          .refine(isValidCampaignCodeFormat, {
+            message:
+              "英数字・ハイフン・アンダースコアの1〜50文字で指定してください",
+          })
+          .optional()
+          .describe(
+            "キャンペーンコードの前方一致フィルタ（例: sapporo → sapporo-0730 等が対象）。大文字小文字は区別しない。省略時は全キャンペーンを対象にする",
+          ),
+        from: z
+          .string()
+          .regex(JST_DATE_REGEX, "YYYY-MM-DD形式で指定してください")
+          .optional()
+          .describe("登録日の下限（JST・YYYY-MM-DD・その日を含む）"),
+        to: z
+          .string()
+          .regex(JST_DATE_REGEX, "YYYY-MM-DD形式で指定してください")
+          .optional()
+          .describe("登録日の上限（JST・YYYY-MM-DD・その日を含む）"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe(
+            `返すキャンペーンコード数の上限（登録数の多い順。既定 ${DEFAULT_CAMPAIGN_STATS_LIMIT}）`,
+          ),
+      },
+      async ({ campaignCodePrefix, from, to, limit }) => {
+        const stats = await getCampaignAttributionStats({
+          campaignCodePrefix,
+          from,
+          to,
+        });
+        const response = buildCampaignStatsResponse(
+          stats,
+          {
+            campaignCodePrefix: campaignCodePrefix ?? null,
+            from: from ?? null,
+            to: to ?? null,
+          },
+          limit,
+        );
 
         return {
           content: [{ type: "text", text: JSON.stringify(response, null, 2) }],

--- a/src/features/campaign-attribution/services/campaign-attribution-stats.test.ts
+++ b/src/features/campaign-attribution/services/campaign-attribution-stats.test.ts
@@ -1,0 +1,137 @@
+import { createAdminClient } from "@/lib/supabase/adminClient";
+import {
+  getCampaignAttributionStats,
+  toJstRangeBoundary,
+} from "./campaign-attribution-stats";
+
+jest.mock("@/lib/supabase/adminClient", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+const mockCreateAdminClient = createAdminClient as jest.Mock;
+
+type StatsRow = {
+  campaign_code: string;
+  registrations: number;
+  first_registered_at: string | null;
+  last_registered_at: string | null;
+};
+
+function setupMockAdminClient({
+  rows = [] as StatsRow[],
+  error = null as { message: string } | null,
+} = {}) {
+  const rpc = jest.fn().mockResolvedValue({ data: rows, error });
+  mockCreateAdminClient.mockResolvedValue({ rpc });
+  return { rpc };
+}
+
+describe("toJstRangeBoundary", () => {
+  it("startはJSTのその日の0時に変換する", () => {
+    expect(toJstRangeBoundary("2026-07-30", "start")).toBe(
+      "2026-07-29T15:00:00.000Z",
+    );
+  });
+
+  it("endはJSTのその日の終わり（23:59:59.999）に変換する", () => {
+    expect(toJstRangeBoundary("2026-07-30", "end")).toBe(
+      "2026-07-30T14:59:59.999Z",
+    );
+  });
+
+  it("YYYY-MM-DD以外の形式はエラーにする", () => {
+    expect(() => toJstRangeBoundary("2026/07/30", "start")).toThrow(
+      "YYYY-MM-DD",
+    );
+  });
+
+  it("存在しない日付はエラーにする", () => {
+    expect(() => toJstRangeBoundary("2026-02-30", "start")).toThrow(
+      "存在しない日付",
+    );
+  });
+});
+
+describe("getCampaignAttributionStats", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("フィルタ未指定のときは絞り込み条件なし（undefined）でRPCを呼ぶ", async () => {
+    const { rpc } = setupMockAdminClient();
+
+    await getCampaignAttributionStats();
+
+    expect(rpc).toHaveBeenCalledWith("get_campaign_attribution_stats", {
+      campaign_code_prefix: undefined,
+      registered_from: undefined,
+      registered_to: undefined,
+    });
+  });
+
+  it("期間はJSTの日境界に変換してRPCに渡す", async () => {
+    const { rpc } = setupMockAdminClient();
+
+    await getCampaignAttributionStats({
+      campaignCodePrefix: " sapporo ",
+      from: "2026-07-30",
+      to: "2026-08-05",
+    });
+
+    expect(rpc).toHaveBeenCalledWith("get_campaign_attribution_stats", {
+      campaign_code_prefix: "sapporo",
+      registered_from: "2026-07-29T15:00:00.000Z",
+      registered_to: "2026-08-05T14:59:59.999Z",
+    });
+  });
+
+  it("RPCの結果をcamelCaseに変換して返す", async () => {
+    setupMockAdminClient({
+      rows: [
+        {
+          campaign_code: "sapporo-0730",
+          registrations: 12,
+          first_registered_at: "2026-07-30T01:00:00.000Z",
+          last_registered_at: "2026-07-30T09:00:00.000Z",
+        },
+      ],
+    });
+
+    const result = await getCampaignAttributionStats();
+
+    expect(result).toEqual([
+      {
+        campaignCode: "sapporo-0730",
+        registrations: 12,
+        firstRegisteredAt: "2026-07-30T01:00:00.000Z",
+        lastRegisteredAt: "2026-07-30T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("形式不正なキャンペーンコードはDBに問い合わせずエラーにする", async () => {
+    const { rpc } = setupMockAdminClient();
+
+    await expect(
+      getCampaignAttributionStats({ campaignCodePrefix: "sapporo 0730!" }),
+    ).rejects.toThrow("キャンペーンコードは英数字");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("期間が逆順のときはDBに問い合わせずエラーにする", async () => {
+    const { rpc } = setupMockAdminClient();
+
+    await expect(
+      getCampaignAttributionStats({ from: "2026-08-05", to: "2026-07-30" }),
+    ).rejects.toThrow("期間の指定が逆");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("RPCがエラーを返したらエラーを投げる", async () => {
+    setupMockAdminClient({ error: { message: "boom" } });
+
+    await expect(getCampaignAttributionStats()).rejects.toThrow(
+      "キャンペーン別集計の取得に失敗しました: boom",
+    );
+  });
+});

--- a/src/features/campaign-attribution/services/campaign-attribution-stats.test.ts
+++ b/src/features/campaign-attribution/services/campaign-attribution-stats.test.ts
@@ -33,9 +33,18 @@ describe("toJstRangeBoundary", () => {
     );
   });
 
-  it("endはJSTのその日の終わり（23:59:59.999）に変換する", () => {
-    expect(toJstRangeBoundary("2026-07-30", "end")).toBe(
-      "2026-07-30T14:59:59.999Z",
+  it("endExclusiveは翌日JSTの0時（排他境界）に変換する", () => {
+    expect(toJstRangeBoundary("2026-07-30", "endExclusive")).toBe(
+      "2026-07-30T15:00:00.000Z",
+    );
+  });
+
+  it("月末・年末をまたぐ排他境界も繰り上がる", () => {
+    expect(toJstRangeBoundary("2026-07-31", "endExclusive")).toBe(
+      "2026-07-31T15:00:00.000Z",
+    );
+    expect(toJstRangeBoundary("2026-12-31", "endExclusive")).toBe(
+      "2026-12-31T15:00:00.000Z",
     );
   });
 
@@ -45,9 +54,25 @@ describe("toJstRangeBoundary", () => {
     );
   });
 
-  it("存在しない日付はエラーにする", () => {
-    expect(() => toJstRangeBoundary("2026-02-30", "start")).toThrow(
-      "存在しない日付",
+  it("存在しない日付はエラーにする（Dateの繰り上げで別日にならない）", () => {
+    // 2026 は平年
+    for (const date of [
+      "2026-02-30",
+      "2026-02-29",
+      "2026-04-31",
+      "2026-13-01",
+      "2026-00-10",
+    ]) {
+      expect(() => toJstRangeBoundary(date, "start")).toThrow("存在しない日付");
+      expect(() => toJstRangeBoundary(date, "endExclusive")).toThrow(
+        "存在しない日付",
+      );
+    }
+  });
+
+  it("うるう日は通す", () => {
+    expect(toJstRangeBoundary("2028-02-29", "start")).toBe(
+      "2028-02-28T15:00:00.000Z",
     );
   });
 });
@@ -65,7 +90,7 @@ describe("getCampaignAttributionStats", () => {
     expect(rpc).toHaveBeenCalledWith("get_campaign_attribution_stats", {
       campaign_code_prefix: undefined,
       registered_from: undefined,
-      registered_to: undefined,
+      registered_before: undefined,
     });
   });
 
@@ -81,7 +106,8 @@ describe("getCampaignAttributionStats", () => {
     expect(rpc).toHaveBeenCalledWith("get_campaign_attribution_stats", {
       campaign_code_prefix: "sapporo",
       registered_from: "2026-07-29T15:00:00.000Z",
-      registered_to: "2026-08-05T14:59:59.999Z",
+      // to に指定した 8/5 を含むため、上限は 8/6 0時 JST（排他）
+      registered_before: "2026-08-05T15:00:00.000Z",
     });
   });
 

--- a/src/features/campaign-attribution/services/campaign-attribution-stats.ts
+++ b/src/features/campaign-attribution/services/campaign-attribution-stats.ts
@@ -22,28 +22,43 @@ export type CampaignAttributionStat = {
   lastRegisteredAt: string | null;
 };
 
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
 /**
- * JSTの日付（YYYY-MM-DD）を、その日の開始/終了時点のタイムスタンプに変換する
+ * JSTの日付（YYYY-MM-DD）を、集計に渡すタイムスタンプに変換する
  *
- * start: 00:00:00.000+09:00 / end: 23:59:59.999+09:00（どちらも境界を含む）
+ * - start: その日の 00:00:00 JST（下限・含む）
+ * - endExclusive: 翌日の 00:00:00 JST（上限・含まない）
+ *
+ * 上限を「その日の 23:59:59.999」にせず翌日0時の排他境界にするのは、created_at が
+ * マイクロ秒精度で、23:59:59.999001〜.999999 の登録を取りこぼさないため。
+ * 呼び出し側から見た契約は「to に指定した日を含む」で変わらない。
  */
 export function toJstRangeBoundary(
   date: string,
-  boundary: "start" | "end",
+  boundary: "start" | "endExclusive",
 ): string {
   if (!JST_DATE_REGEX.test(date)) {
     throw new Error(`日付は YYYY-MM-DD 形式で指定してください: ${date}`);
   }
 
-  const suffix =
-    boundary === "start" ? "T00:00:00.000+09:00" : "T23:59:59.999+09:00";
-  const timestamp = new Date(`${date}${suffix}`);
-
-  if (Number.isNaN(timestamp.getTime())) {
+  // 2026-02-30 のような存在しない日は Date が翌月に繰り上げてしまい NaN にならないため、
+  // 暦日として実在するかを年月日の一致で確かめる（別日の統計を返さないため）
+  const [year, month, day] = date.split("-").map(Number);
+  const probe = new Date(Date.UTC(year, month - 1, day));
+  if (
+    probe.getUTCFullYear() !== year ||
+    probe.getUTCMonth() + 1 !== month ||
+    probe.getUTCDate() !== day
+  ) {
     throw new Error(`存在しない日付です: ${date}`);
   }
 
-  return timestamp.toISOString();
+  const dayOffset = boundary === "start" ? 0 : 1;
+
+  return new Date(
+    Date.UTC(year, month - 1, day + dayOffset) - JST_OFFSET_MS,
+  ).toISOString();
 }
 
 /**
@@ -65,25 +80,25 @@ export async function getCampaignAttributionStats({
     );
   }
 
-  // DB関数側の引数はいずれも省略可（未指定なら絞り込まない）。
-  // undefined はJSON化時に落ちるため、null ではなく undefined を渡す
-  const registeredFrom = from ? toJstRangeBoundary(from, "start") : undefined;
-  const registeredTo = to ? toJstRangeBoundary(to, "end") : undefined;
-
   // 期間が逆順のときは常に0件になってしまうため、無言で空を返さずエラーにする
-  if (registeredFrom && registeredTo && registeredFrom > registeredTo) {
+  // （YYYY-MM-DD は辞書順比較で日付順と一致する）
+  if (from && to && from > to) {
     throw new Error(
       `期間の指定が逆になっています（from: ${from} / to: ${to}）`,
     );
   }
 
+  // DB関数側の引数はいずれも省略可（未指定なら絞り込まない）。
+  // undefined はJSON化時に落ちるため、null ではなく undefined を渡す
   const supabaseAdmin = await createAdminClient();
   const { data, error } = await supabaseAdmin.rpc(
     "get_campaign_attribution_stats",
     {
       campaign_code_prefix: prefix || undefined,
-      registered_from: registeredFrom,
-      registered_to: registeredTo,
+      registered_from: from ? toJstRangeBoundary(from, "start") : undefined,
+      registered_before: to
+        ? toJstRangeBoundary(to, "endExclusive")
+        : undefined,
     },
   );
 

--- a/src/features/campaign-attribution/services/campaign-attribution-stats.ts
+++ b/src/features/campaign-attribution/services/campaign-attribution-stats.ts
@@ -1,0 +1,100 @@
+import "server-only";
+
+import { createAdminClient } from "@/lib/supabase/adminClient";
+import { isValidCampaignCodeFormat } from "@/lib/validation/campaign-attribution";
+
+// 集計の日付指定はJSTの「日」単位で受け取る（依頼者は組織活動本部・広報のため、UTCではなくJSTで揃える）
+export const JST_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export type CampaignAttributionStatsParams = {
+  /** キャンペーンコードの前方一致フィルタ（大文字小文字を区別しない）。省略時は全キャンペーン */
+  campaignCodePrefix?: string;
+  /** 登録日の下限（JST・YYYY-MM-DD・その日を含む） */
+  from?: string;
+  /** 登録日の上限（JST・YYYY-MM-DD・その日を含む） */
+  to?: string;
+};
+
+export type CampaignAttributionStat = {
+  campaignCode: string;
+  registrations: number;
+  firstRegisteredAt: string | null;
+  lastRegisteredAt: string | null;
+};
+
+/**
+ * JSTの日付（YYYY-MM-DD）を、その日の開始/終了時点のタイムスタンプに変換する
+ *
+ * start: 00:00:00.000+09:00 / end: 23:59:59.999+09:00（どちらも境界を含む）
+ */
+export function toJstRangeBoundary(
+  date: string,
+  boundary: "start" | "end",
+): string {
+  if (!JST_DATE_REGEX.test(date)) {
+    throw new Error(`日付は YYYY-MM-DD 形式で指定してください: ${date}`);
+  }
+
+  const suffix =
+    boundary === "start" ? "T00:00:00.000+09:00" : "T23:59:59.999+09:00";
+  const timestamp = new Date(`${date}${suffix}`);
+
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(`存在しない日付です: ${date}`);
+  }
+
+  return timestamp.toISOString();
+}
+
+/**
+ * キャンペーンコード（?cv=）別の新規登録数を集計する
+ *
+ * 集計はDB関数（get_campaign_attribution_stats）側でGROUP BYする。
+ * 返すのは集計値のみで、個人（user_id）は含めない。
+ * 問い合わせ対応ボット（みらいいぬ）向けMCPツールから利用される想定。
+ */
+export async function getCampaignAttributionStats({
+  campaignCodePrefix,
+  from,
+  to,
+}: CampaignAttributionStatsParams = {}): Promise<CampaignAttributionStat[]> {
+  const prefix = campaignCodePrefix?.trim();
+  if (prefix && !isValidCampaignCodeFormat(prefix)) {
+    throw new Error(
+      `キャンペーンコードは英数字・ハイフン・アンダースコアの1〜50文字で指定してください: ${prefix}`,
+    );
+  }
+
+  // DB関数側の引数はいずれも省略可（未指定なら絞り込まない）。
+  // undefined はJSON化時に落ちるため、null ではなく undefined を渡す
+  const registeredFrom = from ? toJstRangeBoundary(from, "start") : undefined;
+  const registeredTo = to ? toJstRangeBoundary(to, "end") : undefined;
+
+  // 期間が逆順のときは常に0件になってしまうため、無言で空を返さずエラーにする
+  if (registeredFrom && registeredTo && registeredFrom > registeredTo) {
+    throw new Error(
+      `期間の指定が逆になっています（from: ${from} / to: ${to}）`,
+    );
+  }
+
+  const supabaseAdmin = await createAdminClient();
+  const { data, error } = await supabaseAdmin.rpc(
+    "get_campaign_attribution_stats",
+    {
+      campaign_code_prefix: prefix || undefined,
+      registered_from: registeredFrom,
+      registered_to: registeredTo,
+    },
+  );
+
+  if (error) {
+    throw new Error(`キャンペーン別集計の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []).map((row) => ({
+    campaignCode: row.campaign_code,
+    registrations: Number(row.registrations),
+    firstRegisteredAt: row.first_registered_at,
+    lastRegisteredAt: row.last_registered_at,
+  }));
+}

--- a/src/features/campaign-attribution/utils/campaign-stats-response.test.ts
+++ b/src/features/campaign-attribution/utils/campaign-stats-response.test.ts
@@ -1,0 +1,83 @@
+import type { CampaignAttributionStat } from "../services/campaign-attribution-stats";
+import { buildCampaignStatsResponse } from "./campaign-stats-response";
+
+const NO_FILTERS = {
+  campaignCodePrefix: null,
+  from: null,
+  to: null,
+};
+
+function stat(
+  campaignCode: string,
+  registrations: number,
+): CampaignAttributionStat {
+  return {
+    campaignCode,
+    registrations,
+    firstRegisteredAt: "2026-07-30T01:00:00.000Z",
+    lastRegisteredAt: "2026-07-30T09:00:00.000Z",
+  };
+}
+
+describe("buildCampaignStatsResponse", () => {
+  it("合計登録数とキャンペーン数を集計する", () => {
+    const response = buildCampaignStatsResponse(
+      [stat("sapporo-0730", 12), stat("aomori-0801", 3)],
+      NO_FILTERS,
+    );
+
+    expect(response.totalRegistrations).toBe(15);
+    expect(response.campaignCount).toBe(2);
+    expect(response.campaigns).toHaveLength(2);
+    expect(response.truncated).toBe(false);
+  });
+
+  it("filtersをそのまま返す", () => {
+    const filters = {
+      campaignCodePrefix: "sapporo",
+      from: "2026-07-30",
+      to: "2026-08-05",
+    };
+
+    const response = buildCampaignStatsResponse(
+      [stat("sapporo-0730", 1)],
+      filters,
+    );
+
+    expect(response.filters).toEqual(filters);
+  });
+
+  it("limitを超えた分は切り詰めるが、合計は全件で計算する", () => {
+    const response = buildCampaignStatsResponse(
+      [stat("a", 5), stat("b", 3), stat("c", 1)],
+      NO_FILTERS,
+      2,
+    );
+
+    expect(response.campaigns.map((c) => c.campaignCode)).toEqual(["a", "b"]);
+    expect(response.totalRegistrations).toBe(9);
+    expect(response.campaignCount).toBe(3);
+    expect(response.truncated).toBe(true);
+    expect(response.notes.join("\n")).toContain("全3件のうち");
+  });
+
+  it("0件のときは確認を促すnoteを添える", () => {
+    const response = buildCampaignStatsResponse([], NO_FILTERS);
+
+    expect(response.totalRegistrations).toBe(0);
+    expect(response.campaignCount).toBe(0);
+    expect(response.notes.join("\n")).toContain("登録はまだありません");
+  });
+
+  it("数字の読み違いを防ぐ注意書きを必ず含める", () => {
+    const response = buildCampaignStatsResponse(
+      [stat("sapporo-0730", 12)],
+      NO_FILTERS,
+    );
+
+    const notes = response.notes.join("\n");
+    expect(notes).toContain("新規登録したユーザー数");
+    expect(notes).toContain("1ユーザーにつき1コード");
+    expect(notes).toContain("党員登録・寄付");
+  });
+});

--- a/src/features/campaign-attribution/utils/campaign-stats-response.ts
+++ b/src/features/campaign-attribution/utils/campaign-stats-response.ts
@@ -1,0 +1,65 @@
+import type { CampaignAttributionStat } from "../services/campaign-attribution-stats";
+
+export const DEFAULT_CAMPAIGN_STATS_LIMIT = 50;
+
+export type CampaignStatsFilters = {
+  campaignCodePrefix: string | null;
+  from: string | null;
+  to: string | null;
+};
+
+export type CampaignStatsResponse = {
+  filters: CampaignStatsFilters;
+  /** 条件に一致する登録数の合計（limitで絞る前の全キャンペーン分） */
+  totalRegistrations: number;
+  /** 条件に一致するキャンペーンコードの数（limitで絞る前） */
+  campaignCount: number;
+  campaigns: CampaignAttributionStat[];
+  truncated: boolean;
+  notes: string[];
+};
+
+/**
+ * キャンペーン別集計を、MCPツールのレスポンス形式に整形する
+ *
+ * notesには数字の読み違いを防ぐための注意書きを含める
+ * （何がカウントされ、何がカウントされないか）。
+ */
+export function buildCampaignStatsResponse(
+  stats: CampaignAttributionStat[],
+  filters: CampaignStatsFilters,
+  limit: number = DEFAULT_CAMPAIGN_STATS_LIMIT,
+): CampaignStatsResponse {
+  const campaigns = stats.slice(0, limit);
+  const totalRegistrations = stats.reduce(
+    (sum, stat) => sum + stat.registrations,
+    0,
+  );
+
+  const notes = [
+    "キャンペーンコード付きURL（?cv=コード）経由で新規登録したユーザー数です。既に登録済みのユーザーが同じURLから訪れてもカウントされません。",
+    "1ユーザーにつき1コード（先勝ち）で記録されます。複数のキャンペーンURLを経由した場合は最初のコードだけが残ります。",
+    "党員登録・寄付の実績はアクションボードではなく公式サイト（Stripe）側の集計です。",
+  ];
+
+  if (stats.length === 0) {
+    notes.push(
+      "条件に一致するキャンペーンコードの登録はまだありません。配布URLに ?cv= が付いているか、コードの綴りを確認してください。",
+    );
+  }
+
+  if (campaigns.length < stats.length) {
+    notes.push(
+      `キャンペーンコードは全${stats.length}件のうち、登録数の多い順に${campaigns.length}件のみ表示しています。`,
+    );
+  }
+
+  return {
+    filters,
+    totalRegistrations,
+    campaignCount: stats.length,
+    campaigns,
+    truncated: campaigns.length < stats.length,
+    notes,
+  };
+}

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -1977,8 +1977,8 @@ export type Database = {
       get_campaign_attribution_stats: {
         Args: {
           campaign_code_prefix?: string;
+          registered_before?: string;
           registered_from?: string;
-          registered_to?: string;
         };
         Returns: {
           campaign_code: string;

--- a/src/lib/types/supabase.ts
+++ b/src/lib/types/supabase.ts
@@ -1974,6 +1974,19 @@ export type Database = {
           status: Database["public"]["Enums"]["poster_board_status"];
         }[];
       };
+      get_campaign_attribution_stats: {
+        Args: {
+          campaign_code_prefix?: string;
+          registered_from?: string;
+          registered_to?: string;
+        };
+        Returns: {
+          campaign_code: string;
+          first_registered_at: string;
+          last_registered_at: string;
+          registrations: number;
+        }[];
+      };
       get_daily_action_history: {
         Args: { end_date?: string; start_date?: string };
         Returns: {

--- a/supabase/migrations/20260804112844_add_campaign_attribution_stats_function.sql
+++ b/supabase/migrations/20260804112844_add_campaign_attribution_stats_function.sql
@@ -1,0 +1,49 @@
+-- キャンペーンコード（?cv=）別の新規登録数を集計する関数
+--
+-- 用途: 全国キャラバン2026の会場別登録数など、流入元別の成果測定。
+-- 組織活動本部・広報からの「会場別の登録数を見たい」に応えるため、
+-- 問い合わせ対応ボット（みらいいぬ）向けMCPツール get_campaign_attribution_stats から
+-- service_role で呼ばれる。集計値のみを返し、個人（user_id）は返さない。
+--
+-- 集計はDB側でGROUP BYする（全行をアプリに転送しないため）。
+CREATE OR REPLACE FUNCTION public.get_campaign_attribution_stats(
+  campaign_code_prefix text DEFAULT NULL,
+  registered_from timestamptz DEFAULT NULL,
+  registered_to timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  campaign_code text,
+  registrations bigint,
+  first_registered_at timestamptz,
+  last_registered_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    uca.campaign_code,
+    count(*)::bigint AS registrations,
+    min(uca.created_at) AS first_registered_at,
+    max(uca.created_at) AS last_registered_at
+  FROM public.user_campaign_attribution uca
+  WHERE (
+      -- 前方一致（大文字小文字を区別しない）。LIKEではなくstarts_withを使い、
+      -- コードに含まれうる _ や % がワイルドカードとして解釈されるのを避ける
+      campaign_code_prefix IS NULL
+      OR starts_with(lower(uca.campaign_code), lower(campaign_code_prefix))
+    )
+    AND (registered_from IS NULL OR uca.created_at >= registered_from)
+    AND (registered_to IS NULL OR uca.created_at <= registered_to)
+  GROUP BY uca.campaign_code
+  ORDER BY count(*) DESC, uca.campaign_code ASC;
+$$;
+
+-- SECURITY INVOKER なのでRLS（本人のみSELECT可）は効くが、
+-- 集計用途の関数をアプリのロールから呼べる必要はないため明示的に遮断する
+REVOKE ALL ON FUNCTION public.get_campaign_attribution_stats(text, timestamptz, timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_campaign_attribution_stats(text, timestamptz, timestamptz) TO service_role;
+
+COMMENT ON FUNCTION public.get_campaign_attribution_stats(text, timestamptz, timestamptz) IS
+'キャンペーンコード（?cv=）別の新規登録数・初回/最終登録日時を集計する。会場別アトリビューション計測のMCPツールから service_role で呼ばれる。';

--- a/supabase/migrations/20260804112844_add_campaign_attribution_stats_function.sql
+++ b/supabase/migrations/20260804112844_add_campaign_attribution_stats_function.sql
@@ -6,10 +6,13 @@
 -- service_role で呼ばれる。集計値のみを返し、個人（user_id）は返さない。
 --
 -- 集計はDB側でGROUP BYする（全行をアプリに転送しないため）。
+-- 期間は半開区間 [registered_from, registered_before) で受ける。
+-- created_at はマイクロ秒精度なので「その日の 23:59:59.999 まで」と包含比較すると
+-- 23:59:59.999001〜.999999 の登録を取りこぼすため、上限は翌日 0 時の排他境界にする。
 CREATE OR REPLACE FUNCTION public.get_campaign_attribution_stats(
   campaign_code_prefix text DEFAULT NULL,
   registered_from timestamptz DEFAULT NULL,
-  registered_to timestamptz DEFAULT NULL
+  registered_before timestamptz DEFAULT NULL
 )
 RETURNS TABLE (
   campaign_code text,
@@ -35,7 +38,7 @@ AS $$
       OR starts_with(lower(uca.campaign_code), lower(campaign_code_prefix))
     )
     AND (registered_from IS NULL OR uca.created_at >= registered_from)
-    AND (registered_to IS NULL OR uca.created_at <= registered_to)
+    AND (registered_before IS NULL OR uca.created_at < registered_before)
   GROUP BY uca.campaign_code
   ORDER BY count(*) DESC, uca.campaign_code ASC;
 $$;
@@ -46,4 +49,4 @@ REVOKE ALL ON FUNCTION public.get_campaign_attribution_stats(text, timestamptz, 
 GRANT EXECUTE ON FUNCTION public.get_campaign_attribution_stats(text, timestamptz, timestamptz) TO service_role;
 
 COMMENT ON FUNCTION public.get_campaign_attribution_stats(text, timestamptz, timestamptz) IS
-'キャンペーンコード（?cv=）別の新規登録数・初回/最終登録日時を集計する。会場別アトリビューション計測のMCPツールから service_role で呼ばれる。';
+'キャンペーンコード（?cv=）別の新規登録数・初回/最終登録日時を集計する。期間は半開区間 [registered_from, registered_before)。会場別アトリビューション計測のMCPツールから service_role で呼ばれる。';

--- a/tests/supabase/db_function/campaign-attribution-stats.test.ts
+++ b/tests/supabase/db_function/campaign-attribution-stats.test.ts
@@ -29,9 +29,11 @@ describe("get_campaign_attribution_stats 関数のテスト", () => {
           created_at: "2026-07-30T03:00:00+09:00",
         },
         {
+          // created_at はマイクロ秒精度。「その日の 23:59:59.999 まで」と包含比較すると
+          // 取りこぼす時刻をあえて置き、半開区間で拾えることを確かめる
           user_id: user2.user.userId,
           campaign_code: SAPPORO,
-          created_at: "2026-07-31T10:00:00+09:00",
+          created_at: "2026-07-30T23:59:59.999500+09:00",
         },
         {
           user_id: user3.user.userId,
@@ -70,9 +72,8 @@ describe("get_campaign_attribution_stats 関数のテスト", () => {
     expect(new Date(sapporo?.first_registered_at ?? "").toISOString()).toBe(
       "2026-07-29T18:00:00.000Z",
     );
-    expect(new Date(sapporo?.last_registered_at ?? "").toISOString()).toBe(
-      "2026-07-31T01:00:00.000Z",
-    );
+    // マイクロ秒はJSのDateで丸めずに文字列で確認する
+    expect(sapporo?.last_registered_at).toContain("2026-07-30T14:59:59.9995");
   });
 
   test("前方一致フィルタは大文字小文字を区別しない", async () => {
@@ -99,21 +100,36 @@ describe("get_campaign_attribution_stats 関数のテスト", () => {
     expect(Number(data?.[0].registrations)).toBe(1);
   });
 
-  test("期間フィルタは境界を含めて絞り込める", async () => {
-    // 7/30 のみ（JST）→ sapporo の1件だけ
+  test("期間フィルタは半開区間で、その日の終わり際（サブミリ秒）も取りこぼさない", async () => {
+    // 7/30 のみ（JST）→ 03:00 と 23:59:59.9995 の2件
     const { data, error } = await adminClient.rpc(
       "get_campaign_attribution_stats",
       {
         campaign_code_prefix: PREFIX,
         registered_from: "2026-07-30T00:00:00+09:00",
-        registered_to: "2026-07-30T23:59:59.999+09:00",
+        registered_before: "2026-07-31T00:00:00+09:00",
       },
     );
 
     expect(error).toBeNull();
     expect(data).toHaveLength(1);
     expect(data?.[0].campaign_code).toBe(SAPPORO);
-    expect(Number(data?.[0].registrations)).toBe(1);
+    expect(Number(data?.[0].registrations)).toBe(2);
+  });
+
+  test("上限は排他境界（指定時刻ぴったりの登録は含まない）", async () => {
+    // 8/1 0時 JST より前 → 7/30 の2件だけ（8/1 12:00 の aomori は入らない）
+    const { data, error } = await adminClient.rpc(
+      "get_campaign_attribution_stats",
+      {
+        campaign_code_prefix: PREFIX,
+        registered_before: "2026-08-01T00:00:00+09:00",
+      },
+    );
+
+    expect(error).toBeNull();
+    expect(data?.map((row) => row.campaign_code)).toEqual([SAPPORO]);
+    expect(Number(data?.[0].registrations)).toBe(2);
   });
 
   test("該当がない期間では空配列を返す", async () => {

--- a/tests/supabase/db_function/campaign-attribution-stats.test.ts
+++ b/tests/supabase/db_function/campaign-attribution-stats.test.ts
@@ -1,0 +1,148 @@
+import {
+  adminClient,
+  cleanupTestUser,
+  createTestUser,
+  getAnonClient,
+} from "../utils";
+
+// 他のテストが入れた行と混ざらないよう、実行ごとにユニークなプレフィックスで隔離する
+const PREFIX = `stats${crypto.randomUUID().replace(/-/g, "").slice(0, 10)}`;
+const SAPPORO = `${PREFIX}-sapporo-0730`;
+const AOMORI = `${PREFIX}-aomori-0801`;
+
+describe("get_campaign_attribution_stats 関数のテスト", () => {
+  let user1: Awaited<ReturnType<typeof createTestUser>>;
+  let user2: Awaited<ReturnType<typeof createTestUser>>;
+  let user3: Awaited<ReturnType<typeof createTestUser>>;
+
+  beforeEach(async () => {
+    user1 = await createTestUser(`${crypto.randomUUID()}@example.com`);
+    user2 = await createTestUser(`${crypto.randomUUID()}@example.com`);
+    user3 = await createTestUser(`${crypto.randomUUID()}@example.com`);
+
+    const { error } = await adminClient
+      .from("user_campaign_attribution")
+      .insert([
+        {
+          user_id: user1.user.userId,
+          campaign_code: SAPPORO,
+          created_at: "2026-07-30T03:00:00+09:00",
+        },
+        {
+          user_id: user2.user.userId,
+          campaign_code: SAPPORO,
+          created_at: "2026-07-31T10:00:00+09:00",
+        },
+        {
+          user_id: user3.user.userId,
+          campaign_code: AOMORI,
+          created_at: "2026-08-01T12:00:00+09:00",
+        },
+      ]);
+    if (error) {
+      throw new Error(`テストデータ作成エラー: ${error.message}`);
+    }
+  });
+
+  afterEach(async () => {
+    await adminClient
+      .from("user_campaign_attribution")
+      .delete()
+      .in("user_id", [user1.user.userId, user2.user.userId, user3.user.userId]);
+
+    await cleanupTestUser(user1.user.userId);
+    await cleanupTestUser(user2.user.userId);
+    await cleanupTestUser(user3.user.userId);
+  });
+
+  test("キャンペーンコード別に登録数と初回/最終登録日時を集計できる", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_campaign_attribution_stats",
+      { campaign_code_prefix: PREFIX },
+    );
+
+    expect(error).toBeNull();
+    // 登録数の多い順に並ぶ
+    expect(data?.map((row) => row.campaign_code)).toEqual([SAPPORO, AOMORI]);
+
+    const sapporo = data?.find((row) => row.campaign_code === SAPPORO);
+    expect(Number(sapporo?.registrations)).toBe(2);
+    expect(new Date(sapporo?.first_registered_at ?? "").toISOString()).toBe(
+      "2026-07-29T18:00:00.000Z",
+    );
+    expect(new Date(sapporo?.last_registered_at ?? "").toISOString()).toBe(
+      "2026-07-31T01:00:00.000Z",
+    );
+  });
+
+  test("前方一致フィルタは大文字小文字を区別しない", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_campaign_attribution_stats",
+      { campaign_code_prefix: PREFIX.toUpperCase() },
+    );
+
+    expect(error).toBeNull();
+    expect(data?.map((row) => row.campaign_code).sort()).toEqual(
+      [AOMORI, SAPPORO].sort(),
+    );
+  });
+
+  test("前方一致フィルタで特定キャンペーンだけに絞れる", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_campaign_attribution_stats",
+      { campaign_code_prefix: `${PREFIX}-aomori` },
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data?.[0].campaign_code).toBe(AOMORI);
+    expect(Number(data?.[0].registrations)).toBe(1);
+  });
+
+  test("期間フィルタは境界を含めて絞り込める", async () => {
+    // 7/30 のみ（JST）→ sapporo の1件だけ
+    const { data, error } = await adminClient.rpc(
+      "get_campaign_attribution_stats",
+      {
+        campaign_code_prefix: PREFIX,
+        registered_from: "2026-07-30T00:00:00+09:00",
+        registered_to: "2026-07-30T23:59:59.999+09:00",
+      },
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data?.[0].campaign_code).toBe(SAPPORO);
+    expect(Number(data?.[0].registrations)).toBe(1);
+  });
+
+  test("該当がない期間では空配列を返す", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_campaign_attribution_stats",
+      {
+        campaign_code_prefix: PREFIX,
+        registered_from: "2026-09-01T00:00:00+09:00",
+      },
+    );
+
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+  });
+
+  test("匿名ユーザーは集計関数を実行できない", async () => {
+    const anonClient = getAnonClient();
+    const { error } = await anonClient.rpc("get_campaign_attribution_stats", {
+      campaign_code_prefix: PREFIX,
+    });
+
+    expect(error).toBeTruthy();
+  });
+
+  test("認証済みユーザーも集計関数を実行できない", async () => {
+    const { error } = await user1.client.rpc("get_campaign_attribution_stats", {
+      campaign_code_prefix: PREFIX,
+    });
+
+    expect(error).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## なぜ

全国キャラバン2026 の会場別アトリビューション計測（#2266）で `?cv=` 経由の登録は `user_campaign_attribution` に溜まるようになったが、**その数字を見る手段が Supabase の直参照しかない**。組織活動本部・広報（岩瀬さん）から「会場別のアクションボード登録数を自分で見られるようにしてほしい / 週次で出してほしい」という依頼が来ているため、問い合わせ対応ボット（みらいいぬ）から聞ける MCP ツールを追加する。

管理画面を作る案・スプレッドシート同期案と比べ、既存の MCP サーバー（`/api/mcp`）にツールを1本足すだけで済み、期間や会場の切り口を自然言語で自由に指定できるため、この方式を選んだ。

## 変更内容

**DB関数（新規マイグレーション）**
- `get_campaign_attribution_stats(campaign_code_prefix, registered_from, registered_to)` を追加。コード別の登録数・初回/最終登録日時を返す
- 集計は **DB側で GROUP BY**（全行をアプリに転送しない）
- 前方一致は `LIKE` ではなく `starts_with(lower(...), lower(...))`。コードに含まれうる `_` がワイルドカードとして解釈されるのを避けるため
- `SECURITY INVOKER` + `REVOKE ... FROM PUBLIC, anon, authenticated` / `GRANT EXECUTE TO service_role`。集計用途の関数をアプリのロールから呼べる必要はないため明示的に遮断

**サービス層 / MCPツール**
- `features/campaign-attribution/services/campaign-attribution-stats.ts`: 日付は **JSTの日単位**（`YYYY-MM-DD`・両端を含む）で受け取り、境界タイムスタンプに変換して RPC を呼ぶ
- `features/campaign-attribution/utils/campaign-stats-response.ts`: MCP レスポンス整形。`limit` で切り詰めても **合計は全件で計算**し、`truncated` で明示
- `app/api/[transport]/route.ts`: `get_campaign_attribution_stats` を登録（引数: `campaignCodePrefix` / `from` / `to` / `limit`）
- **返すのは集計値のみで、`user_id` 等の個人は含めない**（既存の党員バッジ照会ツールと違い個人情報を扱わない）
- 数字の読み違いを防ぐため、レスポンスに `notes` を付ける（新規登録のみカウント・1ユーザー1コード先勝ち・党員登録側は別集計）

## 検証

- `pnpm run biome:check:write` / `pnpm run typecheck` / `pnpm run test:unit`（2107件、うち今回追加16件）すべてパス
- `tests/supabase/db_function/campaign-attribution-stats.test.ts`（実DB・7件パス）: コード別集計・大文字小文字を区別しない前方一致・期間境界・空結果・**anon / authenticated が実行できないこと**
- **ローカル dev server で `/api/mcp` をE2E確認**: `tools/list` にスキーマ付きで載る／実データ3件を仕込んで `tools/call` が正しい集計（合計3・2コード）を返す／期間絞り込み（7/30のみ→1件）／Bearer なしは401／不正なコード形式は zod で弾く

## 補足（このPRのスコープ外）

`get_users_by_emails`（#2266 以前から存在）は `SECURITY DEFINER` かつ EXECUTE が PUBLIC に開いたままで、anon からメールアドレスの登録有無・user_id を引ける状態に見える。別途 REVOKE を入れたほうがよいと思われるが、本PRのスコープ外として報告のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - キャンペーンコード、登録日範囲、取得件数を指定して、キャンペーン別の新規登録数を確認できるようになりました。
  - 登録件数、初回・最終登録日時、対象キャンペーン数をJSONで取得できます。
  - 個人情報を含まない集計結果のみを返します。
  - 前方一致検索、期間指定、件数制限に対応しました。
  - 該当データがない場合や表示件数を超える場合は、レスポンスに注記を表示します。

- **テスト**
  - 日付範囲、検索条件、集計結果、権限、不正入力に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->