### PR TITLE
feat: Google Tag Manager (GTM) を設置できるようにする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=service-role-key
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+# Google Tag Manager コンテナID（未設定ならGTMは読み込まれない）
+NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX
 NEXT_PUBLIC_APP_ORIGIN=http://localhost:3000
 
 SITE_URL=http://localhost:3000

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { CampaignCodeHandlerWrapper } from "@/features/campaign-attribution/comp
 import { ReferralCodeHandlerWrapper } from "@/features/referral/components/referral-code-handler-wrapper";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 
 //metadata.tsxでmetadataを管理
 export const generateMetadata = generateRootMetadata;
@@ -31,6 +32,28 @@ export default function RootLayout({
   return (
     <html lang="ja" className={notoSansJP.variable} suppressHydrationWarning>
       <body className="bg-background text-foreground">
+        {GTM_ID && (
+          <>
+            <noscript>
+              <iframe
+                src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+                height="0"
+                width="0"
+                style={{ display: "none", visibility: "hidden" }}
+                title="Google Tag Manager"
+              />
+            </noscript>
+            <Script id="gtm-init" strategy="afterInteractive">
+              {`
+              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','${GTM_ID}');
+            `}
+            </Script>
+          </>
+        )}
         <NextTopLoader showSpinner={false} color="#2aa693" />
         {GA_ID && (
           <>


### PR DESCRIPTION
## 背景

広報から「キャラバン集客の広告 CV としてアクションボードの新規登録を計測したい」という依頼があり、そのために GTM コンテナ（広報が用意した `GTM-P9W57HSJ`。公式サイトの `GTM-WQBF2DWC` とは別コンテナ）をアクションボードに載せたい、という要望です。

現状 action-board は `NEXT_PUBLIC_GA_ID` で gtag を直貼りしているだけで、GTM コンテナは入っていません（repo 内に `gtm.js` / `GTM-` の記述なし）。GTM が入ると、以降のタグ追加・CV 設定は広報が GTM 管理画面だけで完結できるようになり、都度の開発依頼が不要になります。

## 変更内容

- `src/app/layout.tsx`: `NEXT_PUBLIC_GTM_ID` が設定されているときだけ GTM の標準スニペット（`<Script strategy="afterInteractive">` + `<body>` 直後の noscript iframe）を出力する。既存の GA（gtag）はそのまま
- `.env.example`: `NEXT_PUBLIC_GTM_ID` を追記

既存 GA の実装パターン（`GA_ID &&` の条件付きレンダリング）に揃えており、env 未設定の環境（ローカル / preview）では一切読み込まれません。

## マージ後に必要な設定（お願い）

デプロイ環境（Vercel の action-board プロジェクト）の環境変数に以下を設定してください。設定しないと GTM は読み込まれません。

```
NEXT_PUBLIC_GTM_ID=GTM-P9W57HSJ
```

- Production のみ設定 / Preview にも設定するかは運用判断でお任せします（Preview にも入れる場合は GTM 側トリガーでホスト名条件を付ける想定）
- GCP(Cloud Run) 側にも通す必要がある場合は、`Dockerfile` / `cloudbuild.yaml` / `terraform` への `ARG`/`ENV`/変数追加も追記しますので、その旨コメントください（現状のデプロイは Vercel deploy hook 経由と理解して Vercel 側のみを前提にしています）

## 補足（計測設計）

- CV の発火点は `/sign-up-success`（アカウント作成完了ページ）が実在するので、GTM のページビュートリガーだけで CV を取れます。dataLayer の追加実装は不要です
- 既存の `?cv=` キャンペーンコード計測とは役割が異なります（`?cv=` は DB 上の正確な帰属、GTM/pixel は広告プラットフォーム側の最適化シグナル）

## 確認事項

- ローカルで `biome check` は通過済み。typecheck / unit test は CI に委ねています
- コミットの author email が GitHub アカウント未解決のため preview deploy が失敗する場合は、squash merge / rebase で解消できます

依頼元: 広報・吉田早希さん（Slack）。実装は開発本部のレビュー前提です。不要・方針違いであれば close いただいて構いません。

<!-- mirai-inu-session: sesn_01XbEFqYeLqYwo3knRAT7THZ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Google Tag Managerに対応しました。
  * 設定された場合、ページに計測用タグを自動的に読み込みます。

* **ドキュメント**
  * Google Tag Managerの設定方法と必要な環境変数の例を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->