### PR TITLE
退会モーダルにサポーター退会の注意文を追加

### DIFF
--- a/src/features/user-settings/components/delete-account-modal.tsx
+++ b/src/features/user-settings/components/delete-account-modal.tsx
@@ -75,6 +75,14 @@ export function DeleteAccountModal({
               <li>その他のアカウントに関連するすべてのデータ</li>
             </ul>
           </div>
+          <div className="text-left space-y-2 text-sm">
+            <p>
+              アクションボードから退会すると、サポーターも自動的に退会となります。
+            </p>
+            <p>
+              ただし、2026年8月5日以前にサポーター登録フォームから登録された方は、お問い合わせフォームより退会の旨をお申し出ください。
+            </p>
+          </div>
           <div className="space-y-2">
             <Label htmlFor="confirm-text">
               続行するには「退会する」と入力してください


### PR DESCRIPTION
## 概要

マイページの「アクションボードを退会する」で表示される警告モーダルに、サポーター登録の扱いについての注意文を追加します。

追加する文言(組織活動本部・湯田さんからの依頼どおりの原文):

> アクションボードから退会すると、サポーターも自動的に退会となります。
> ただし、2026年8月5日以前にサポーター登録フォームから登録された方は、お問い合わせフォームより退会の旨をお申し出ください。

## 変更点

- `src/features/user-settings/components/delete-account-modal.tsx`
  - 削除データの箇条書きと、確認入力欄のラベル「続行するには「退会する」と入力してください」の **間** に上記 2 文を追加(依頼どおり「続行するには〜」の前の行)
  - 既存のダイアログのスタイル(`text-sm` / `space-y-2`)に合わせただけで、ロジックの変更はありません

## 補足

- 文言は依頼された原文のままです。文中の「お問い合わせフォーム」をリンクにする / 表現を調整する必要があれば、この PR で対応します
- 依頼者: 湯田瑞希(組織活動本部)。Slack の依頼スレッドに添付されたモーダルのスクリーンショットをもとに、該当箇所を特定しました
- みらいいぬ(bot)は team-mirai/action-board への push 権限がないため、fork(`mirai-inu/action-board`)からの PR になっています。コミットの author メール(`takahiro.anno.ai@team-mir.ai`)は GitHub アカウントに紐づいていないため、preview deploy で author 解決のエラーが出る場合はメンテナ側で squash merge / rebase していただければ解消します

<!-- mirai-inu-session: sesn_01PD9onLSdpmm41z2cYvqg4Q -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 退会確認モーダルに、アクションボードから退会する際はサポーターも自動退会となる旨を追加しました。
  * 2026年8月5日以前にサポーター登録フォームから登録した場合は、お問い合わせフォームから退会を申し出る必要がある旨を案内します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->