### PR TITLE
fix: ミッション「企画チーム」の名称を「テーマ別コミュニティ企画チーム」に変更

### DIFF
--- a/mission_data/missions.yaml
+++ b/mission_data/missions.yaml
@@ -323,9 +323,9 @@ missions:
     artifact_label: 登録したメールアドレス
     ogp_image_url: https://tibsocpjqvxxipszbwui.supabase.co/storage/v1/object/public/ogp//16_slack_join.png
   - slug: join-planning-team
-    title: 企画チームのメンバーになろう
+    title: テーマ別コミュニティ企画チームのメンバーになろう
     icon_url: /img/mission-icons/actionboard_icon_work_20260715_ol_join-planning-team.png
-    content: テーマベースのコミュニティを、みんなで企画・実現していく「企画チーム」を立ち上げます！<br>地域の枠を越えて、横断で動く新しいかたちのサポーターチームです。<br><br>いまは立ち上げ準備中です。まずはサポーターSlackの <b>#1_サポーター全体_テーマ別企画チーム</b> に入ってお待ちください！<br>具体的な活動内容と次のご案内は、チャンネル内でお届けします（8月末までにご案内予定）。
+    content: テーマベースのコミュニティを、みんなで企画・実現していく「テーマ別コミュニティ企画チーム」を立ち上げます！<br>地域の枠を越えて、横断で動く新しいかたちのサポーターチームです。<br><br>いまは立ち上げ準備中です。まずはサポーターSlackの <b>#1_サポーター全体_テーマ別企画チーム</b> に入ってお待ちください！<br>具体的な活動内容と次のご案内は、チャンネル内でお届けします（8月末までにご案内予定）。
     difficulty: 1
     required_artifact_type: TEXT
     max_achievement_count: 1


### PR DESCRIPTION
## 概要
アクションボードのミッション「企画チームのメンバーになろう」（slug: `join-planning-team`）で使われているチーム名「企画チーム」を「テーマ別コミュニティ企画チーム」に変更します。

## 変更内容
`mission_data/missions.yaml` の `join-planning-team` ミッションについて、以下の2箇所のみ変更:

- `title`: 「企画チームのメンバーになろう」→「テーマ別コミュニティ企画チームのメンバーになろう」
- `content`: 「〜企画・実現していく「企画チーム」を立ち上げます！」→「〜企画・実現していく「テーマ別コミュニティ企画チーム」を立ち上げます！」

## 変更していない箇所（要確認）
本文中の案内チャンネル名 `#1_サポーター全体_テーマ別企画チーム` は実際のSlackチャンネル名の可能性があるため、今回は変更していません。こちらも合わせて変更が必要な場合はお知らせください。

## 経緯
Slackでの依頼: 武藤かず子さんより「企画チーム」→「テーマ別コミュニティ企画チーム」への名称変更依頼。

<!-- mirai-inu-session: sesn_011waPwAAPDiqxaUUqCWVJQM -->
<!-- mirai-inu-provenance: runtime=cma; model=claude-sonnet-5 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * 「企画チーム」ミッションのタイトルを「テーマ別コミュニティ企画チーム」に更新しました。
  * ミッションの説明文内のチーム名称も更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->