### PR TITLE
feat: パブリック版BQパイプライン用のpublication/スロットを追加

### DIFF
--- a/supabase/migrations/20260813000000_add_public_bq_replication_pipeline.sql
+++ b/supabase/migrations/20260813000000_add_public_bq_replication_pipeline.sql
@@ -1,0 +1,76 @@
+-- データ分析基盤（BigQuery）の「パブリック版」パイプライン用の
+-- publication / レプリケーションスロットを追加する
+--
+-- 背景:
+--   既存の連携は publication `bq_pub`（FOR ALL TABLES）+ スロット `bq_slot` の1系統のみ
+--   （20250620122832_bigquery_replication_setup.sql）。FOR ALL TABLES のため auth スキーマ等
+--   すべてのテーブルが配信対象になる。
+--
+--   データ基盤を「プライベート版（＝従来の全テーブル）」と「（社内）パブリック版」の
+--   2系統に分けるため、public スキーマのテーブルのみを対象とする publication
+--   `bq_pub_for_all` と、そのためのスロット `bq_slot_for_all` を新設する。
+--   既存の `bq_pub` / `bq_slot` はプライベート版としてそのまま維持する。
+--
+-- 注意（重要）:
+--   1. public スキーマには `public.user_emails`（auth.users.email のミラー。
+--      20260716073000_add_user_emails_mirror_for_bq.sql）が存在するため、
+--      `FOR TABLES IN SCHEMA public` はメールアドレスも配信対象に含む。
+--      パブリック版にメールアドレスを含めたくない場合は、
+--      publication をテーブル列挙型（FOR TABLE a, b, c ...）にするか、
+--      user_emails を別スキーマ（例: private）へ移す必要がある。
+--      PostgreSQL 15 では `FOR TABLES IN SCHEMA ... EXCEPT` は使えない。
+--   2. スロットは作成した時点から WAL を保持し続ける。コンシューマ（Datastream 等）を
+--      接続しないまま放置すると WAL が増え続けディスクを圧迫するため、
+--      本マイグレーション適用後は速やかに取り込み側を設定すること。
+--   3. スロットを読むロールには REPLICATION 権限が必要。既存の `bq_user` は
+--      REPLICATION と public スキーマの SELECT を持つためそのまま利用できる。
+--      パブリック版に専用ロールを分けたい場合は別途作成する。
+
+-- トランザクションの制限を避けるため、既存マイグレーションと同様に文ごとに区切る
+
+BEGIN;
+-- 1. public スキーマのテーブルのみを対象とする publication（冪等）
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'bq_pub_for_all') THEN
+        CREATE PUBLICATION bq_pub_for_all FOR TABLES IN SCHEMA public;
+    END IF;
+END $$;
+COMMIT;
+
+BEGIN;
+-- 2. パブリック版用の論理レプリケーションスロット（冪等）
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = 'bq_slot_for_all') THEN
+        PERFORM pg_create_logical_replication_slot('bq_slot_for_all', 'pgoutput');
+    END IF;
+END $$;
+COMMIT;
+
+-- 検証クエリ（手動実行用・コメントアウト）:
+/*
+-- publication の確認（puballtables = false / 対象は public スキーマ）
+SELECT pubname, puballtables FROM pg_publication WHERE pubname IN ('bq_pub', 'bq_pub_for_all');
+
+-- publication に含まれるスキーマ
+SELECT p.pubname, n.nspname
+FROM pg_publication_namespace pn
+JOIN pg_publication p ON p.oid = pn.pnpubid
+JOIN pg_namespace n ON n.oid = pn.pnnspid
+WHERE p.pubname = 'bq_pub_for_all';
+
+-- 実際に配信されるテーブル一覧（user_emails が含まれる点に注意）
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'bq_pub_for_all'
+ORDER BY schemaname, tablename;
+
+-- スロットの確認と WAL 保持量
+SELECT
+    slot_name,
+    active,
+    pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal_size
+FROM pg_replication_slots
+WHERE slot_name IN ('bq_slot', 'bq_slot_for_all');
+*/


### PR DESCRIPTION
# 変更の概要
- マイグレーション `supabase/migrations/20260813000000_add_public_bq_replication_pipeline.sql` を追加
- publication `bq_pub_for_all`（`FOR TABLES IN SCHEMA public`）を作成
- 論理レプリケーションスロット `bq_slot_for_all`（`pgoutput`）を作成
- 既存の `20250620122832_bigquery_replication_setup.sql` と同じスタイルで、`pg_publication` / `pg_replication_slots` を確認する冪等な `DO` ブロック + 文ごとのトランザクション区切りにしている
- 既存の `bq_pub` / `bq_slot` は変更していない（プライベート版としてそのまま維持）

# 変更の背景
- データ分析基盤を「プライベート版（従来どおり全テーブル）」と「（社内）パブリック版」の2系統に分けるため、public スキーマのみを対象とする2系統目の publication / スロットが必要になった
- 既存の `bq_pub` は `FOR ALL TABLES` のため auth スキーマ等も含む。パブリック版は `FOR TABLES IN SCHEMA public` に限定する

## レビュー時に確認してほしい点
- **`public.user_emails` が配信対象に含まれる**: `public` スキーマにはメールアドレスのミラーテーブル `public.user_emails`（`20260716073000_add_user_emails_mirror_for_bq.sql` で追加）があるため、`FOR TABLES IN SCHEMA public` ではメールアドレスもパブリック版に流れる。含めたくない場合は publication をテーブル列挙型にするか、`user_emails` を別スキーマへ移す必要がある（PostgreSQL 15 では `FOR TABLES IN SCHEMA ... EXCEPT` は使えない）。マイグレーション本文にも注意書きとして記載済み
- **スロットの WAL 保持**: 作成時点から WAL を保持し続けるため、適用後は速やかに取り込み側（Datastream 等）を接続する必要がある
- **消費ロール**: スロットの読み取りには REPLICATION 権限が必要。既存の `bq_user` がそのまま使える想定で、専用ロールは作成していない。パブリック版に専用ロールを分ける方針であれば追加する

# スクリーンショット
- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# 検証方法
適用後に以下で確認できる（マイグレーション末尾にもコメントとして記載）:

```sql
-- publication の種別（bq_pub は puballtables=true、bq_pub_for_all は false）
SELECT pubname, puballtables FROM pg_publication WHERE pubname IN ('bq_pub', 'bq_pub_for_all');

-- 実際に配信されるテーブル一覧
SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = 'bq_pub_for_all' ORDER BY 1, 2;

-- スロットと WAL 保持量
SELECT slot_name, active,
       pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal_size
FROM pg_replication_slots WHERE slot_name IN ('bq_slot', 'bq_slot_for_all');
```

ローカルでの確認:
- `pnpm run biome:check:write` / `pnpm run typecheck` / `pnpm run test:unit`（178 suites / 2131 tests）はすべてパス
- SQL 自体は Docker が使えない環境のため未実行。`supabase db reset` での適用確認をお願いしたい

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました

（CLAの同意はPR作成者本人による意思表示のため、チェックは入れていません。マージ前にご自身でチェックしてください）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `public` スキーマ内のテーブルを対象としたBigQuery向け論理レプリケーションを追加しました。
  * レプリケーション用のPublicationとスロットを冪等に作成できるようになりました。
  * 対象テーブルや設定を確認するための手順を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->